### PR TITLE
Add unit tests for migration and cleanup

### DIFF
--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -162,8 +162,8 @@
         "Typecheck passes"
       ],
       "priority": 11,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Added patterns section to AGENTS.md"
     }
   ]
 }

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -1,110 +1,168 @@
 {
   "project": "Hal",
-  "branchName": "hal/goreleaser-cicd",
-  "description": "GoReleaser CI/CD and Homebrew Release Pipeline - Automated cross-platform releases using GoReleaser v2, GitHub Actions, and a Homebrew tap",
+  "branchName": "hal/consolidate-progress-files",
+  "description": "Consolidate auto-progress.txt into progress.txt so both manual and auto workflows use a single progress file",
   "userStories": [
     {
       "id": "US-001",
-      "title": "Create GoReleaser v2 configuration",
-      "description": "As a developer, I want a .goreleaser.yaml config file so that GoReleaser can build cross-platform binaries, generate changelogs, create GitHub releases, and push a Homebrew formula.",
+      "title": "Remove AutoProgressFile constant from template package",
+      "description": "As a developer, I need the codebase to use a single progress file constant so both workflows write to the same location.",
       "acceptanceCriteria": [
-        ".goreleaser.yaml exists at the repo root with version: 2",
-        "project_name is 'hal'",
-        "before.hooks runs 'go mod tidy' and 'go vet ./...'",
-        "Build config: CGO_ENABLED=0, targets linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64",
-        "Ldflags set -s -w and inject Version, Commit, BuildDate into github.com/jywlabs/hal/cmd",
-        "Archives use tar.gz by default, zip for Windows, name template: {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}",
-        "Checksum file generated as checksums.txt using sha256",
-        "Changelog sorted ascending, uses GitHub, excludes docs:/test:/chore:/ci: commits, groups by Features/Bug Fixes/Refactoring/Others",
-        "Release targets j-yw/goralph, draft false, prerelease auto, name template 'Hal v{{ .Version }}'",
-        "Brews section: formula name 'hal', pushes to j-yw/homebrew-tap using HOMEBREW_TAP_TOKEN env, directory Formula, includes install and test blocks",
+        "Remove AutoProgressFile = \"auto-progress.txt\" constant from internal/template/template.go:25",
+        "Remove AutoProgressFile: DefaultProgress from DefaultFiles() map at internal/template/template.go:35",
+        "hal init no longer creates auto-progress.txt",
         "Typecheck passes"
       ],
       "priority": 1,
       "passes": true,
-      "notes": ""
+      "notes": "Completed - removed constant and updated all usages to make it compile"
     },
     {
       "id": "US-002",
-      "title": "Create release GitHub Actions workflow",
-      "description": "As a developer, I want a GitHub Actions workflow that triggers on version tag pushes so that releases are fully automated.",
+      "title": "Update auto pipeline to use unified progress file",
+      "description": "As an operator running hal auto, I want progress written to progress.txt so hal review can see my work.",
       "acceptanceCriteria": [
-        ".github/workflows/release.yml exists",
-        "Triggers on push of tags matching v*",
-        "Sets permissions: contents: write",
-        "Uses actions/checkout@v4 with fetch-depth: 0",
-        "Uses actions/setup-go@v5 with go-version-file: go.mod",
-        "Runs 'go test -v ./...' before releasing (tests gate the release)",
-        "Uses goreleaser/goreleaser-action@v6 with version '~> v2' and args 'release --clean'",
-        "Passes GITHUB_TOKEN and HOMEBREW_TAP_TOKEN as env vars to GoReleaser step",
+        "Change template.AutoProgressFile to template.ProgressFile in internal/compound/pipeline.go:495",
+        "Update error messages at lines 501 and 504 to reference ProgressFile",
+        "Change ProgressFile: template.AutoProgressFile to ProgressFile: template.ProgressFile in loop config at line 511",
+        "Auto pipeline writes to progress.txt",
         "Typecheck passes"
       ],
       "priority": 2,
       "passes": true,
-      "notes": ""
+      "notes": "Completed as part of US-001 to make codebase compile"
     },
     {
       "id": "US-003",
-      "title": "Create CI GitHub Actions workflow",
-      "description": "As a developer, I want a CI workflow that runs tests and validates GoReleaser config on pushes and PRs so that I catch issues before merging.",
+      "title": "Add migration logic for existing auto-progress.txt",
+      "description": "As a user with an existing auto-progress.txt, I want its content merged into progress.txt when running hal auto so I don't lose progress history.",
       "acceptanceCriteria": [
-        ".github/workflows/ci.yml exists",
-        "Triggers on push to main and develop branches, and on PRs to main",
-        "Contains a 'test' job that checks out code, sets up Go from go.mod, runs 'go vet ./...', runs 'go test -v ./...'",
-        "Contains a 'goreleaser-check' job that checks out code with fetch-depth: 0, sets up Go from go.mod, runs goreleaser check via goreleaser/goreleaser-action@v6",
-        "Both jobs run on ubuntu-latest",
-        "Both jobs run in parallel (no dependency between them)",
+        "Before progress file initialization in runLoopStep(), check if auto-progress.txt exists",
+        "If auto-progress.txt exists and progress.txt is empty/default, append auto-progress content to progress.txt",
+        "If both files have content, append auto-progress content to progress.txt with separator line",
+        "Delete auto-progress.txt after successful migration",
+        "Migration is logged to display output",
         "Typecheck passes"
       ],
       "priority": 3,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-004",
-      "title": "Update .gitignore for GoReleaser dist output",
-      "description": "As a developer, I want dist/ ignored by git so that local GoReleaser dry-run output is not accidentally committed.",
+      "title": "Fix hardcoded path in hal review context gathering",
+      "description": "As a user running hal review, I want progress read from the correct location using the template constant so maintenance is easier.",
       "acceptanceCriteria": [
-        ".gitignore contains dist/ entry",
-        "Entry is in the binaries/build-artifacts section of the file",
-        "Existing entries are unchanged",
+        "Add github.com/jywlabs/hal/internal/template import to internal/compound/review.go",
+        "Change hardcoded filepath.Join(dir, \".hal\", \"progress.txt\") to filepath.Join(dir, template.HalDir, template.ProgressFile) at line 133",
+        "Behavior unchanged for review command",
         "Typecheck passes"
       ],
       "priority": 4,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-005",
-      "title": "Add release Makefile targets",
-      "description": "As a developer, I want make release-dry-run and make release-check targets so that I can test releases locally before pushing tags.",
+      "title": "Add JSON PRD reading to hal review context",
+      "description": "As a user running hal review, I want the review to see task completion status from JSON PRDs so recommendations are based on actual progress.",
       "acceptanceCriteria": [
-        "release-dry-run target runs 'goreleaser release --snapshot --clean'",
-        "release-check target runs 'goreleaser check'",
-        "Both targets are listed in the .PHONY line",
-        "Both targets are documented in the help target output",
-        "Existing Makefile targets and behavior are unchanged",
+        "Add PRDJSONContent string and AutoPRDContent string fields to reviewContext struct",
+        "After reading markdown PRD (around line 155), read prd.json content if exists",
+        "Read auto-prd.json content if exists",
+        "Update hasAnyContext() to include new JSON PRD fields",
         "Typecheck passes"
       ],
       "priority": 5,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-006",
-      "title": "Verify end-to-end release pipeline locally",
-      "description": "As a developer, I want to verify the full pipeline works by running a local dry-run and checking all expected artifacts are produced.",
+      "title": "Include JSON PRD content in review prompt",
+      "description": "As a user running hal review, I want the AI to see task completion percentages so it can accurately report what's done vs remaining.",
       "acceptanceCriteria": [
-        "make release-check exits 0 (config is valid)",
-        "make release-dry-run exits 0 (snapshot build succeeds)",
-        "dist/ directory contains 5 archive files matching hal_*_linux_amd64.tar.gz, hal_*_linux_arm64.tar.gz, hal_*_darwin_amd64.tar.gz, hal_*_darwin_arm64.tar.gz, hal_*_windows_amd64.zip",
-        "dist/ contains checksums.txt with sha256 hashes for all 5 archives",
-        "Each archive contains a hal binary (or hal.exe for Windows)",
-        "make test and make vet still pass (no regressions)",
+        "Update buildReviewPrompt() to include PRDJSONContent section when available",
+        "Update buildReviewPrompt() to include AutoPRDContent section when available",
+        "Truncate JSON PRD content to reasonable size (5000 chars each)",
+        "Dry-run output shows JSON PRD context sizes when available",
         "Typecheck passes"
       ],
       "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Remove AutoProgressFile from archive feature state files",
+      "description": "As a developer, I need the archive system to stop treating auto-progress.txt as a feature state file since it no longer exists.",
+      "acceptanceCriteria": [
+        "Remove template.AutoProgressFile from featureStateFiles slice in internal/archive/archive.go:23",
+        "hal archive no longer includes auto-progress.txt in new archives",
+        "Old archives with auto-progress.txt still restore correctly (restore iterates all files)",
+        "Typecheck passes"
+      ],
+      "priority": 7,
       "passes": true,
+      "notes": "Completed as part of US-001 to make codebase compile"
+    },
+    {
+      "id": "US-008",
+      "title": "Update archive command help text",
+      "description": "As a user reading help text, I want accurate documentation about which files are archived.",
+      "acceptanceCriteria": [
+        "Remove auto-progress.txt from the archived files list in cmd/archive.go:27 Long description",
+        "Help text accurately reflects current behavior",
+        "Typecheck passes"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-009",
+      "title": "Update archive tests for consolidated progress",
+      "description": "As a developer, I need tests to pass after removing AutoProgressFile references.",
+      "acceptanceCriteria": [
+        "Remove writeFile(t, filepath.Join(halDir, template.AutoProgressFile), ...) calls from internal/archive/archive_test.go",
+        "Remove template.AutoProgressFile from verification slices in tests",
+        "Update auto-state only archives test (line ~148-165) to use ProgressFile instead",
+        "All archive tests pass",
+        "Typecheck passes"
+      ],
+      "priority": 9,
+      "passes": true,
+      "notes": "Completed as part of US-001 to make tests pass"
+    },
+    {
+      "id": "US-010",
+      "title": "Add hal cleanup command",
+      "description": "As a user who upgraded hal, I want a command to remove orphaned files like auto-progress.txt that are no longer used.",
+      "acceptanceCriteria": [
+        "Create cmd/cleanup.go with hal cleanup command",
+        "Command checks for and removes orphaned auto-progress.txt in .hal/",
+        "Command reports which files were removed",
+        "Command is idempotent (safe to run multiple times)",
+        "Add --dry-run flag to preview what would be removed",
+        "Typecheck passes"
+      ],
+      "priority": 10,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-011",
+      "title": "Document consolidation pattern in AGENTS.md",
+      "description": "As a future developer, I want documentation about why progress files were consolidated so I understand the design decision.",
+      "acceptanceCriteria": [
+        "Add Patterns from hal/consolidate-progress-files section to AGENTS.md",
+        "Document that progress.txt is the single source of truth for both workflows",
+        "Document migration approach (append with separator)",
+        "Document that old auto-progress.txt files are orphaned but harmless",
+        "Typecheck passes"
+      ],
+      "priority": 11,
+      "passes": false,
       "notes": ""
     }
   ]

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -147,8 +147,8 @@
         "Typecheck passes"
       ],
       "priority": 10,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Created cmd/cleanup.go with --dry-run flag"
     },
     {
       "id": "US-011",

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -116,8 +116,8 @@
         "Typecheck passes"
       ],
       "priority": 8,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Removed auto-progress.txt from help text"
     },
     {
       "id": "US-009",

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -74,8 +74,8 @@
         "Typecheck passes"
       ],
       "priority": 5,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Added JSON PRD fields and reading logic to review.go"
     },
     {
       "id": "US-006",

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -59,8 +59,8 @@
         "Typecheck passes"
       ],
       "priority": 4,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Updated review.go to use template constants"
     },
     {
       "id": "US-005",

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -45,8 +45,8 @@
         "Typecheck passes"
       ],
       "priority": 3,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Implemented migrateAutoProgress() method in pipeline.go"
     },
     {
       "id": "US-004",

--- a/.hal/prd.json
+++ b/.hal/prd.json
@@ -89,8 +89,8 @@
         "Typecheck passes"
       ],
       "priority": 6,
-      "passes": false,
-      "notes": ""
+      "passes": true,
+      "notes": "Updated review prompt and dry-run output"
     },
     {
       "id": "US-007",

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -40,3 +40,12 @@
   - Use template constants for all .hal directory paths to ensure consistency
   - Template package provides HalDir, ProgressFile, PRDFile, etc. constants
 ---
+
+## 2026-02-05 - US-005: Add JSON PRD reading to hal review context
+- Added PRDJSONContent and AutoPRDContent fields to reviewContext struct
+- Read prd.json and auto-prd.json content after markdown PRD reading
+- Updated hasAnyContext() to include PRDJSONContent and AutoPRDContent
+- **Learnings for future iterations:**
+  - JSON PRDs contain task completion status (passes field) that markdown PRDs don't
+  - Both prd.json (manual flow) and auto-prd.json (auto flow) should be checked
+---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -65,3 +65,14 @@
   - Keep CLI help text synchronized with actual behavior
   - Help text is in cobra.Command Long field
 ---
+
+## 2026-02-05 - US-010: Add hal cleanup command
+- Created cmd/cleanup.go with hal cleanup command
+- Command checks for and removes orphaned auto-progress.txt
+- Added --dry-run flag to preview what would be removed
+- Command is idempotent (no-op when files don't exist)
+- **Learnings for future iterations:**
+  - Use a slice of orphanedFiles to easily add more files in the future
+  - Always provide --dry-run flag for destructive operations
+  - Use os.IsNotExist() to handle missing files gracefully
+---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -32,3 +32,11 @@
   - Use os.IsNotExist() to distinguish "file not found" from other read errors
   - Template.DefaultProgress can be used to detect "unchanged default" state
 ---
+
+## 2026-02-05 - US-004: Fix hardcoded path in hal review context gathering
+- Added template import to internal/compound/review.go
+- Changed hardcoded filepath.Join(dir, ".hal", "progress.txt") to filepath.Join(dir, template.HalDir, template.ProgressFile)
+- **Learnings for future iterations:**
+  - Use template constants for all .hal directory paths to ensure consistency
+  - Template package provides HalDir, ProgressFile, PRDFile, etc. constants
+---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -76,3 +76,14 @@
   - Always provide --dry-run flag for destructive operations
   - Use os.IsNotExist() to handle missing files gracefully
 ---
+
+## 2026-02-05 - US-011: Document consolidation pattern in AGENTS.md
+- Added "Patterns from hal/consolidate-progress-files" section to AGENTS.md
+- Documented progress.txt as single source of truth for both workflows
+- Documented migration approach (append with separator)
+- Documented cleanup command for orphaned files
+- Documented JSON PRD reading for review context
+- **Learnings for future iterations:**
+  - Add AGENTS.md patterns section when completing significant refactoring work
+  - Document both the what and the why for future developers
+---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -1,70 +1,20 @@
+# Hal Progress
+
 ## Codebase Patterns
-- Ldflags variables are in `cmd` package: `cmd.Version`, `cmd.Commit`, `cmd.BuildDate`
-- Module path: `github.com/jywlabs/hal`
-- GitHub org: `j-yw`, repo: `goralph`
-- Homebrew tap repo: `j-yw/homebrew-tap`
-- Platform-specific syscall usage must go through `newSysProcAttr()` in `sysproc_unix.go`/`sysproc_windows.go` — never use `syscall.SysProcAttr` directly in engine files
-- GoReleaser v2 uses `formats` (list) instead of `format` (string) in archives section, and `homebrew_casks` instead of `brews` for Homebrew formulae
+- progress.txt is the single source of truth for both manual and auto workflows (consolidated from separate files)
+- When removing constants, also update all usages in tests to maintain compilation
+- Archive feature state files are defined in internal/archive/archive.go featureStateFiles slice
 
 ---
 
-## 2026-02-05 - US-001
-- Created `.goreleaser.yaml` with GoReleaser v2 config
-- Files changed: `.goreleaser.yaml` (new)
+## 2026-02-05 - US-001: Remove AutoProgressFile constant from template package
+- Removed AutoProgressFile constant from internal/template/template.go
+- Removed AutoProgressFile from DefaultFiles() map (hal init no longer creates auto-progress.txt)
+- Updated internal/archive/archive.go to remove AutoProgressFile from featureStateFiles
+- Updated internal/compound/pipeline.go to use ProgressFile instead of AutoProgressFile
+- Updated internal/archive/archive_test.go to use ProgressFile instead of AutoProgressFile
 - **Learnings for future iterations:**
-  - GoReleaser v2 requires `version: 2` at the top of the config
-  - Windows/arm64 is excluded from builds (only 5 targets total)
-  - The `ignore` directive filters out goos/goarch combos from the matrix
-  - Brews section uses `repository` (not `tap`) in v2
----
-
-## 2026-02-05 - US-002
-- Created `.github/workflows/release.yml` for automated releases on tag push
-- Files changed: `.github/workflows/release.yml` (new)
-- **Learnings for future iterations:**
-  - GoReleaser action v6 uses `version: "~> v2"` syntax
-  - Tests run before GoReleaser to gate the release
-  - HOMEBREW_TAP_TOKEN is a separate secret from GITHUB_TOKEN (needed for cross-repo push)
----
-
-## 2026-02-05 - US-003
-- Created `.github/workflows/ci.yml` with test and goreleaser-check jobs
-- Files changed: `.github/workflows/ci.yml` (new)
-- **Learnings for future iterations:**
-  - CI workflow triggers on push to main/develop and PRs to main
-  - Test and goreleaser-check jobs run in parallel (no `needs` dependency)
-  - goreleaser-check needs `fetch-depth: 0` for tag history
----
-
-## 2026-02-05 - US-004
-- Added `dist/` to `.gitignore` in the binaries section
-- Files changed: `.gitignore`
-- **Learnings for future iterations:**
-  - GoReleaser outputs to `dist/` by default during `--snapshot` and real builds
----
-
-## 2026-02-05 - US-005
-- Added `release-dry-run` and `release-check` targets to Makefile
-- Files changed: `Makefile`
-- **Learnings for future iterations:**
-  - `release-dry-run` uses `goreleaser release --snapshot --clean` (snapshot = no publish, clean = remove prior dist/)
-  - `release-check` uses `goreleaser check` to validate config
-  - Aligned all help text padding when adding new longer target names
----
-
-## 2026-02-05 - US-006
-- Verified end-to-end release pipeline: `make release-check` and `make release-dry-run` both exit 0
-- Fixed cross-platform build: replaced direct `syscall.SysProcAttr` usage with `newSysProcAttr()` in `claude.go` and `codex.go`
-- Added platform-specific `sysproc_unix.go` and `sysproc_windows.go` for both claude and codex engines (were untracked)
-- Updated `.goreleaser.yaml` to use GoReleaser v2 `formats` syntax (list instead of scalar)
-- Verified all 5 archive files produced: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
-- Verified checksums.txt contains sha256 hashes for all 5 archives
-- Verified each archive contains `hal` binary (`hal.exe` for Windows)
-- All tests pass, `go vet` clean
-- Files changed: `internal/engine/claude/claude.go`, `internal/engine/codex/codex.go`, `internal/engine/claude/sysproc_unix.go` (new), `internal/engine/claude/sysproc_windows.go` (new), `internal/engine/codex/sysproc_unix.go` (new), `internal/engine/codex/sysproc_windows.go` (new), `.goreleaser.yaml`, `go.mod`, `go.sum`, `.hal/prd.json`, `.hal/progress.txt`
-- **Learnings for future iterations:**
-  - GoReleaser's before hooks run `go vet` which will catch cross-compilation issues early
-  - The `sysproc_*.go` build-tag pattern is essential for cross-platform builds with `syscall` usage
-  - GoReleaser v2 changed `format` to `formats` (list) and `brews` to `homebrew_casks`
-  - Snapshot builds use version format `0.0.0-SNAPSHOT-<commit>` when no tags exist
+  - Removing a constant requires updating all usages including test files
+  - The featureStateFiles slice defines which files are archived - update it when removing state files
+  - Pipeline uses ProgressFile for loop config, not a separate auto file
 ---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -58,3 +58,10 @@
   - JSON PRDs provide task completion percentages for accurate progress reporting
   - Keep truncation limits reasonable to fit within model context windows
 ---
+
+## 2026-02-05 - US-008: Update archive command help text
+- Removed auto-progress.txt from the archived files list in cmd/archive.go help text
+- **Learnings for future iterations:**
+  - Keep CLI help text synchronized with actual behavior
+  - Help text is in cobra.Command Long field
+---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -49,3 +49,12 @@
   - JSON PRDs contain task completion status (passes field) that markdown PRDs don't
   - Both prd.json (manual flow) and auto-prd.json (auto flow) should be checked
 ---
+
+## 2026-02-05 - US-006: Include JSON PRD content in review prompt
+- Updated buildReviewPrompt() to include PRDJSONContent and AutoPRDContent sections
+- Truncate JSON PRD content to 5000 chars each
+- Updated dry-run output to show JSON PRD context sizes
+- **Learnings for future iterations:**
+  - JSON PRDs provide task completion percentages for accurate progress reporting
+  - Keep truncation limits reasonable to fit within model context windows
+---

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -18,3 +18,17 @@
   - The featureStateFiles slice defines which files are archived - update it when removing state files
   - Pipeline uses ProgressFile for loop config, not a separate auto file
 ---
+
+## 2026-02-05 - US-003: Add migration logic for existing auto-progress.txt
+- Added migrateAutoProgress() method to internal/compound/pipeline.go
+- Migration runs before progress file initialization in runLoopStep()
+- If auto-progress.txt exists and has content, it is merged into progress.txt:
+  - If progress.txt is empty/default: auto-progress content replaces it
+  - If both have content: auto-progress content is appended with separator
+- Legacy auto-progress.txt is deleted after successful migration
+- Migration is logged to display output
+- **Learnings for future iterations:**
+  - Migration logic should handle edge cases: empty files, default content, missing files
+  - Use os.IsNotExist() to distinguish "file not found" from other read errors
+  - Template.DefaultProgress can be used to detect "unchanged default" state
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,12 @@
 - AutoConfig.Validate() checks 3 fields: ReportsDir non-empty, BranchPrefix non-empty, MaxIterations > 0. Error messages follow the format "auto.<field> must not be empty" / "must be greater than 0".
 - runInit in cmd/init.go uses relative paths (.hal, .) so tests must os.Chdir to a temp directory and restore with t.Cleanup. runInit(nil, nil) works for testing.
 - FindLatestReport skips hidden files (dot prefix) and directories. FindRecentPRDs matches prd-*.md in .hal/ and returns nil (not error) for missing directories.
+
+## Patterns from hal/consolidate-progress-files (2026-02-05)
+
+- progress.txt is the single source of truth for both manual (`hal run`) and auto (`hal auto`) workflows. The separate auto-progress.txt file was consolidated.
+- When removing a constant from internal/template/template.go, also update all usages in tests and other packages (archive, compound) to maintain compilation.
+- Migration logic for legacy files (like auto-progress.txt) uses append-with-separator strategy: if destination has content, append with "---" divider; if empty/default, replace entirely.
+- The `hal cleanup` command removes orphaned files via an `orphanedFiles` slice — add files here when deprecating state files, and always provide --dry-run flag for preview.
+- hal review gathers context from JSON PRDs (prd.json, auto-prd.json) in addition to markdown PRDs for accurate task completion reporting. The JSON files contain the `passes` field showing which stories are complete.
+- Use template constants (template.HalDir, template.ProgressFile, etc.) for all .hal/ paths instead of hardcoded strings to ensure consistency across the codebase.

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -24,8 +24,8 @@ var archiveCmd = &cobra.Command{
 	Short: "Archive current feature state",
 	Long: `Archive all feature state files from .hal/ into .hal/archive/<date>-<name>/.
 
-Archives: prd.json, prd-*.md, progress.txt, auto-prd.json, auto-progress.txt,
-auto-state.json, and reports/* (non-hidden files).
+Archives: prd.json, prd-*.md, progress.txt, auto-prd.json, auto-state.json,
+and reports/* (non-hidden files).
 
 Never touches: config.yaml, prompt.md, skills/, rules/.
 

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/jywlabs/hal/internal/template"
+	"github.com/spf13/cobra"
+)
+
+var cleanupDryRun bool
+
+var cleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Remove orphaned files from .hal/",
+	Long: `Remove orphaned files from .hal/ that are no longer used.
+
+This command removes:
+  - auto-progress.txt (replaced by unified progress.txt)
+
+Use --dry-run to preview what would be removed without making changes.
+
+This command is idempotent and safe to run multiple times.`,
+	RunE: runCleanup,
+}
+
+func init() {
+	cleanupCmd.Flags().BoolVar(&cleanupDryRun, "dry-run", false, "Preview changes without removing files")
+	rootCmd.AddCommand(cleanupCmd)
+}
+
+// orphanedFiles lists files that are no longer used and can be safely removed.
+var orphanedFiles = []string{
+	"auto-progress.txt", // Replaced by unified progress.txt
+}
+
+func runCleanup(cmd *cobra.Command, args []string) error {
+	halDir := template.HalDir
+	removed := 0
+
+	for _, file := range orphanedFiles {
+		path := filepath.Join(halDir, file)
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			// File doesn't exist, nothing to do
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("failed to stat %s: %w", file, err)
+		}
+		if info.IsDir() {
+			// Skip directories for safety
+			continue
+		}
+
+		if cleanupDryRun {
+			fmt.Printf("Would remove: %s\n", path)
+		} else {
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("failed to remove %s: %w", file, err)
+			}
+			fmt.Printf("Removed: %s\n", path)
+		}
+		removed++
+	}
+
+	if removed == 0 {
+		fmt.Println("No orphaned files found.")
+	} else if cleanupDryRun {
+		fmt.Printf("\nWould remove %d file(s). Run without --dry-run to remove.\n", removed)
+	} else {
+		fmt.Printf("\nRemoved %d file(s).\n", removed)
+	}
+
+	return nil
+}

--- a/cmd/cleanup_test.go
+++ b/cmd/cleanup_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCleanupFn_DryRun(t *testing.T) {
+	// Create temp directory to simulate .hal/
+	tmpDir := t.TempDir()
+	halDir := filepath.Join(tmpDir, ".hal")
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("failed to create .hal directory: %v", err)
+	}
+
+	// Create auto-progress.txt file (orphaned file)
+	autoProgressPath := filepath.Join(halDir, "auto-progress.txt")
+	if err := os.WriteFile(autoProgressPath, []byte("test content"), 0644); err != nil {
+		t.Fatalf("failed to create auto-progress.txt: %v", err)
+	}
+
+	// Run cleanup with dry-run
+	var out bytes.Buffer
+	err := runCleanupFn(halDir, true, &out)
+	if err != nil {
+		t.Fatalf("runCleanupFn returned error: %v", err)
+	}
+
+	output := out.String()
+
+	// Verify output contains "Would remove:" and the file path
+	if !strings.Contains(output, "Would remove:") {
+		t.Errorf("expected output to contain 'Would remove:', got: %s", output)
+	}
+	if !strings.Contains(output, autoProgressPath) {
+		t.Errorf("expected output to contain file path %s, got: %s", autoProgressPath, output)
+	}
+
+	// Verify file still exists after dry-run
+	if _, err := os.Stat(autoProgressPath); os.IsNotExist(err) {
+		t.Error("auto-progress.txt should still exist after dry-run")
+	}
+
+	// Verify summary of how many files would be removed
+	if !strings.Contains(output, "Would remove 1 file(s)") {
+		t.Errorf("expected output to contain summary 'Would remove 1 file(s)', got: %s", output)
+	}
+}

--- a/cmd/cleanup_test.go
+++ b/cmd/cleanup_test.go
@@ -96,3 +96,37 @@ func TestRunCleanupFn_ActualDeletion(t *testing.T) {
 		t.Errorf("expected output to contain summary 'Removed 1 file(s)', got: %s", output)
 	}
 }
+
+func TestRunCleanupFn_NoOrphanedFiles(t *testing.T) {
+	// Create temp directory to simulate .hal/
+	tmpDir := t.TempDir()
+	halDir := filepath.Join(tmpDir, ".hal")
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("failed to create .hal directory: %v", err)
+	}
+
+	// Create a config.yaml file (not an orphaned file)
+	configPath := filepath.Join(halDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("version: 1"), 0644); err != nil {
+		t.Fatalf("failed to create config.yaml: %v", err)
+	}
+
+	// Run cleanup with dryRun=false
+	var out bytes.Buffer
+	err := runCleanupFn(halDir, false, &out)
+	if err != nil {
+		t.Fatalf("runCleanupFn returned error: %v", err)
+	}
+
+	output := out.String()
+
+	// Verify output contains "No orphaned files found."
+	if !strings.Contains(output, "No orphaned files found.") {
+		t.Errorf("expected output to contain 'No orphaned files found.', got: %s", output)
+	}
+
+	// Verify config.yaml still exists (was not deleted)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("config.yaml should still exist after cleanup")
+	}
+}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -20,7 +20,6 @@ var featureStateFiles = []string{
 	template.PRDFile,
 	template.AutoPRDFile,
 	template.ProgressFile,
-	template.AutoProgressFile,
 	template.AutoStateFile,
 }
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -56,13 +56,12 @@ func TestCreate(t *testing.T) {
 				writePRD(t, halDir, template.PRDFile, "hal/my-feature", nil)
 				writePRD(t, halDir, template.AutoPRDFile, "hal/my-feature", nil)
 				writeFile(t, filepath.Join(halDir, template.ProgressFile), "progress")
-				writeFile(t, filepath.Join(halDir, template.AutoProgressFile), "auto-progress")
 				writeFile(t, filepath.Join(halDir, template.AutoStateFile), `{"step":"done"}`)
 			},
 			archName: "my-feature",
 			check: func(t *testing.T, halDir, archDir string) {
 				// Files should be in archive
-				for _, f := range []string{template.PRDFile, template.AutoPRDFile, template.ProgressFile, template.AutoProgressFile, template.AutoStateFile} {
+				for _, f := range []string{template.PRDFile, template.AutoPRDFile, template.ProgressFile, template.AutoStateFile} {
 					if !fileExists(filepath.Join(archDir, f)) {
 						t.Errorf("expected %s in archive", f)
 					}
@@ -116,7 +115,7 @@ func TestCreate(t *testing.T) {
 		{
 			name: "sanitizes archive name with separators",
 			setup: func(t *testing.T, halDir string) {
-				writeFile(t, filepath.Join(halDir, template.AutoProgressFile), "auto-progress")
+				writeFile(t, filepath.Join(halDir, template.ProgressFile), "progress")
 			},
 			archName: "feature/foo",
 			check: func(t *testing.T, halDir, archDir string) {
@@ -132,7 +131,7 @@ func TestCreate(t *testing.T) {
 		{
 			name: "sanitizes empty archive name",
 			setup: func(t *testing.T, halDir string) {
-				writeFile(t, filepath.Join(halDir, template.AutoProgressFile), "auto-progress")
+				writeFile(t, filepath.Join(halDir, template.ProgressFile), "progress")
 			},
 			archName: "   ",
 			check: func(t *testing.T, halDir, archDir string) {
@@ -148,12 +147,12 @@ func TestCreate(t *testing.T) {
 		{
 			name: "auto-state only archives",
 			setup: func(t *testing.T, halDir string) {
-				writeFile(t, filepath.Join(halDir, template.AutoProgressFile), "auto-progress")
+				writeFile(t, filepath.Join(halDir, template.ProgressFile), "progress")
 				writeFile(t, filepath.Join(halDir, template.AutoStateFile), `{"step":"paused"}`)
 			},
 			archName: "auto-only",
 			check: func(t *testing.T, halDir, archDir string) {
-				for _, f := range []string{template.AutoProgressFile, template.AutoStateFile} {
+				for _, f := range []string{template.ProgressFile, template.AutoStateFile} {
 					if !fileExists(filepath.Join(archDir, f)) {
 						t.Errorf("expected %s in archive", f)
 					}
@@ -454,7 +453,7 @@ func TestRestore(t *testing.T) {
 			name: "auto-archives auto-state before restore",
 			setup: func(t *testing.T, halDir string) string {
 				// Create current auto state only
-				writeFile(t, filepath.Join(halDir, template.AutoProgressFile), "auto-progress")
+				writeFile(t, filepath.Join(halDir, template.ProgressFile), "progress")
 				writeFile(t, filepath.Join(halDir, template.AutoStateFile), `{"step":"paused"}`)
 
 				// Create archive to restore

--- a/internal/compound/migrate.go
+++ b/internal/compound/migrate.go
@@ -1,0 +1,89 @@
+package compound
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jywlabs/hal/internal/template"
+)
+
+// DisplayWriter is an interface for display output used during migration.
+// It is satisfied by *engine.Display.
+type DisplayWriter interface {
+	ShowInfo(format string, args ...any)
+}
+
+// MigrateAutoProgress migrates content from legacy auto-progress.txt to unified progress.txt.
+// If auto-progress.txt exists, its content is appended to progress.txt and the legacy file is deleted.
+// If display is nil, no status messages are printed.
+func MigrateAutoProgress(dir string, display DisplayWriter) error {
+	halDir := filepath.Join(dir, template.HalDir)
+	autoProgressPath := filepath.Join(halDir, "auto-progress.txt")
+	progressPath := filepath.Join(halDir, template.ProgressFile)
+
+	// Check if legacy auto-progress.txt exists
+	autoProgressData, err := os.ReadFile(autoProgressPath)
+	if os.IsNotExist(err) {
+		// No legacy file to migrate
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read auto-progress.txt: %w", err)
+	}
+
+	autoContent := string(autoProgressData)
+	// Skip if auto-progress.txt is empty or just the default template
+	if autoContent == "" || autoContent == template.DefaultProgress {
+		// Remove empty/default legacy file
+		if err := os.Remove(autoProgressPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove empty auto-progress.txt: %w", err)
+		}
+		if display != nil {
+			display.ShowInfo("   Removed empty auto-progress.txt\n")
+		}
+		return nil
+	}
+
+	// Read current progress.txt content
+	progressData, err := os.ReadFile(progressPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read progress.txt: %w", err)
+	}
+	progressContent := string(progressData)
+
+	// Determine if progress.txt has meaningful content
+	progressIsEmpty := progressContent == "" || progressContent == template.DefaultProgress
+
+	var newContent string
+	if progressIsEmpty {
+		// Replace default/empty with auto-progress content
+		newContent = autoContent
+	} else {
+		// Append auto-progress content with separator
+		newContent = progressContent
+		if !strings.HasSuffix(newContent, "\n") {
+			newContent += "\n"
+		}
+		newContent += "\n---\n\n## Migrated from auto-progress.txt\n\n" + autoContent
+	}
+
+	// Write merged content to progress.txt
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		return fmt.Errorf("failed to create .hal directory: %w", err)
+	}
+	if err := os.WriteFile(progressPath, []byte(newContent), 0644); err != nil {
+		return fmt.Errorf("failed to write merged progress.txt: %w", err)
+	}
+
+	// Remove legacy auto-progress.txt
+	if err := os.Remove(autoProgressPath); err != nil {
+		return fmt.Errorf("failed to remove auto-progress.txt after migration: %w", err)
+	}
+
+	if display != nil {
+		display.ShowInfo("   Migrated auto-progress.txt to progress.txt\n")
+	}
+	return nil
+}

--- a/internal/compound/migrate_test.go
+++ b/internal/compound/migrate_test.go
@@ -129,3 +129,58 @@ func TestMigrateAutoProgress_ReplaceWhenEmpty(t *testing.T) {
 		t.Errorf("auto-progress.txt should be deleted after replacement")
 	}
 }
+
+func TestMigrateAutoProgress_ReplaceWhenDefault(t *testing.T) {
+	// Create temp directory
+	dir := t.TempDir()
+	halDir := filepath.Join(dir, template.HalDir)
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("failed to create hal dir: %v", err)
+	}
+
+	// Create progress.txt with default template content
+	progressPath := filepath.Join(halDir, template.ProgressFile)
+	if err := os.WriteFile(progressPath, []byte(template.DefaultProgress), 0644); err != nil {
+		t.Fatalf("failed to write progress.txt with default content: %v", err)
+	}
+
+	// Create auto-progress.txt with meaningful content to migrate
+	autoProgressPath := filepath.Join(halDir, "auto-progress.txt")
+	autoContent := "Meaningful auto progress content"
+	if err := os.WriteFile(autoProgressPath, []byte(autoContent), 0644); err != nil {
+		t.Fatalf("failed to write auto-progress.txt: %v", err)
+	}
+
+	// Run migration
+	display := &mockDisplay{}
+	err := MigrateAutoProgress(dir, display)
+	if err != nil {
+		t.Fatalf("MigrateAutoProgress returned error: %v", err)
+	}
+
+	// Verify progress.txt contains exactly the auto-progress content (no separator)
+	result, err := os.ReadFile(progressPath)
+	if err != nil {
+		t.Fatalf("failed to read progress.txt: %v", err)
+	}
+	resultStr := string(result)
+
+	if resultStr != autoContent {
+		t.Errorf("progress.txt should contain exactly auto-progress content, got %q, want %q", resultStr, autoContent)
+	}
+
+	// Verify no separator is present (replacement, not merge)
+	if strings.Contains(resultStr, "---") {
+		t.Errorf("progress.txt should not contain separator for replacement: got %q", resultStr)
+	}
+
+	// Verify default content is NOT present
+	if strings.Contains(resultStr, "Codebase Patterns") {
+		t.Errorf("progress.txt should not contain default template content after replacement: got %q", resultStr)
+	}
+
+	// Verify auto-progress.txt was deleted
+	if _, err := os.Stat(autoProgressPath); !os.IsNotExist(err) {
+		t.Errorf("auto-progress.txt should be deleted after replacement")
+	}
+}

--- a/internal/compound/migrate_test.go
+++ b/internal/compound/migrate_test.go
@@ -1,0 +1,81 @@
+package compound
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/template"
+)
+
+// mockDisplay is a simple DisplayWriter implementation for testing.
+type mockDisplay struct {
+	messages []string
+}
+
+func (m *mockDisplay) ShowInfo(format string, args ...any) {
+	// Not used in these tests but satisfies interface
+}
+
+func TestMigrateAutoProgress_MergeBothHaveContent(t *testing.T) {
+	// Create temp directory
+	dir := t.TempDir()
+	halDir := filepath.Join(dir, template.HalDir)
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("failed to create hal dir: %v", err)
+	}
+
+	// Create progress.txt with existing content
+	progressPath := filepath.Join(halDir, template.ProgressFile)
+	existingContent := "Existing progress notes"
+	if err := os.WriteFile(progressPath, []byte(existingContent), 0644); err != nil {
+		t.Fatalf("failed to write progress.txt: %v", err)
+	}
+
+	// Create auto-progress.txt with content to migrate
+	autoProgressPath := filepath.Join(halDir, "auto-progress.txt")
+	autoContent := "Auto progress notes"
+	if err := os.WriteFile(autoProgressPath, []byte(autoContent), 0644); err != nil {
+		t.Fatalf("failed to write auto-progress.txt: %v", err)
+	}
+
+	// Run migration
+	display := &mockDisplay{}
+	err := MigrateAutoProgress(dir, display)
+	if err != nil {
+		t.Fatalf("MigrateAutoProgress returned error: %v", err)
+	}
+
+	// Verify progress.txt contains merged content
+	merged, err := os.ReadFile(progressPath)
+	if err != nil {
+		t.Fatalf("failed to read merged progress.txt: %v", err)
+	}
+	mergedStr := string(merged)
+
+	// Check original content is present
+	if !strings.Contains(mergedStr, existingContent) {
+		t.Errorf("merged content missing original progress: got %q", mergedStr)
+	}
+
+	// Check separator is present
+	if !strings.Contains(mergedStr, "---") {
+		t.Errorf("merged content missing separator: got %q", mergedStr)
+	}
+
+	// Check migration header is present
+	if !strings.Contains(mergedStr, "Migrated from auto-progress.txt") {
+		t.Errorf("merged content missing migration header: got %q", mergedStr)
+	}
+
+	// Check auto-progress content is present
+	if !strings.Contains(mergedStr, autoContent) {
+		t.Errorf("merged content missing auto-progress content: got %q", mergedStr)
+	}
+
+	// Verify auto-progress.txt was deleted
+	if _, err := os.Stat(autoProgressPath); !os.IsNotExist(err) {
+		t.Errorf("auto-progress.txt should be deleted after merge")
+	}
+}

--- a/internal/compound/migrate_test.go
+++ b/internal/compound/migrate_test.go
@@ -79,3 +79,53 @@ func TestMigrateAutoProgress_MergeBothHaveContent(t *testing.T) {
 		t.Errorf("auto-progress.txt should be deleted after merge")
 	}
 }
+
+func TestMigrateAutoProgress_ReplaceWhenEmpty(t *testing.T) {
+	// Create temp directory
+	dir := t.TempDir()
+	halDir := filepath.Join(dir, template.HalDir)
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("failed to create hal dir: %v", err)
+	}
+
+	// Create empty progress.txt file
+	progressPath := filepath.Join(halDir, template.ProgressFile)
+	if err := os.WriteFile(progressPath, []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write empty progress.txt: %v", err)
+	}
+
+	// Create auto-progress.txt with content to migrate
+	autoProgressPath := filepath.Join(halDir, "auto-progress.txt")
+	autoContent := "Auto progress content"
+	if err := os.WriteFile(autoProgressPath, []byte(autoContent), 0644); err != nil {
+		t.Fatalf("failed to write auto-progress.txt: %v", err)
+	}
+
+	// Run migration
+	display := &mockDisplay{}
+	err := MigrateAutoProgress(dir, display)
+	if err != nil {
+		t.Fatalf("MigrateAutoProgress returned error: %v", err)
+	}
+
+	// Verify progress.txt contains exactly the auto-progress content (no separator)
+	result, err := os.ReadFile(progressPath)
+	if err != nil {
+		t.Fatalf("failed to read progress.txt: %v", err)
+	}
+	resultStr := string(result)
+
+	if resultStr != autoContent {
+		t.Errorf("progress.txt should contain exactly auto-progress content, got %q, want %q", resultStr, autoContent)
+	}
+
+	// Verify no separator is present (replacement, not merge)
+	if strings.Contains(resultStr, "---") {
+		t.Errorf("progress.txt should not contain separator for replacement: got %q", resultStr)
+	}
+
+	// Verify auto-progress.txt was deleted
+	if _, err := os.Stat(autoProgressPath); !os.IsNotExist(err) {
+		t.Errorf("auto-progress.txt should be deleted after replacement")
+	}
+}

--- a/internal/compound/migrate_test.go
+++ b/internal/compound/migrate_test.go
@@ -184,3 +184,39 @@ func TestMigrateAutoProgress_ReplaceWhenDefault(t *testing.T) {
 		t.Errorf("auto-progress.txt should be deleted after replacement")
 	}
 }
+
+func TestMigrateAutoProgress_NoOpWhenNoLegacyFile(t *testing.T) {
+	// Create temp directory
+	dir := t.TempDir()
+	halDir := filepath.Join(dir, template.HalDir)
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("failed to create hal dir: %v", err)
+	}
+
+	// Create only progress.txt with content (no auto-progress.txt)
+	progressPath := filepath.Join(halDir, template.ProgressFile)
+	existingContent := "Existing content"
+	if err := os.WriteFile(progressPath, []byte(existingContent), 0644); err != nil {
+		t.Fatalf("failed to write progress.txt: %v", err)
+	}
+
+	// Run migration
+	display := &mockDisplay{}
+	err := MigrateAutoProgress(dir, display)
+
+	// Function should return nil (no error)
+	if err != nil {
+		t.Errorf("MigrateAutoProgress should return nil when no legacy file exists, got: %v", err)
+	}
+
+	// Verify progress.txt is unchanged
+	result, err := os.ReadFile(progressPath)
+	if err != nil {
+		t.Fatalf("failed to read progress.txt: %v", err)
+	}
+	resultStr := string(result)
+
+	if resultStr != existingContent {
+		t.Errorf("progress.txt should be unchanged, got %q, want %q", resultStr, existingContent)
+	}
+}

--- a/internal/compound/pipeline.go
+++ b/internal/compound/pipeline.go
@@ -492,23 +492,23 @@ func (p *Pipeline) runLoopStep(ctx context.Context, state *PipelineState, opts R
 		return nil
 	}
 
-	progressPath := filepath.Join(p.dir, template.HalDir, template.AutoProgressFile)
+	progressPath := filepath.Join(p.dir, template.HalDir, template.ProgressFile)
 	if _, err := os.Stat(progressPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(progressPath), 0755); err != nil {
 			return fmt.Errorf("failed to create progress directory: %w", err)
 		}
 		if err := os.WriteFile(progressPath, []byte(template.DefaultProgress), 0644); err != nil {
-			return fmt.Errorf("failed to write %s: %w", template.AutoProgressFile, err)
+			return fmt.Errorf("failed to write %s: %w", template.ProgressFile, err)
 		}
 	} else if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", template.AutoProgressFile, err)
+		return fmt.Errorf("failed to stat %s: %w", template.ProgressFile, err)
 	}
 
 	// Create loop runner with config from auto settings
 	loopConfig := loop.Config{
 		Dir:           filepath.Join(p.dir, template.HalDir),
 		PRDFile:       template.AutoPRDFile,
-		ProgressFile:  template.AutoProgressFile,
+		ProgressFile:  template.ProgressFile,
 		MaxIterations: p.config.MaxIterations,
 		Engine:        p.engine.Name(),
 		Logger:        p.display.Writer(),

--- a/internal/compound/pipeline.go
+++ b/internal/compound/pipeline.go
@@ -556,69 +556,7 @@ func (p *Pipeline) runLoopStep(ctx context.Context, state *PipelineState, opts R
 // migrateAutoProgress migrates content from legacy auto-progress.txt to unified progress.txt.
 // If auto-progress.txt exists, its content is appended to progress.txt and the legacy file is deleted.
 func (p *Pipeline) migrateAutoProgress() error {
-	halDir := filepath.Join(p.dir, template.HalDir)
-	autoProgressPath := filepath.Join(halDir, "auto-progress.txt")
-	progressPath := filepath.Join(halDir, template.ProgressFile)
-
-	// Check if legacy auto-progress.txt exists
-	autoProgressData, err := os.ReadFile(autoProgressPath)
-	if os.IsNotExist(err) {
-		// No legacy file to migrate
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to read auto-progress.txt: %w", err)
-	}
-
-	autoContent := string(autoProgressData)
-	// Skip if auto-progress.txt is empty or just the default template
-	if autoContent == "" || autoContent == template.DefaultProgress {
-		// Remove empty/default legacy file
-		if err := os.Remove(autoProgressPath); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("failed to remove empty auto-progress.txt: %w", err)
-		}
-		p.display.ShowInfo("   Removed empty auto-progress.txt\n")
-		return nil
-	}
-
-	// Read current progress.txt content
-	progressData, err := os.ReadFile(progressPath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to read progress.txt: %w", err)
-	}
-	progressContent := string(progressData)
-
-	// Determine if progress.txt has meaningful content
-	progressIsEmpty := progressContent == "" || progressContent == template.DefaultProgress
-
-	var newContent string
-	if progressIsEmpty {
-		// Replace default/empty with auto-progress content
-		newContent = autoContent
-	} else {
-		// Append auto-progress content with separator
-		newContent = progressContent
-		if !strings.HasSuffix(newContent, "\n") {
-			newContent += "\n"
-		}
-		newContent += "\n---\n\n## Migrated from auto-progress.txt\n\n" + autoContent
-	}
-
-	// Write merged content to progress.txt
-	if err := os.MkdirAll(halDir, 0755); err != nil {
-		return fmt.Errorf("failed to create .hal directory: %w", err)
-	}
-	if err := os.WriteFile(progressPath, []byte(newContent), 0644); err != nil {
-		return fmt.Errorf("failed to write merged progress.txt: %w", err)
-	}
-
-	// Remove legacy auto-progress.txt
-	if err := os.Remove(autoProgressPath); err != nil {
-		return fmt.Errorf("failed to remove auto-progress.txt after migration: %w", err)
-	}
-
-	p.display.ShowInfo("   Migrated auto-progress.txt to progress.txt\n")
-	return nil
+	return MigrateAutoProgress(p.dir, p.display)
 }
 
 // runPRStep pushes the branch and creates a draft pull request.

--- a/internal/compound/review.go
+++ b/internal/compound/review.go
@@ -68,6 +68,12 @@ func Review(ctx context.Context, eng engine.Engine, display *engine.Display, dir
 		if rc.PRDContent != "" {
 			display.ShowInfo("     - PRD content (%d bytes)\n", len(rc.PRDContent))
 		}
+		if rc.PRDJSONContent != "" {
+			display.ShowInfo("     - PRD JSON (%d bytes)\n", len(rc.PRDJSONContent))
+		}
+		if rc.AutoPRDContent != "" {
+			display.ShowInfo("     - Auto PRD JSON (%d bytes)\n", len(rc.AutoPRDContent))
+		}
 		return &ReviewResult{}, nil
 	}
 
@@ -219,6 +225,18 @@ func buildReviewPrompt(rc *reviewContext) string {
 	if rc.PRDContent != "" {
 		sb.WriteString("### PRD Goals\n```markdown\n")
 		sb.WriteString(truncateContent(rc.PRDContent, 8000))
+		sb.WriteString("\n```\n\n")
+	}
+
+	if rc.PRDJSONContent != "" {
+		sb.WriteString("### PRD Task Status (prd.json)\n```json\n")
+		sb.WriteString(truncateContent(rc.PRDJSONContent, 5000))
+		sb.WriteString("\n```\n\n")
+	}
+
+	if rc.AutoPRDContent != "" {
+		sb.WriteString("### Auto PRD Task Status (auto-prd.json)\n```json\n")
+		sb.WriteString(truncateContent(rc.AutoPRDContent, 5000))
 		sb.WriteString("\n```\n\n")
 	}
 

--- a/internal/compound/review.go
+++ b/internal/compound/review.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jywlabs/hal/internal/engine"
 	"github.com/jywlabs/hal/internal/skills"
+	"github.com/jywlabs/hal/internal/template"
 )
 
 // reviewContext holds gathered context for the review.
@@ -130,7 +131,7 @@ func gatherReviewContext(dir string) (*reviewContext, error) {
 	}
 
 	// Read progress log
-	progressPath := filepath.Join(dir, ".hal", "progress.txt")
+	progressPath := filepath.Join(dir, template.HalDir, template.ProgressFile)
 	if content, err := os.ReadFile(progressPath); err == nil {
 		rc.ProgressContent = string(content)
 	} else {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -18,21 +18,19 @@ const HalDir = ".hal"
 
 // File name constants for consistent usage across the codebase.
 const (
-	PRDFile          = "prd.json"      // Manual flow (plan, convert, validate, run)
-	AutoPRDFile      = "auto-prd.json" // Auto flow (auto, explode)
-	PromptFile       = "prompt.md"
-	ProgressFile     = "progress.txt"      // Manual flow
-	AutoProgressFile = "auto-progress.txt" // Auto flow
-	AutoStateFile    = "auto-state.json"   // Auto flow pipeline state
-	ConfigFile       = "config.yaml"
+	PRDFile       = "prd.json"      // Manual flow (plan, convert, validate, run)
+	AutoPRDFile   = "auto-prd.json" // Auto flow (auto, explode)
+	PromptFile    = "prompt.md"
+	ProgressFile  = "progress.txt"       // Unified progress for both flows
+	AutoStateFile = "auto-state.json"    // Auto flow pipeline state
+	ConfigFile    = "config.yaml"
 )
 
 // DefaultFiles returns the default files to create in .hal/
 func DefaultFiles() map[string]string {
 	return map[string]string{
-		PromptFile:       DefaultPrompt,
-		ProgressFile:     DefaultProgress,
-		AutoProgressFile: DefaultProgress,
-		ConfigFile:       DefaultConfig,
+		PromptFile:   DefaultPrompt,
+		ProgressFile: DefaultProgress,
+		ConfigFile:   DefaultConfig,
 	}
 }


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for the migrateAutoProgress function and hal cleanup command. Tests should cover merge behavior when both files have content, replacement when progress.txt is empty/default, dry-run output verification, and actual deletion behavior.

### Rationale

The tech debt section explicitly calls out missing tests for critical new functionality. Without tests, the merge semantics and cleanup behavior could regress or behave unexpectedly. This is high impact because it locks in the correctness of the consolidation work just completed and prevents future regressions.

### Acceptance Criteria

- Unit tests exist for migrateAutoProgress covering: merge with separator when both files have content
- Unit tests exist for migrateAutoProgress covering: full replacement when progress.txt is empty or contains only default content
- Unit tests exist for migrateAutoProgress covering: no-op when auto-progress.txt does not exist
- Unit tests exist for migrateAutoProgress covering: legacy file deletion after successful merge
- Unit tests exist for hal cleanup --dry-run showing files that would be deleted without deleting them
- Unit tests exist for hal cleanup actually deleting orphaned files
- Unit tests exist for hal cleanup when no orphaned files exist
- All tests pass with make test

### Task Status

- Completed: 10/10

---

🤖 Generated by [hal](https://github.com/jywlabs/hal) compound pipeline
