### PR TITLE
hotfix: keep spinner running while loading text switches to tool activity

### DIFF
--- a/internal/engine/display_test.go
+++ b/internal/engine/display_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"regexp"
 	"strings"
 	"testing"
@@ -44,4 +45,38 @@ func TestRenderAnimatedSpinnerText_Empty(t *testing.T) {
 	if rendered != "" {
 		t.Errorf("expected empty rendered text for empty input, got %q", rendered)
 	}
+}
+
+func TestStartSpinner_UpdatesMessageWhenAlreadySpinning(t *testing.T) {
+	var out bytes.Buffer
+	d := NewDisplay(&out)
+
+	d.StartSpinner("thinking...")
+	d.StartSpinner("run ls -la")
+
+	if !d.spinning {
+		t.Fatal("expected spinner to remain active")
+	}
+	if d.spinMsg != "run ls -la" {
+		t.Fatalf("expected spinner message to update, got %q", d.spinMsg)
+	}
+
+	d.StopSpinner()
+}
+
+func TestShowEvent_ToolKeepsSpinnerAndUpdatesMessage(t *testing.T) {
+	var out bytes.Buffer
+	d := NewDisplay(&out)
+
+	d.StartSpinner("thinking...")
+	d.ShowEvent(&Event{Type: EventTool, Tool: "run", Detail: "ls -la"})
+
+	if !d.spinning {
+		t.Fatal("expected spinner to stay active across tool event")
+	}
+	if d.spinMsg != "run ls -la" {
+		t.Fatalf("expected spinner message to be updated to tool text, got %q", d.spinMsg)
+	}
+
+	d.StopSpinner()
 }


### PR DESCRIPTION
## Summary
- keep spinner goroutine active when message changes (e.g. thinking... -> run ls -la)
- update spinner text in place without stopping/restarting spinner
- keep immutable tool history output clean by clearing active spinner line first
- add display tests for spinner-message update behavior

## Validation
- go test ./...
- go test -race ./internal/engine/...