### PR TITLE
Spinner/progress state machine refactor

### DIFF
--- a/.hal/auto-prd.json
+++ b/.hal/auto-prd.json
@@ -1,0 +1,179 @@
+{
+  "project": "spinner-state-machine-refactor",
+  "branchName": "compound/spinner-state-machine-refactor",
+  "description": "Refactor HAL CLI spinner/progress rendering from ad-hoc booleans into an explicit finite state machine with validated transitions and comprehensive tests.",
+  "userStories": [
+    {
+      "id": "T-001",
+      "title": "Define SpinnerState type and transition table",
+      "description": "As a developer, I need a SpinnerState type with named constants and a transition validation function in internal/engine/spinner_state.go so that all spinner state changes are explicit and invalid transitions return errors.",
+      "acceptanceCriteria": [
+        "New file internal/engine/spinner_state.go defines SpinnerState type as an int with iota constants: StateIdle, StateThinking, StateToolActivity, StateCompletion, StateError",
+        "Transition(from, to SpinnerState) error function validates against explicit allow-list",
+        "Valid transitions: Idle→Thinking, Thinking→ToolActivity, Thinking→Completion, Thinking→Error, ToolActivity→Thinking, ToolActivity→Completion, ToolActivity→Error, ToolActivity→ToolActivity, Completion→Idle, Error→Idle, Idle→Idle",
+        "Invalid transitions return fmt.Errorf with descriptive message including state names",
+        "SpinnerState has a String() method returning the state name",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-002",
+      "title": "Implement SpinnerFSM struct with state, message, and timing",
+      "description": "As a developer, I need a SpinnerFSM struct in internal/engine/spinner_state.go that encapsulates current state, message, thinking start time, and last tool key so that Display can delegate all state tracking to this single type.",
+      "acceptanceCriteria": [
+        "SpinnerFSM struct holds: state SpinnerState, message string, thinkingStart time.Time, lastTool string",
+        "NewSpinnerFSM() returns FSM in StateIdle with zero-value fields",
+        "FSM.State() returns the current SpinnerState",
+        "FSM.GoTo(next SpinnerState, msg string) error calls Transition() and updates state + message; sets thinkingStart=time.Now() when entering StateThinking",
+        "FSM.Message() returns current message string",
+        "FSM.ThinkingElapsed() returns time.Since(thinkingStart) when in StateThinking, zero otherwise",
+        "FSM.SetLastTool(key string) and FSM.LastTool() string for dedup tracking",
+        "FSM.Reset() sets state to StateIdle and clears message, thinkingStart, lastTool",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-003",
+      "title": "Unit test every valid and invalid state transition",
+      "description": "As a developer, I need exhaustive table-driven tests in internal/engine/spinner_state_test.go verifying every valid transition succeeds and invalid transitions return errors.",
+      "acceptanceCriteria": [
+        "New file internal/engine/spinner_state_test.go exists",
+        "Table-driven test covers all 11 valid transitions from T-001 — each succeeds without error",
+        "Table-driven test covers at least 5 invalid transitions: Idle→Completion, Idle→Error, Completion→Thinking, Error→Thinking, Completion→ToolActivity — each returns non-nil error",
+        "Test verifies GoTo updates state and message correctly",
+        "Test verifies GoTo into StateThinking sets thinkingStart to a non-zero time",
+        "Test verifies Reset() returns state to StateIdle and clears message, thinkingStart, lastTool",
+        "Tests pass with go test ./internal/engine/...",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-004",
+      "title": "Wire SpinnerFSM into Display struct replacing boolean fields",
+      "description": "As a developer, I need to replace the isThinking, thinkingStart, and lastTool fields on Display with a single fsm *SpinnerFSM field, updating NewDisplay and helper methods to delegate to the FSM.",
+      "acceptanceCriteria": [
+        "Display struct replaces isThinking bool, thinkingStart time.Time, lastTool string with fsm *SpinnerFSM",
+        "NewDisplay initializes fsm via NewSpinnerFSM()",
+        "clearThinkingState() delegates to fsm: sets state to Idle if currently Thinking, clears thinkingStart",
+        "spinnerDisplayMessage() reads elapsed from fsm.ThinkingElapsed() instead of d.thinkingStart",
+        "spinning bool, spinMsg string, spinCtx, spinCancel, spinDone fields remain unchanged",
+        "Existing tests still pass with go test ./internal/engine/...",
+        "Typecheck passes"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-005",
+      "title": "Refactor ShowEvent for EventInit and EventThinking to use FSM",
+      "description": "As a developer, I need ShowEvent to drive FSM transitions for EventInit and EventThinking events so that the thinking lifecycle is state-machine-governed instead of boolean-flag-governed.",
+      "acceptanceCriteria": [
+        "EventInit triggers fsm.GoTo(StateThinking, msg) and starts spinner",
+        "EventThinking 'start' triggers fsm.GoTo(StateThinking, msg) with thinkingStart set automatically by FSM",
+        "EventThinking 'delta' updates spinner message without changing FSM state",
+        "EventThinking 'end' triggers fsm.GoTo(StateCompletion, '') then fsm.Reset(), prints thinking-complete line",
+        "Direct assignments to d.isThinking and d.thinkingStart are removed from these event handlers",
+        "Spinner stays active across thinking deltas (no stop/start)",
+        "Existing tests still pass with go test ./internal/engine/...",
+        "Typecheck passes"
+      ],
+      "priority": 5,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-006",
+      "title": "Refactor ShowEvent for EventTool and EventText to use FSM",
+      "description": "As a developer, I need ShowEvent to drive FSM transitions for EventTool and EventText events so that tool-activity state is governed by the FSM.",
+      "acceptanceCriteria": [
+        "EventTool triggers fsm.GoTo(StateToolActivity, toolMsg) — spinner keeps running, message updates",
+        "Duplicate tool dedup uses fsm.LastTool() and fsm.SetLastTool() instead of d.lastTool",
+        "EventText triggers fsm.GoTo(StateToolActivity, workingMsg)",
+        "Spinner line clearing before tool history line output is preserved",
+        "Direct assignments to d.lastTool are removed",
+        "Existing TestShowEvent_ToolKeepsSpinnerAndUpdatesMessage still passes",
+        "Typecheck passes"
+      ],
+      "priority": 6,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-007",
+      "title": "Refactor ShowEvent for EventResult and EventError to use FSM",
+      "description": "As a developer, I need ShowEvent to drive FSM transitions for EventResult and EventError events so that completion and error states are state-machine-governed.",
+      "acceptanceCriteria": [
+        "EventResult triggers fsm.GoTo(StateCompletion, '') then fsm.Reset(), stops spinner, prints result line",
+        "EventError triggers fsm.GoTo(StateError, errorMsg) then fsm.Reset(), stops spinner, prints error line",
+        "The keepSpinner logic at top of ShowEvent is replaced by FSM-driven decision: only stop spinner when next event is not EventTool or EventThinking delta",
+        "Direct calls to clearThinkingState() in these handlers are removed or replaced by FSM transitions",
+        "Existing tests still pass with go test ./internal/engine/...",
+        "Typecheck passes"
+      ],
+      "priority": 7,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-008",
+      "title": "Add ShowEvent unit tests for full event lifecycle sequences",
+      "description": "As a developer, I need unit tests verifying ShowEvent drives the FSM correctly through realistic multi-event sequences so that lifecycle regressions are caught.",
+      "acceptanceCriteria": [
+        "Test: Init → Thinking start → Thinking delta → Tool → Tool → Thinking end → Result — verifies FSM state at each step via display.fsm.State()",
+        "Test: Init → Thinking start → Error — verifies error handling resets FSM to StateIdle",
+        "Test: Duplicate consecutive tool events are deduplicated via FSM lastTool",
+        "Test: Spinner message updates on Thinking→ToolActivity transition",
+        "All tests use bytes.Buffer writer (non-TTY) to avoid goroutine timing issues",
+        "Tests pass with go test ./internal/engine/...",
+        "Typecheck passes"
+      ],
+      "priority": 8,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-009",
+      "title": "Add golden-output test for full lifecycle terminal output",
+      "description": "As a developer, I need a golden-output test capturing expected terminal output for a complete thinking→tool-activity→completion lifecycle so that visual regressions are caught automatically.",
+      "acceptanceCriteria": [
+        "New test TestShowEvent_GoldenLifecycle in display_test.go",
+        "Feeds event sequence: Init(model) → Thinking start → Thinking end → Tool(Read, file.go) → Tool(Write, file.go) → Result(success, 1500 tokens, 5000ms)",
+        "Captures output via bytes.Buffer (non-TTY, no spinner goroutine)",
+        "Strips ANSI escape codes before comparison",
+        "Golden string includes: model line, thinking-complete \u003e line, tool \u003e lines, result [OK] line with duration and tokens",
+        "Test fails with clear diff if output changes",
+        "Tests pass with go test ./internal/engine/...",
+        "Typecheck passes"
+      ],
+      "priority": 9,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "T-010",
+      "title": "Remove dead code and verify full test suite",
+      "description": "As a developer, I need to clean up dead code from the old ad-hoc spinner control (unused fields, orphaned methods) and verify the entire project builds and passes tests.",
+      "acceptanceCriteria": [
+        "clearThinkingState() is removed if fully replaced by FSM, or reduced to a thin FSM wrapper if still referenced",
+        "No unused fields remain on Display struct (isThinking, thinkingStart, lastTool are all gone)",
+        "go vet ./... passes with no warnings",
+        "go test ./... passes (all existing and new tests)",
+        "make build succeeds",
+        "Typecheck passes"
+      ],
+      "priority": 10,
+      "passes": true,
+      "notes": ""
+    }
+  ]
+}

--- a/.hal/progress.txt
+++ b/.hal/progress.txt
@@ -1,0 +1,162 @@
+# Ralph Progress Log
+
+## Codebase Patterns
+
+- Display struct now delegates state tracking to `fsm *SpinnerFSM` — old fields `isThinking`, `thinkingStart`, `lastTool` are removed.
+- Display uses two mutexes: `mu` (general output) and `spinMu` (spinner state). FSM fields are guarded by `mu`.
+- Event types are defined in `internal/engine/types.go` as string constants (EventInit, EventTool, etc.).
+- Existing display tests use `bytes.Buffer` (non-TTY) to avoid spinner goroutine timing issues.
+- `ShowIterationHeader` calls `fsm.Reset()` to clear state for new iterations.
+- `clearThinkingState()` is now dead code — no ShowEvent handler calls it. T-010 should remove it.
+- `d.fsm.thinkingStart` (unexported field) is accessible within the `engine` package — used by `formatThinkingComplete()` in thinking "end" handler.
+- Tool dedup key is `e.Tool + e.Detail` (no space) — space is added later for display only.
+- ShowEvent lifecycle tests must call `d.StopSpinner()` between events to clean up spinner state for FSM assertions.
+
+---
+
+## 2026-02-07 - T-001
+- Implemented SpinnerState type with iota constants: StateIdle, StateThinking, StateToolActivity, StateCompletion, StateError
+- Implemented Transition(from, to) error function with explicit allow-list of 11 valid transitions
+- Added String() method for human-readable state names
+- Files changed: internal/engine/spinner_state.go (new)
+- **Learnings for future iterations:**
+  - The transition table includes Idle→Idle for idempotent resets and ToolActivity→ToolActivity for consecutive tool events
+  - Display struct has `lastTool string` that tracks tool dedup — this will move into SpinnerFSM in T-002
+  - `clearThinkingState()` zeroes both `isThinking` and `thinkingStart` — FSM equivalent is GoTo(StateIdle) or Reset()
+---
+
+## 2026-02-07 - T-002
+- Implemented SpinnerFSM struct with fields: state, message, thinkingStart, lastTool
+- NewSpinnerFSM() constructor returns FSM in StateIdle
+- State(), GoTo(), Message(), ThinkingElapsed(), SetLastTool(), LastTool(), Reset() methods
+- GoTo() validates transitions via Transition() and auto-sets thinkingStart on StateThinking entry
+- ThinkingElapsed() returns duration only when in StateThinking, zero otherwise
+- Reset() clears all fields back to zero values
+- Files changed: internal/engine/spinner_state.go (modified)
+- **Learnings for future iterations:**
+  - SpinnerFSM is intentionally not thread-safe — Display's `mu` mutex already guards access
+  - GoTo() only sets thinkingStart on StateThinking entry; other state transitions don't touch it
+  - Reset() is a hard reset (Idle + clear all) vs GoTo(StateIdle) which only changes state+message
+---
+
+## 2026-02-07 - T-003
+- Implemented exhaustive table-driven tests in internal/engine/spinner_state_test.go
+- TestTransition_ValidTransitions: covers all 11 valid transitions
+- TestTransition_InvalidTransitions: covers 11 invalid transitions (exceeding the minimum 5)
+- TestSpinnerState_String: covers all named states plus unknown state fallback
+- TestNewSpinnerFSM: verifies initial zero-value state
+- TestFSM_GoTo_UpdatesStateAndMessage: table-driven test for state/message updates and invalid transition rejection
+- TestFSM_GoTo_ThinkingSetsThinkingStart: verifies thinkingStart is set within time bounds on StateThinking entry
+- TestFSM_GoTo_NonThinkingDoesNotSetThinkingStart: verifies thinkingStart is preserved on non-Thinking transitions
+- TestFSM_ThinkingElapsed_ZeroWhenNotThinking: verifies zero duration in non-Thinking states
+- TestFSM_LastTool: verifies SetLastTool/LastTool pair
+- TestFSM_Reset: verifies all fields cleared (state, message, thinkingStart, lastTool)
+- Files changed: internal/engine/spinner_state_test.go (new)
+- **Learnings for future iterations:**
+  - Test file uses `package engine` (not `engine_test`) since it needs access to unexported fields (thinkingStart) for time assertions
+  - ThinkingElapsed() test needs state transitions first (Idle→Thinking→ToolActivity) to get the FSM into the right state for assertions
+---
+
+## 2026-02-07 - T-004
+- Replaced `isThinking bool`, `thinkingStart time.Time`, `lastTool string` on Display with single `fsm *SpinnerFSM` field
+- NewDisplay initializes fsm via NewSpinnerFSM()
+- clearThinkingState() delegates to fsm.Reset() when in StateThinking
+- spinnerDisplayMessage() reads elapsed from fsm.ThinkingElapsed() instead of d.thinkingStart
+- ShowEvent tool dedup uses fsm.LastTool() / fsm.SetLastTool() instead of d.lastTool
+- EventThinking "start" uses fsm.GoTo(StateThinking, msg) with auto-set thinkingStart
+- EventThinking "end" reads d.fsm.thinkingStart for formatThinkingComplete()
+- ShowIterationHeader calls fsm.Reset() instead of d.lastTool = ""
+- spinning, spinMsg, spinCtx, spinCancel, spinDone fields unchanged (spinner goroutine state)
+- Files changed: internal/engine/display.go (modified)
+- **Learnings for future iterations:**
+  - clearThinkingState() uses fsm.Reset() (hard reset) rather than GoTo because Thinking→Idle is not a valid transition in the FSM table — Reset() bypasses transition validation
+  - d.fsm.thinkingStart is accessible as unexported field within the same package — no getter needed for formatThinkingComplete()
+  - EventThinking "start" does fsm.Reset() first to ensure clean state, then GoTo(StateThinking) — this handles edge cases where thinking restarts without proper end
+  - The keepSpinner logic at top of ShowEvent is unchanged — it still uses event type checks, not FSM state. T-007 will refactor this.
+---
+
+## 2026-02-07 - T-005
+- Refactored EventInit handler: replaced `clearThinkingState()` with `fsm.Reset()` + `fsm.GoTo(StateThinking, msg)`, spinner message driven from `fsm.Message()`
+- Refactored EventThinking "end": replaced `clearThinkingState()` with `fsm.GoTo(StateCompletion, "")` then `fsm.Reset()` — properly transitions through Completion state
+- EventThinking "start" and "delta" handlers were already FSM-driven from T-004, no changes needed
+- No direct boolean assignments (`d.isThinking`, `d.thinkingStart`) exist — all removed in T-004
+- Spinner stays active across thinking deltas via keepSpinner logic (unchanged)
+- Files changed: internal/engine/display.go (modified)
+- **Learnings for future iterations:**
+  - EventInit uses `fsm.Reset()` before `GoTo(StateThinking)` because init can arrive from any FSM state (e.g., after an error) — Reset bypasses transition validation
+  - EventThinking "end" must read `d.fsm.thinkingStart` BEFORE transitioning to Completion, since GoTo doesn't clear timing fields but Reset does
+  - Only EventInit and EventThinking handlers were modified for T-005 — EventTool, EventResult, EventError, EventText still use `clearThinkingState()` and will be refactored in T-006/T-007
+---
+
+## 2026-02-07 - T-006
+- Refactored EventTool handler: replaced `clearThinkingState()` with `fsm.GoTo(StateToolActivity, toolMsg)` — FSM now governs tool-activity state
+- Refactored EventText handler: replaced `clearThinkingState()` with `fsm.GoTo(StateToolActivity, workingMsg)` — FSM now governs working state
+- Duplicate tool dedup already uses `fsm.LastTool()` / `fsm.SetLastTool()` from T-004 — no direct `d.lastTool` assignments exist
+- Spinner line clearing before tool history output preserved unchanged
+- Edge case handling: if FSM GoTo fails (unexpected state), falls back to `fsm.Reset()`
+- Files changed: internal/engine/display.go (modified)
+- **Learnings for future iterations:**
+  - `toolMsg` must be constructed AFTER the `detail` space-prefix logic (`detail = " " + detail`) to avoid missing space in spinner messages (caught by TestShowEvent_ToolKeepsSpinnerAndUpdatesMessage)
+  - Dedup check should happen BEFORE FSM transition so duplicate tools don't change FSM state needlessly
+  - EventResult and EventError still use `clearThinkingState()` — T-007 will refactor these
+  - After T-006, only EventResult and EventError handlers still call `clearThinkingState()`
+---
+
+## 2026-02-07 - T-007
+- Refactored EventResult handler: replaced `clearThinkingState()` with `fsm.GoTo(StateCompletion, "")` then `fsm.Reset()` — proper FSM transitions through Completion→Idle
+- Refactored EventError handler: replaced `clearThinkingState()` with `fsm.GoTo(StateError, errorMsg)` then `fsm.Reset()` — proper FSM transitions through Error→Idle
+- Replaced keepSpinner logic with FSM-driven switch statement using descriptive comments about spinner-continuing vs terminal states
+- Both handlers use fallback `fsm.Reset()` if GoTo fails (unexpected FSM state)
+- `clearThinkingState()` is now completely unused in ShowEvent — only the function definition remains (T-010 cleanup target)
+- Files changed: internal/engine/display.go (modified)
+- **Learnings for future iterations:**
+  - EventResult/EventError use the same pattern as EventThinking "end": GoTo(terminal state) → Reset() — this is the canonical teardown pattern
+  - GoTo(StateCompletion/StateError) can fail if FSM is in Idle (e.g., result event arrives without prior thinking/tool) — always fall back to Reset()
+  - `clearThinkingState()` is now dead code — T-010 should remove it entirely since no ShowEvent handler calls it anymore
+  - The keepSpinner switch-statement approach is more extensible than the boolean expression — new event types can be added as additional cases
+---
+
+## 2026-02-07 - T-008
+- Added 4 new ShowEvent unit tests for full event lifecycle sequences in display_test.go
+- TestShowEvent_FullLifecycleSequence: Init → Thinking start → Thinking delta → Tool → Tool → Thinking end → Result — verifies FSM state at each step
+- TestShowEvent_ErrorResetsToIdle: Init → Thinking start → Error — verifies error handling resets FSM to StateIdle
+- TestShowEvent_DuplicateToolDedup: verifies duplicate consecutive tool events are deduplicated via FSM lastTool
+- TestShowEvent_SpinnerMessageUpdatesOnTransition: verifies spinner message updates on Thinking→ToolActivity transition
+- All tests use bytes.Buffer writer (non-TTY) to avoid goroutine timing issues
+- Files changed: internal/engine/display_test.go (modified)
+- **Learnings for future iterations:**
+  - Tool dedup key is `e.Tool + e.Detail` (no space separator) — the space is added later for display only (`detail = " " + detail`)
+  - ShowEvent must be followed by `d.StopSpinner()` in tests to clean up spinner state before the next event when checking FSM state between events
+  - EventThinking "delta" does NOT change FSM state — it only starts the spinner if not already running
+  - To test EventResult, the FSM needs to be in a valid source state (Thinking or ToolActivity) — use EventInit first to get there
+---
+
+## 2026-02-07 - T-009
+- Added TestShowEvent_GoldenLifecycle golden-output test in display_test.go
+- Feeds event sequence: Init(claude-3) → Thinking start → Thinking end → Tool(Read, file.go) → Tool(Write, file.go) → Result(success, 1500 tokens, 5000ms)
+- Captures output via bytes.Buffer (non-TTY, no spinner goroutine)
+- Strips ANSI escape codes via existing ansiRegex before comparison
+- Golden string verifies: model line, thinking-complete > line with 0s elapsed, tool > lines, result [OK] line with duration and tokens
+- Test fails with clear diff if output changes (got vs want format)
+- Files changed: internal/engine/display_test.go (modified)
+- **Learnings for future iterations:**
+  - Thinking start produces NO visible output — only FSM state change and spinner start. Don't expect it in golden output.
+  - formatThinkingComplete uses time.Since(thinkingStart) truncated to seconds — in fast tests this is always "0s"
+  - EventTool from Idle state: GoTo(StateToolActivity) fails (invalid transition) but ShowEvent falls back to fsm.Reset() — tool output still prints correctly
+  - Non-TTY display skips the `\r\033[2K` spinner line clearing (isTTY check) so golden output is clean sequential lines
+---
+
+## 2026-02-07 - T-010
+- Removed `clearThinkingState()` method from Display — it was dead code after the FSM refactor (no callers remained)
+- Verified no unused fields remain on Display struct: `isThinking`, `thinkingStart`, `lastTool` were all removed in T-004
+- Confirmed `isThinking` references in `internal/engine/pi/parser.go` are unrelated (Pi parser struct, not Display)
+- `go vet ./...` passes with no warnings
+- `go test ./...` passes (all existing and new tests)
+- `make build` succeeds
+- Files changed: internal/engine/display.go (modified — 6 lines deleted)
+- **Learnings for future iterations:**
+  - The FSM refactor is complete: all spinner state is now governed by `SpinnerFSM` via `fsm.GoTo()`, `fsm.Reset()`, `fsm.LastTool()`, `fsm.ThinkingElapsed()`
+  - Display struct's state fields are: `fsm *SpinnerFSM` (state machine) + spinner goroutine fields (`spinning`, `spinMsg`, `spinCtx`, `spinCancel`, `spinDone`)
+  - When removing dead code, always grep for the method name across the entire repo to confirm zero callers — field names may appear in other structs (e.g., Pi parser's `isThinking`)
+---
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,11 @@
 - When migrating legacy .hal state files, merge content into the new target with a separator if both have content, then delete the legacy file after a successful merge.
 - Treat orphaned legacy files via a dedicated cleanup command that supports --dry-run and uses a centralized orphanedFiles slice for extensibility.
 - Review context should load both markdown PRDs and JSON PRDs (prd.json, auto-prd.json) because JSON includes pass/fail completion status.
+
+## Patterns from main (2026-02-07)
+
+- Drive HAL progress UI from parsed engine lifecycle events (thinking/tool/completion) rather than raw output text heuristics.
+- Spinner behavior contract is strict: keep it active across loading-text to tool-activity transitions, include HAL-eye branding, and preserve completed thinking lines as quoted output.
+- Engine install commands are coupled with symlink creation and matching .gitignore exceptions; tests should assert symlink targets directly.
+- Standards injection is implemented as loader + prompt placeholder + CLI wiring, and user-facing paths should consistently use .hal/standards.
+- Release workflow conventions are repository-specific: use git-flow-style release/hotfix branches and v-prefixed tags, then keep docs aligned to that process.

--- a/internal/engine/display.go
+++ b/internal/engine/display.go
@@ -164,12 +164,6 @@ func (d *Display) currentSpinnerMessage() string {
 	return msg
 }
 
-func (d *Display) clearThinkingState() {
-	if d.fsm.State() == StateThinking {
-		d.fsm.Reset()
-	}
-}
-
 // spinnerDisplayMessage returns the message shown on the spinner line.
 // Caller must hold d.mu.
 func (d *Display) spinnerDisplayMessage(base string) string {

--- a/internal/engine/display_test.go
+++ b/internal/engine/display_test.go
@@ -80,3 +80,228 @@ func TestShowEvent_ToolKeepsSpinnerAndUpdatesMessage(t *testing.T) {
 
 	d.StopSpinner()
 }
+
+func TestShowEvent_FullLifecycleSequence(t *testing.T) {
+	// Init → Thinking start → Thinking delta → Tool → Tool → Thinking end → Result
+	// Verifies FSM state at each step via display.fsm.State()
+	var out bytes.Buffer
+	d := NewDisplay(&out)
+
+	// Step 1: Init — should transition to StateThinking
+	d.ShowEvent(&Event{
+		Type: EventInit,
+		Data: EventData{Model: "test-model"},
+	})
+	if d.fsm.State() != StateThinking {
+		t.Errorf("after Init: state = %v, want StateThinking", d.fsm.State())
+	}
+	d.StopSpinner()
+
+	// Step 2: Thinking start — should stay in StateThinking (Reset + GoTo)
+	d.ShowEvent(&Event{
+		Type: EventThinking,
+		Data: EventData{Message: "start"},
+	})
+	if d.fsm.State() != StateThinking {
+		t.Errorf("after Thinking start: state = %v, want StateThinking", d.fsm.State())
+	}
+	if d.fsm.thinkingStart.IsZero() {
+		t.Error("after Thinking start: thinkingStart should be non-zero")
+	}
+	d.StopSpinner()
+
+	// Step 3: Thinking delta — should keep StateThinking unchanged
+	d.ShowEvent(&Event{
+		Type: EventThinking,
+		Data: EventData{Message: "delta"},
+	})
+	if d.fsm.State() != StateThinking {
+		t.Errorf("after Thinking delta: state = %v, want StateThinking", d.fsm.State())
+	}
+	d.StopSpinner()
+
+	// Step 4: Tool — should transition to StateToolActivity
+	d.ShowEvent(&Event{
+		Type:   EventTool,
+		Tool:   "Read",
+		Detail: "main.go",
+	})
+	if d.fsm.State() != StateToolActivity {
+		t.Errorf("after Tool(Read): state = %v, want StateToolActivity", d.fsm.State())
+	}
+	d.StopSpinner()
+
+	// Step 5: Second Tool — should stay in StateToolActivity
+	d.ShowEvent(&Event{
+		Type:   EventTool,
+		Tool:   "Write",
+		Detail: "main.go",
+	})
+	if d.fsm.State() != StateToolActivity {
+		t.Errorf("after Tool(Write): state = %v, want StateToolActivity", d.fsm.State())
+	}
+	d.StopSpinner()
+
+	// Step 6: Thinking end — should transition through Completion then Reset to Idle
+	d.ShowEvent(&Event{
+		Type: EventThinking,
+		Data: EventData{Message: "end"},
+	})
+	if d.fsm.State() != StateIdle {
+		t.Errorf("after Thinking end: state = %v, want StateIdle", d.fsm.State())
+	}
+
+	// Step 7: Result — Init first to get to a valid state, then Result
+	d.ShowEvent(&Event{
+		Type: EventInit,
+		Data: EventData{Model: "test-model"},
+	})
+	d.StopSpinner()
+	d.ShowEvent(&Event{
+		Type: EventResult,
+		Data: EventData{
+			Success:    true,
+			Tokens:     1500,
+			DurationMs: 5000,
+		},
+	})
+	if d.fsm.State() != StateIdle {
+		t.Errorf("after Result: state = %v, want StateIdle", d.fsm.State())
+	}
+}
+
+func TestShowEvent_ErrorResetsToIdle(t *testing.T) {
+	// Init → Thinking start → Error — verifies error handling resets FSM to StateIdle
+	var out bytes.Buffer
+	d := NewDisplay(&out)
+
+	// Init
+	d.ShowEvent(&Event{
+		Type: EventInit,
+		Data: EventData{Model: "test-model"},
+	})
+	d.StopSpinner()
+	if d.fsm.State() != StateThinking {
+		t.Fatalf("after Init: state = %v, want StateThinking", d.fsm.State())
+	}
+
+	// Thinking start
+	d.ShowEvent(&Event{
+		Type: EventThinking,
+		Data: EventData{Message: "start"},
+	})
+	d.StopSpinner()
+	if d.fsm.State() != StateThinking {
+		t.Fatalf("after Thinking start: state = %v, want StateThinking", d.fsm.State())
+	}
+
+	// Error — should transition through StateError and reset to StateIdle
+	d.ShowEvent(&Event{
+		Type: EventError,
+		Data: EventData{Message: "something went wrong"},
+	})
+	if d.fsm.State() != StateIdle {
+		t.Errorf("after Error: state = %v, want StateIdle", d.fsm.State())
+	}
+
+	// Verify error message was printed
+	output := out.String()
+	if !strings.Contains(output, "something went wrong") {
+		t.Errorf("error message not in output: %q", output)
+	}
+}
+
+func TestShowEvent_DuplicateToolDedup(t *testing.T) {
+	// Duplicate consecutive tool events are deduplicated via FSM lastTool
+	var out bytes.Buffer
+	d := NewDisplay(&out)
+
+	// Init to get FSM into Thinking
+	d.ShowEvent(&Event{
+		Type: EventInit,
+		Data: EventData{Model: "test-model"},
+	})
+	d.StopSpinner()
+
+	// First tool event
+	d.ShowEvent(&Event{
+		Type:   EventTool,
+		Tool:   "Read",
+		Detail: "config.go",
+	})
+	d.StopSpinner()
+	firstOutput := out.String()
+
+	// Same tool event again — should be deduplicated (no additional output)
+	d.ShowEvent(&Event{
+		Type:   EventTool,
+		Tool:   "Read",
+		Detail: "config.go",
+	})
+	d.StopSpinner()
+	secondOutput := out.String()
+
+	if firstOutput != secondOutput {
+		t.Errorf("duplicate tool event produced output:\nfirst:  %q\nsecond: %q", firstOutput, secondOutput)
+	}
+
+	// Verify FSM lastTool tracks the key
+	expectedKey := "Readconfig.go"
+	if d.fsm.LastTool() != expectedKey {
+		t.Errorf("fsm.LastTool() = %q, want %q", d.fsm.LastTool(), expectedKey)
+	}
+
+	// Different tool should NOT be deduplicated
+	d.ShowEvent(&Event{
+		Type:   EventTool,
+		Tool:   "Write",
+		Detail: "config.go",
+	})
+	d.StopSpinner()
+	thirdOutput := out.String()
+
+	if thirdOutput == secondOutput {
+		t.Error("different tool event was incorrectly deduplicated")
+	}
+}
+
+func TestShowEvent_SpinnerMessageUpdatesOnTransition(t *testing.T) {
+	// Spinner message updates on Thinking→ToolActivity transition
+	var out bytes.Buffer
+	d := NewDisplay(&out)
+
+	// Init → FSM goes to Thinking, spinner starts with thinking word
+	d.ShowEvent(&Event{
+		Type: EventInit,
+		Data: EventData{Model: "test-model"},
+	})
+	if d.fsm.State() != StateThinking {
+		t.Fatalf("after Init: state = %v, want StateThinking", d.fsm.State())
+	}
+	// Spinner message should be a HAL thinking word
+	thinkingMsg := d.spinMsg
+	if thinkingMsg == "" {
+		t.Fatal("spinner message should be set after Init")
+	}
+
+	// Tool event → FSM transitions to ToolActivity, spinner message updates
+	d.ShowEvent(&Event{
+		Type:   EventTool,
+		Tool:   "Read",
+		Detail: "server.go",
+	})
+	if d.fsm.State() != StateToolActivity {
+		t.Fatalf("after Tool: state = %v, want StateToolActivity", d.fsm.State())
+	}
+
+	// Spinner message should now reflect the tool
+	toolMsg := d.spinMsg
+	if toolMsg == thinkingMsg {
+		t.Errorf("spinner message did not update on Thinking→ToolActivity transition: still %q", toolMsg)
+	}
+	if !strings.Contains(toolMsg, "Read") {
+		t.Errorf("spinner message should contain tool name, got %q", toolMsg)
+	}
+
+	d.StopSpinner()
+}

--- a/internal/engine/spinner_state.go
+++ b/internal/engine/spinner_state.go
@@ -1,6 +1,9 @@
 package engine
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // SpinnerState represents the current state of the spinner finite state machine.
 type SpinnerState int
@@ -65,4 +68,68 @@ func Transition(from, to SpinnerState) error {
 		}
 	}
 	return fmt.Errorf("invalid spinner transition: %s → %s", from, to)
+}
+
+// SpinnerFSM encapsulates spinner state, message, timing, and tool dedup tracking.
+type SpinnerFSM struct {
+	state         SpinnerState
+	message       string
+	thinkingStart time.Time
+	lastTool      string
+}
+
+// NewSpinnerFSM returns a new FSM in StateIdle with zero-value fields.
+func NewSpinnerFSM() *SpinnerFSM {
+	return &SpinnerFSM{state: StateIdle}
+}
+
+// State returns the current SpinnerState.
+func (f *SpinnerFSM) State() SpinnerState {
+	return f.state
+}
+
+// GoTo transitions the FSM to the next state with the given message.
+// Returns an error if the transition is invalid.
+func (f *SpinnerFSM) GoTo(next SpinnerState, msg string) error {
+	if err := Transition(f.state, next); err != nil {
+		return err
+	}
+	f.state = next
+	f.message = msg
+	if next == StateThinking {
+		f.thinkingStart = time.Now()
+	}
+	return nil
+}
+
+// Message returns the current message string.
+func (f *SpinnerFSM) Message() string {
+	return f.message
+}
+
+// ThinkingElapsed returns the time elapsed since entering StateThinking.
+// Returns zero if not currently in StateThinking.
+func (f *SpinnerFSM) ThinkingElapsed() time.Duration {
+	if f.state == StateThinking {
+		return time.Since(f.thinkingStart)
+	}
+	return 0
+}
+
+// SetLastTool sets the last tool key for dedup tracking.
+func (f *SpinnerFSM) SetLastTool(key string) {
+	f.lastTool = key
+}
+
+// LastTool returns the last tool key.
+func (f *SpinnerFSM) LastTool() string {
+	return f.lastTool
+}
+
+// Reset sets the FSM back to StateIdle and clears all fields.
+func (f *SpinnerFSM) Reset() {
+	f.state = StateIdle
+	f.message = ""
+	f.thinkingStart = time.Time{}
+	f.lastTool = ""
 }

--- a/internal/engine/spinner_state.go
+++ b/internal/engine/spinner_state.go
@@ -1,0 +1,68 @@
+package engine
+
+import "fmt"
+
+// SpinnerState represents the current state of the spinner finite state machine.
+type SpinnerState int
+
+const (
+	StateIdle         SpinnerState = iota // No activity
+	StateThinking                         // Model is reasoning
+	StateToolActivity                     // Tool is executing
+	StateCompletion                       // Execution completed successfully
+	StateError                            // Error occurred
+)
+
+// String returns a human-readable name for the state.
+func (s SpinnerState) String() string {
+	switch s {
+	case StateIdle:
+		return "Idle"
+	case StateThinking:
+		return "Thinking"
+	case StateToolActivity:
+		return "ToolActivity"
+	case StateCompletion:
+		return "Completion"
+	case StateError:
+		return "Error"
+	default:
+		return fmt.Sprintf("Unknown(%d)", int(s))
+	}
+}
+
+// validTransitions defines the explicit allow-list of state transitions.
+var validTransitions = map[SpinnerState]map[SpinnerState]bool{
+	StateIdle: {
+		StateThinking: true,
+		StateIdle:     true,
+	},
+	StateThinking: {
+		StateToolActivity: true,
+		StateCompletion:   true,
+		StateError:        true,
+	},
+	StateToolActivity: {
+		StateThinking:     true,
+		StateToolActivity: true,
+		StateCompletion:   true,
+		StateError:        true,
+	},
+	StateCompletion: {
+		StateIdle: true,
+	},
+	StateError: {
+		StateIdle: true,
+	},
+}
+
+// Transition validates whether a state transition from → to is allowed.
+// Returns nil if the transition is valid, or an error describing the invalid transition.
+func Transition(from, to SpinnerState) error {
+	if targets, ok := validTransitions[from]; ok {
+		if targets[to] {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid spinner transition: %s → %s", from, to)
+}

--- a/internal/engine/spinner_state_test.go
+++ b/internal/engine/spinner_state_test.go
@@ -1,0 +1,273 @@
+package engine
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTransition_ValidTransitions(t *testing.T) {
+	tests := []struct {
+		name string
+		from SpinnerState
+		to   SpinnerState
+	}{
+		{"Idle→Thinking", StateIdle, StateThinking},
+		{"Idle→Idle", StateIdle, StateIdle},
+		{"Thinking→ToolActivity", StateThinking, StateToolActivity},
+		{"Thinking→Completion", StateThinking, StateCompletion},
+		{"Thinking→Error", StateThinking, StateError},
+		{"ToolActivity→Thinking", StateToolActivity, StateThinking},
+		{"ToolActivity→ToolActivity", StateToolActivity, StateToolActivity},
+		{"ToolActivity→Completion", StateToolActivity, StateCompletion},
+		{"ToolActivity→Error", StateToolActivity, StateError},
+		{"Completion→Idle", StateCompletion, StateIdle},
+		{"Error→Idle", StateError, StateIdle},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Transition(tt.from, tt.to); err != nil {
+				t.Errorf("expected valid transition %s → %s, got error: %v", tt.from, tt.to, err)
+			}
+		})
+	}
+}
+
+func TestTransition_InvalidTransitions(t *testing.T) {
+	tests := []struct {
+		name string
+		from SpinnerState
+		to   SpinnerState
+	}{
+		{"Idle→Completion", StateIdle, StateCompletion},
+		{"Idle→Error", StateIdle, StateError},
+		{"Idle→ToolActivity", StateIdle, StateToolActivity},
+		{"Completion→Thinking", StateCompletion, StateThinking},
+		{"Completion→ToolActivity", StateCompletion, StateToolActivity},
+		{"Completion→Error", StateCompletion, StateError},
+		{"Error→Thinking", StateError, StateThinking},
+		{"Error→ToolActivity", StateError, StateToolActivity},
+		{"Error→Completion", StateError, StateCompletion},
+		{"Thinking→Idle", StateThinking, StateIdle},
+		{"Thinking→Thinking", StateThinking, StateThinking},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Transition(tt.from, tt.to)
+			if err == nil {
+				t.Errorf("expected error for invalid transition %s → %s, got nil", tt.from, tt.to)
+			}
+		})
+	}
+}
+
+func TestSpinnerState_String(t *testing.T) {
+	tests := []struct {
+		state SpinnerState
+		want  string
+	}{
+		{StateIdle, "Idle"},
+		{StateThinking, "Thinking"},
+		{StateToolActivity, "ToolActivity"},
+		{StateCompletion, "Completion"},
+		{StateError, "Error"},
+		{SpinnerState(99), "Unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.want {
+				t.Errorf("SpinnerState(%d).String() = %q, want %q", int(tt.state), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewSpinnerFSM(t *testing.T) {
+	fsm := NewSpinnerFSM()
+	if fsm.State() != StateIdle {
+		t.Errorf("NewSpinnerFSM().State() = %v, want StateIdle", fsm.State())
+	}
+	if fsm.Message() != "" {
+		t.Errorf("NewSpinnerFSM().Message() = %q, want empty", fsm.Message())
+	}
+	if fsm.LastTool() != "" {
+		t.Errorf("NewSpinnerFSM().LastTool() = %q, want empty", fsm.LastTool())
+	}
+	if fsm.ThinkingElapsed() != 0 {
+		t.Errorf("NewSpinnerFSM().ThinkingElapsed() = %v, want 0", fsm.ThinkingElapsed())
+	}
+}
+
+func TestFSM_GoTo_UpdatesStateAndMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(f *SpinnerFSM)
+		next      SpinnerState
+		msg       string
+		wantState SpinnerState
+		wantMsg   string
+		wantErr   bool
+	}{
+		{
+			name:      "Idle to Thinking",
+			setup:     nil,
+			next:      StateThinking,
+			msg:       "thinking...",
+			wantState: StateThinking,
+			wantMsg:   "thinking...",
+		},
+		{
+			name:      "Thinking to ToolActivity",
+			setup:     func(f *SpinnerFSM) { f.GoTo(StateThinking, "think") },
+			next:      StateToolActivity,
+			msg:       "running tool",
+			wantState: StateToolActivity,
+			wantMsg:   "running tool",
+		},
+		{
+			name:      "Thinking to Completion",
+			setup:     func(f *SpinnerFSM) { f.GoTo(StateThinking, "think") },
+			next:      StateCompletion,
+			msg:       "done",
+			wantState: StateCompletion,
+			wantMsg:   "done",
+		},
+		{
+			name:      "Invalid: Idle to Completion",
+			setup:     nil,
+			next:      StateCompletion,
+			msg:       "done",
+			wantState: StateIdle,
+			wantMsg:   "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fsm := NewSpinnerFSM()
+			if tt.setup != nil {
+				tt.setup(fsm)
+			}
+			err := fsm.GoTo(tt.next, tt.msg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fsm.State() != tt.wantState {
+				t.Errorf("state = %v, want %v", fsm.State(), tt.wantState)
+			}
+			if fsm.Message() != tt.wantMsg {
+				t.Errorf("message = %q, want %q", fsm.Message(), tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestFSM_GoTo_ThinkingSetsThinkingStart(t *testing.T) {
+	fsm := NewSpinnerFSM()
+	before := time.Now()
+	if err := fsm.GoTo(StateThinking, "thinking"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	after := time.Now()
+
+	if fsm.thinkingStart.Before(before) || fsm.thinkingStart.After(after) {
+		t.Errorf("thinkingStart = %v, want between %v and %v", fsm.thinkingStart, before, after)
+	}
+
+	elapsed := fsm.ThinkingElapsed()
+	if elapsed <= 0 {
+		t.Errorf("ThinkingElapsed() = %v, want > 0", elapsed)
+	}
+}
+
+func TestFSM_GoTo_NonThinkingDoesNotSetThinkingStart(t *testing.T) {
+	fsm := NewSpinnerFSM()
+	fsm.GoTo(StateThinking, "think")
+	originalStart := fsm.thinkingStart
+
+	fsm.GoTo(StateToolActivity, "tool")
+	if fsm.thinkingStart != originalStart {
+		t.Errorf("thinkingStart changed on non-Thinking transition: got %v, want %v", fsm.thinkingStart, originalStart)
+	}
+}
+
+func TestFSM_ThinkingElapsed_ZeroWhenNotThinking(t *testing.T) {
+	fsm := NewSpinnerFSM()
+
+	// Idle state
+	if elapsed := fsm.ThinkingElapsed(); elapsed != 0 {
+		t.Errorf("ThinkingElapsed() in Idle = %v, want 0", elapsed)
+	}
+
+	// Move to Thinking then to ToolActivity
+	fsm.GoTo(StateThinking, "think")
+	fsm.GoTo(StateToolActivity, "tool")
+	if elapsed := fsm.ThinkingElapsed(); elapsed != 0 {
+		t.Errorf("ThinkingElapsed() in ToolActivity = %v, want 0", elapsed)
+	}
+}
+
+func TestFSM_LastTool(t *testing.T) {
+	fsm := NewSpinnerFSM()
+	if fsm.LastTool() != "" {
+		t.Errorf("initial LastTool() = %q, want empty", fsm.LastTool())
+	}
+
+	fsm.SetLastTool("Read:file.go")
+	if got := fsm.LastTool(); got != "Read:file.go" {
+		t.Errorf("LastTool() = %q, want %q", got, "Read:file.go")
+	}
+
+	fsm.SetLastTool("Write:main.go")
+	if got := fsm.LastTool(); got != "Write:main.go" {
+		t.Errorf("LastTool() = %q, want %q", got, "Write:main.go")
+	}
+}
+
+func TestFSM_Reset(t *testing.T) {
+	fsm := NewSpinnerFSM()
+	fsm.GoTo(StateThinking, "thinking hard")
+	fsm.SetLastTool("Read:file.go")
+
+	// Verify pre-conditions
+	if fsm.State() != StateThinking {
+		t.Fatalf("setup: state = %v, want StateThinking", fsm.State())
+	}
+	if fsm.Message() == "" {
+		t.Fatalf("setup: message should not be empty")
+	}
+	if fsm.LastTool() == "" {
+		t.Fatalf("setup: lastTool should not be empty")
+	}
+	if fsm.thinkingStart.IsZero() {
+		t.Fatalf("setup: thinkingStart should not be zero")
+	}
+
+	// Reset
+	fsm.Reset()
+
+	if fsm.State() != StateIdle {
+		t.Errorf("after Reset(), State() = %v, want StateIdle", fsm.State())
+	}
+	if fsm.Message() != "" {
+		t.Errorf("after Reset(), Message() = %q, want empty", fsm.Message())
+	}
+	if fsm.LastTool() != "" {
+		t.Errorf("after Reset(), LastTool() = %q, want empty", fsm.LastTool())
+	}
+	if !fsm.thinkingStart.IsZero() {
+		t.Errorf("after Reset(), thinkingStart = %v, want zero", fsm.thinkingStart)
+	}
+	if fsm.ThinkingElapsed() != 0 {
+		t.Errorf("after Reset(), ThinkingElapsed() = %v, want 0", fsm.ThinkingElapsed())
+	}
+}


### PR DESCRIPTION
## Summary

Refactor the spinner and progress rendering into an explicit finite state machine with well-defined transitions (idle, thinking, tool-activity, completion, error). Back the state machine with unit tests and golden-output tests to prevent the recurring regressions seen in the hotfix cycle.

### Rationale

Back-to-back hotfixes (507f20e, 1367de6) for spinner regressions indicate the current ad-hoc lifecycle handling is fragile and the highest source of recent bugs. A state machine consolidation directly addresses the most active tech debt, prevents future regressions, and improves developer confidence when touching UI code. It is well-scoped, high-impact, and not yet started.

### Acceptance Criteria

- Spinner/progress rendering is driven by a single state machine type with explicit named states (e.g. Idle, Thinking, ToolActivity, Completion, Error)
- All state transitions are validated—invalid transitions return an error or are logged
- Existing spinner behavior is preserved: HAL-eye branding, continuous spinning across loading-to-tool transitions, completed thinking lines rendered as quoted output
- Unit tests cover every valid state transition and at least two invalid transitions
- Golden-output tests capture expected terminal output for a full thinking→tool-activity→completion lifecycle
- No spinner regressions: existing integration/CLI tests continue to pass
- The old ad-hoc spinner control code in the display/loop path is removed or replaced by state machine calls

### Task Status

- Completed: 10/10

---

🤖 Generated by [hal](https://github.com/jywlabs/hal) compound pipeline
