### PR TITLE
feat(ci): harden auth, push, and merge safety workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,3 +240,9 @@
 - Keep CI aggregation in `internal/ci/status.go` gap-free by fetching **both** check-runs and commit statuses with explicit pagination loops (`per_page=100`, continue until page size drops below limit).
 - Lock dedupe keys to `check:<name>` for check-runs and `status:<context>` for commit statuses, and build aggregation through the shared `getStatusWithDeps` path so tests can inject paged fixtures deterministically.
 - Preserve safety precedence exactly as pending > failing > passing, and treat zero-context repositories as `StatusPending` with `ChecksDiscovered=false` (never passing by default).
+
+## Patterns from hal/ci-wait-no-checks-determinism (2026-03-29)
+
+- Keep CI wait defaults centralized in `internal/ci/status.go` (`PollInterval=30s`, `Timeout=30m`, `NoChecksGrace=90s`) via a single defaults helper so command wiring and core behavior stay in sync.
+- Implement wait-loop orchestration behind injectable deps (`waitForChecksWithDeps` with `getStatus`/`newTicker`/`after`) to keep completed/timeout/no-checks paths deterministic in unit tests without real sleeps.
+- When no-checks grace expires, re-fetch status once before returning `WaitTerminalReasonNoChecksDetected` so checks that appear near the grace boundary are not misclassified.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,3 +271,9 @@
 - Stage 6A `runPRStep` in `internal/compound/pipeline.go` delegates push + PR creation to `internal/ci.PushAndCreatePR`, but still generates title/body in compound so existing PR content stays stable.
 - Keep `--skip-pr` and `--dry-run` branches as early returns before CI delegation to preserve legacy StepPR behavior and avoid remote side effects.
 - `Pipeline` now uses an injectable `pushAndCreatePR` function field; use this seam in unit tests (`internal/compound/pipeline_pr_test.go`) to assert StepPR behavior without invoking real git/gh commands.
+
+## Patterns from hal/ci-command-push-wiring (2026-03-29)
+
+- Keep CI command-layer orchestration behind `run<Cmd>WithDeps` helpers (for example `runCIPushWithDeps`) so tests can stub side-effecting core operations and git lookups deterministically.
+- In `--json` mode, emit pure JSON only (no human-readable lines); lock this with tests that assert valid object-only output.
+- Implement `--dry-run` at the command layer by bypassing core side effects (`PushAndCreatePR`) and returning preview data only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,9 @@
 - Centralize CI repo detection in `internal/ci/remote.go` via `ResolveGitHubRepository` (reads `git remote get-url origin`) and `ParseGitHubRepository` (URL parsing) so all CI flows share one remote-validation path.
 - Support the common GitHub remote formats (`git@github.com:<owner>/<repo>.git`, `ssh://git@github.com/<owner>/<repo>.git`, and HTTPS variants) and reject non-`github.com` remotes with actionable guidance.
 - Keep origin-remote failures machine-testable with sentinel errors (`ErrMissingOriginRemote`, `ErrNonGitHubOriginRemote`) while wrapping returned errors with user-facing remediation text.
+
+## Patterns from hal/ci-gap-free-status-aggregation (2026-03-29)
+
+- Keep CI aggregation in `internal/ci/status.go` gap-free by fetching **both** check-runs and commit statuses with explicit pagination loops (`per_page=100`, continue until page size drops below limit).
+- Lock dedupe keys to `check:<name>` for check-runs and `status:<context>` for commit statuses, and build aggregation through the shared `getStatusWithDeps` path so tests can inject paged fixtures deterministically.
+- Preserve safety precedence exactly as pending > failing > passing, and treat zero-context repositories as `StatusPending` with `ChecksDiscovered=false` (never passing by default).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,3 +222,9 @@
 - Keep CI machine-output structs centralized in `internal/ci/types.go` (push/status/fix/merge) so command handlers and pipeline integrations share one schema source of truth.
 - Lock CI contract stability with both explicit `json` tags on every exported field and tests that assert required JSON keys plus marshal/unmarshal round-trip behavior (see `internal/ci/types_test.go`).
 - Keep contract/version and wait-terminal-reason string values as package constants to avoid drift across commands, docs, and tests.
+
+## Patterns from hal/ci-auth-client-selection (2026-03-29)
+
+- Keep CI auth/client selection deterministic in `internal/ci/auth.go`: env token (`GITHUB_TOKEN` then `GH_TOKEN`) selects the API path, otherwise fall back only to authenticated `gh` CLI.
+- If an env token is present but fails validation, return `ErrInvalidEnvToken` and do **not** attempt `gh` fallback; this guard is locked with tests in `internal/ci/auth_test.go`.
+- Keep user-facing auth guidance as exact sentinel errors (`ErrInvalidEnvToken`, `ErrNoGitHubAuth`) so command output remains stable and testable across CI command implementations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,3 +216,9 @@
 
 - Keep sandbox lifecycle status values centralized in `internal/sandbox/types.go` constants (`StatusRunning`, `StatusStopped`, `StatusUnknown`) instead of duplicating string literals across commands/providers.
 - `SandboxState` JSON tags are camelCase with selective `omitempty`; preserve this contract with focused marshal/unmarshal key assertions in `internal/sandbox/types_test.go` when adding or renaming fields.
+
+## Patterns from hal/ci-shared-types-contracts (2026-03-29)
+
+- Keep CI machine-output structs centralized in `internal/ci/types.go` (push/status/fix/merge) so command handlers and pipeline integrations share one schema source of truth.
+- Lock CI contract stability with both explicit `json` tags on every exported field and tests that assert required JSON keys plus marshal/unmarshal round-trip behavior (see `internal/ci/types_test.go`).
+- Keep contract/version and wait-terminal-reason string values as package constants to avoid drift across commands, docs, and tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@
 - For doctor checks that depend on GitHub context (`github_auth`), treat non-git directories, missing `origin`, and non-GitHub remotes as `status=skip` + `applicability=not_applicable`; only emit a warning with remediation `gh auth login` (`Safe=false`) when a valid GitHub remote lacks authentication.
 - The Codex linker uses `codexHome()` which prefers `$HOME` over `os.UserHomeDir()` so tests can isolate global link operations via `t.Setenv("HOME", tmpDir)`. All init tests must use `t.Setenv("HOME", dir)`.
 - Tests that walk the shared global `Root()` Cobra command tree must NOT use `t.Parallel()` (race condition on Cobra command state).
-- The `hal continue` command is the single entry point for "what to do next" — it combines status + doctor and shows doctor issues as blockers before workflow actions.
+- The `hal continue` command is the single entry point for "what to do next" — it combines status + doctor, blocks readiness only on doctor failures, and keeps warning-only doctor output advisory.
 - The `hal repair` command auto-applies safe remediations from doctor results. To add a new remediation, add `Remediation: &Remediation{Command: "...", Safe: true}` to the check and register the command in `executeRepairCommand`.
 - The `hal links` command group (status/refresh/clean) manages engine skill links separately from `hal init`. Use `hal links refresh codex` for targeted Codex link updates.
 - Doctor checks for link health should suggest `hal links refresh` or `hal links clean` instead of `hal init` — more targeted remediation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,3 +228,9 @@
 - Keep CI auth/client selection deterministic in `internal/ci/auth.go`: env token (`GITHUB_TOKEN` then `GH_TOKEN`) selects the API path, otherwise fall back only to authenticated `gh` CLI.
 - If an env token is present but fails validation, return `ErrInvalidEnvToken` and do **not** attempt `gh` fallback; this guard is locked with tests in `internal/ci/auth_test.go`.
 - Keep user-facing auth guidance as exact sentinel errors (`ErrInvalidEnvToken`, `ErrNoGitHubAuth`) so command output remains stable and testable across CI command implementations.
+
+## Patterns from hal/ci-origin-remote-validation (2026-03-29)
+
+- Centralize CI repo detection in `internal/ci/remote.go` via `ResolveGitHubRepository` (reads `git remote get-url origin`) and `ParseGitHubRepository` (URL parsing) so all CI flows share one remote-validation path.
+- Support the common GitHub remote formats (`git@github.com:<owner>/<repo>.git`, `ssh://git@github.com/<owner>/<repo>.git`, and HTTPS variants) and reject non-`github.com` remotes with actionable guidance.
+- Keep origin-remote failures machine-testable with sentinel errors (`ErrMissingOriginRemote`, `ErrNonGitHubOriginRemote`) while wrapping returned errors with user-facing remediation text.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@
 - Keep user-facing command examples in Cobra `Example` fields (not just prose in `Long`) and lock required metadata (`Use`, `Short`, `Long`, `Example`) with focused table-driven command tests.
 - Add a global recursive metadata contract test (`cmd/docs_metadata_test.go`) that walks all in-scope commands from `cmd.Root()` and reports command path + missing fields for fast triage.
 - For family-level metadata contracts, recurse through in-scope descendants under each top-level command family (for example `archive`) and assert each command's `Example` includes its command path.
+- When adding a new required top-level command family, update both core command metadata coverage (`TestCoreCommandsHaveCompleteMetadata`) and family-level metadata coverage so the family is enforced in both tables.
+- Keep focused family tests (for example `cmd/ci_test.go`) asserting required `Long` help phrases plus key `Example` lines so help text regressions are caught alongside metadata-field checks.
 - When a command family may not exist in every branch (for example `sandbox`), make that family optional in focused tests while keeping required families strict.
 - Keep a dedicated README `CLI Reference` section linking `docs/cli/` and `docs/cli/hal.md` so generated command docs are easy to discover.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,7 @@
 - New machine-readable surfaces (`--json` flag) must ship with: contract doc in `docs/contracts/`, example JSON payloads, field-locking tests in `cmd/machine_contracts_test.go`, and doc-code sync tests in `cmd/contracts_doc_test.go`.
 - Workflow state classification lives in `internal/status` — a pure filesystem package with no engine or config dependencies. The `cmd/status.go` wrapper adds engine from config.
 - Health/readiness checks live in `internal/doctor` — each check has `scope` (repo/engine_local/engine_global/migration) and `applicability` (required/optional/not_applicable) fields. The check order is locked by `TestRun_CheckCount`.
+- For doctor checks that depend on GitHub context (`github_auth`), treat non-git directories, missing `origin`, and non-GitHub remotes as `status=skip` + `applicability=not_applicable`; only emit a warning with remediation `gh auth login` (`Safe=false`) when a valid GitHub remote lacks authentication.
 - The Codex linker uses `codexHome()` which prefers `$HOME` over `os.UserHomeDir()` so tests can isolate global link operations via `t.Setenv("HOME", tmpDir)`. All init tests must use `t.Setenv("HOME", dir)`.
 - Tests that walk the shared global `Root()` Cobra command tree must NOT use `t.Parallel()` (race condition on Cobra command state).
 - The `hal continue` command is the single entry point for "what to do next" — it combines status + doctor and shows doctor issues as blockers before workflow actions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,3 +283,9 @@
 - Keep `hal ci status` command-layer orchestration behind `runCIStatusWithDeps` with injectable `getStatus` / `waitForChecks` deps so tests can validate wait and non-wait paths without invoking real git/gh commands.
 - Wire `--wait`, `--timeout`, `--poll-interval`, and `--no-checks-grace` directly into `ci.WaitOptions`; pass zero-value durations through so `internal/ci/status.go` remains the single source of wait defaults.
 - In `--json` mode, emit only the marshaled `ci.StatusResult`; this preserves machine-readable wait terminal reasons (including `no_checks_detected`) without human-text drift.
+
+## Patterns from hal/ci-fix-command-wiring (2026-03-29)
+
+- Keep `hal ci fix` command-layer orchestration behind `runCIFixWithDeps` with injectable `newEngine`, `getStatus`, `waitForChecks`, and `fixWithEngine` deps so retry behavior is deterministic in tests without real engine/git/gh calls.
+- Keep retries in the command layer only: call single-attempt `ci.FixWithEngine` per attempt, wait for fresh CI status between attempts, and stop with actionable errors when status remains non-passing after `--max-attempts`.
+- In `--json` mode, emit only the marshaled `ci.FixResult`; validate `--max-attempts > 0` and resolve engine selection in `runCIFix` before invoking retry orchestration.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,3 +265,9 @@
 - Keep merge orchestration behind `mergePRWithDeps` in `internal/ci/merge.go` so strategy/status/head-drift/delete-branch paths can be tested deterministically without real GitHub calls.
 - Validate merge safety in this order: strategy allowlist (`squash|merge|rebase`), aggregated status guard (passing required unless `AllowNoChecks` with zero contexts), then PR head drift check (`status.SHA` vs current PR head SHA) before issuing merge side effects.
 - Remote branch cleanup after merge must treat 404 as non-fatal (`ErrRemoteBranchNotFound`) and surface other deletion failures as `DeleteWarning` on `MergeResult` instead of failing an otherwise successful merge.
+
+## Patterns from hal/compound-steppr-ci-delegation (2026-03-29)
+
+- Stage 6A `runPRStep` in `internal/compound/pipeline.go` delegates push + PR creation to `internal/ci.PushAndCreatePR`, but still generates title/body in compound so existing PR content stays stable.
+- Keep `--skip-pr` and `--dry-run` branches as early returns before CI delegation to preserve legacy StepPR behavior and avoid remote side effects.
+- `Pipeline` now uses an injectable `pushAndCreatePR` function field; use this seam in unit tests (`internal/compound/pipeline_pr_test.go`) to assert StepPR behavior without invoking real git/gh commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,9 @@
 - Keep CI fix core behavior in `internal/ci/fix.go` as a **single attempt** (`FixWithEngine`), with command-layer retry loops built on top of it.
 - Enforce fix safety guards before running the engine: aggregated status must be `failing`, engine must be non-nil, and the working tree must be clean by default (including untracked files via `git status --porcelain --untracked-files=all`).
 - After engine execution, require real file changes before staging/commit/push; if no files changed, return `ErrFixNoChanges` and create no commit.
+
+## Patterns from hal/ci-merge-safety-guards (2026-03-29)
+
+- Keep merge orchestration behind `mergePRWithDeps` in `internal/ci/merge.go` so strategy/status/head-drift/delete-branch paths can be tested deterministically without real GitHub calls.
+- Validate merge safety in this order: strategy allowlist (`squash|merge|rebase`), aggregated status guard (passing required unless `AllowNoChecks` with zero contexts), then PR head drift check (`status.SHA` vs current PR head SHA) before issuing merge side effects.
+- Remote branch cleanup after merge must treat 404 as non-fatal (`ErrRemoteBranchNotFound`) and surface other deletion failures as `DeleteWarning` on `MergeResult` instead of failing an otherwise successful merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,3 +277,9 @@
 - Keep CI command-layer orchestration behind `run<Cmd>WithDeps` helpers (for example `runCIPushWithDeps`) so tests can stub side-effecting core operations and git lookups deterministically.
 - In `--json` mode, emit pure JSON only (no human-readable lines); lock this with tests that assert valid object-only output.
 - Implement `--dry-run` at the command layer by bypassing core side effects (`PushAndCreatePR`) and returning preview data only.
+
+## Patterns from hal/ci-status-command-wiring (2026-03-29)
+
+- Keep `hal ci status` command-layer orchestration behind `runCIStatusWithDeps` with injectable `getStatus` / `waitForChecks` deps so tests can validate wait and non-wait paths without invoking real git/gh commands.
+- Wire `--wait`, `--timeout`, `--poll-interval`, and `--no-checks-grace` directly into `ci.WaitOptions`; pass zero-value durations through so `internal/ci/status.go` remains the single source of wait defaults.
+- In `--json` mode, emit only the marshaled `ci.StatusResult`; this preserves machine-readable wait terminal reasons (including `no_checks_detected`) without human-text drift.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,8 @@
 - Keep `hal ci merge` command-layer orchestration behind `runCIMergeWithDeps` with injectable `mergePR` and `currentBranch` deps so tests can verify flag wiring and dry-run behavior without real git/gh side effects.
 - Implement merge `--dry-run` at the command layer by bypassing `ci.MergePR` and returning a preview `ci.MergeResult`; this guarantees no merge/delete side effects in preview mode.
 - In `--json` mode, emit only the marshaled `ci.MergeResult`; lock this with tests to prevent human-readable output from leaking into machine contracts.
+
+## Patterns from hal/ci-doc-discoverability (2026-03-29)
+
+- When adding or changing `hal ci` command surfaces, update the README command tables and machine-contract links together so human docs stay aligned with generated and machine-readable docs.
+- Regenerate CLI docs with `make docs-cli` and verify with `make docs-check`; commit both new command pages (`docs/cli/hal_ci*.md`) and any updated parent pages (for example `docs/cli/hal.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,3 +252,9 @@
 - Keep CI push/PR orchestration behind `pushAndCreatePRWithDeps` in `internal/ci/push.go` so tests can inject git/GitHub behavior without spawning real CLIs.
 - Reuse existing pull requests by querying `head=<owner>:<branch>` before creation; this prevents duplicate PRs for the same branch.
 - Model draft preference as pointer-based options (`PushOptions.Draft *bool`) so default behavior (`nil => draft=true`) stays distinct from an explicit non-draft request (`false`).
+
+## Patterns from hal/ci-fix-single-attempt-safety (2026-03-29)
+
+- Keep CI fix core behavior in `internal/ci/fix.go` as a **single attempt** (`FixWithEngine`), with command-layer retry loops built on top of it.
+- Enforce fix safety guards before running the engine: aggregated status must be `failing`, engine must be non-nil, and the working tree must be clean by default (including untracked files via `git status --porcelain --untracked-files=all`).
+- After engine execution, require real file changes before staging/commit/push; if no files changed, return `ErrFixNoChanges` and create no commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,3 +289,9 @@
 - Keep `hal ci fix` command-layer orchestration behind `runCIFixWithDeps` with injectable `newEngine`, `getStatus`, `waitForChecks`, and `fixWithEngine` deps so retry behavior is deterministic in tests without real engine/git/gh calls.
 - Keep retries in the command layer only: call single-attempt `ci.FixWithEngine` per attempt, wait for fresh CI status between attempts, and stop with actionable errors when status remains non-passing after `--max-attempts`.
 - In `--json` mode, emit only the marshaled `ci.FixResult`; validate `--max-attempts > 0` and resolve engine selection in `runCIFix` before invoking retry orchestration.
+
+## Patterns from hal/ci-merge-command-wiring (2026-03-29)
+
+- Keep `hal ci merge` command-layer orchestration behind `runCIMergeWithDeps` with injectable `mergePR` and `currentBranch` deps so tests can verify flag wiring and dry-run behavior without real git/gh side effects.
+- Implement merge `--dry-run` at the command layer by bypassing `ci.MergePR` and returning a preview `ci.MergeResult`; this guarantees no merge/delete side effects in preview mode.
+- In `--json` mode, emit only the marshaled `ci.MergeResult`; lock this with tests to prevent human-readable output from leaking into machine contracts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,3 +246,9 @@
 - Keep CI wait defaults centralized in `internal/ci/status.go` (`PollInterval=30s`, `Timeout=30m`, `NoChecksGrace=90s`) via a single defaults helper so command wiring and core behavior stay in sync.
 - Implement wait-loop orchestration behind injectable deps (`waitForChecksWithDeps` with `getStatus`/`newTicker`/`after`) to keep completed/timeout/no-checks paths deterministic in unit tests without real sleeps.
 - When no-checks grace expires, re-fetch status once before returning `WaitTerminalReasonNoChecksDetected` so checks that appear near the grace boundary are not misclassified.
+
+## Patterns from hal/ci-push-pr-core (2026-03-29)
+
+- Keep CI push/PR orchestration behind `pushAndCreatePRWithDeps` in `internal/ci/push.go` so tests can inject git/GitHub behavior without spawning real CLIs.
+- Reuse existing pull requests by querying `head=<owner>:<branch>` before creation; this prevents duplicate PRs for the same branch.
+- Model draft preference as pointer-based options (`PushOptions.Draft *bool`) so default behavior (`nil => draft=true`) stays distinct from an explicit non-draft request (`false`).

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Stable JSON contracts for agent integration:
 - [`docs/contracts/status-v1.md`](docs/contracts/status-v1.md) — Workflow state machine
 - [`docs/contracts/doctor-v1.md`](docs/contracts/doctor-v1.md) — Health/readiness checks
 - [`docs/contracts/continue-v1.md`](docs/contracts/continue-v1.md) — What to do next
+- [`docs/contracts/ci-push-v1.md`](docs/contracts/ci-push-v1.md) — `hal ci push` output contract
+- [`docs/contracts/ci-status-v1.md`](docs/contracts/ci-status-v1.md) — `hal ci status` output contract
+- [`docs/contracts/ci-fix-v1.md`](docs/contracts/ci-fix-v1.md) — `hal ci fix` output contract
+- [`docs/contracts/ci-merge-v1.md`](docs/contracts/ci-merge-v1.md) — `hal ci merge` output contract
 
 ## Commands
 
@@ -144,6 +148,15 @@ Stable JSON contracts for agent integration:
 | `hal doctor [--json]` | Check environment health (engine-aware, detects broken links) |
 | `hal continue [--json]` | Show what to do next (combines status + doctor) |
 | `hal repair [--dry-run] [--json]` | Auto-fix safe issues detected by doctor |
+
+### CI Workflow
+
+| Command | Description |
+|---------|-------------|
+| `hal ci push [--dry-run] [--json]` | Push current branch and create or reuse an open pull request |
+| `hal ci status [--wait] [--json]` | Show aggregated CI status, with deterministic wait controls |
+| `hal ci fix [--max-attempts N] [-e engine] [--json]` | Attempt CI fixes with command-layer retries |
+| `hal ci merge [--strategy <squash\|merge\|rebase>] [--delete-branch] [--allow-no-checks] [--dry-run] [--json]` | Merge PR with explicit safety controls |
 
 ### Link Management
 

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	ci "github.com/jywlabs/hal/internal/ci"
 	"github.com/spf13/cobra"
@@ -17,6 +18,12 @@ import (
 var (
 	ciPushDryRunFlag bool
 	ciPushJSONFlag   bool
+
+	ciStatusWaitFlag          bool
+	ciStatusTimeoutFlag       time.Duration
+	ciStatusPollIntervalFlag  time.Duration
+	ciStatusNoChecksGraceFlag time.Duration
+	ciStatusJSONFlag          bool
 )
 
 var ciCmd = &cobra.Command{
@@ -50,11 +57,33 @@ Use --json for machine-readable output.`,
 	RunE: runCIPush,
 }
 
+var ciStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show aggregated CI status for the current branch",
+	Args:  noArgsValidation(),
+	Long: `Show aggregated CI status for the current branch.
+
+By default, this command returns the latest aggregated status immediately.
+Use --wait to poll until checks complete, timeout, or no checks are detected.
+Use --json for machine-readable output.`,
+	Example: `  hal ci status
+  hal ci status --wait
+  hal ci status --wait --json`,
+	RunE: runCIStatus,
+}
+
 func init() {
 	ciPushCmd.Flags().BoolVar(&ciPushDryRunFlag, "dry-run", false, "Preview push/PR behavior without remote side effects")
 	ciPushCmd.Flags().BoolVar(&ciPushJSONFlag, "json", false, "Output machine-readable JSON result")
 
+	ciStatusCmd.Flags().BoolVar(&ciStatusWaitFlag, "wait", false, "Wait for checks to complete, timeout, or no-check detection")
+	ciStatusCmd.Flags().DurationVar(&ciStatusTimeoutFlag, "timeout", 0, "Wait timeout override (default: internal ci wait timeout)")
+	ciStatusCmd.Flags().DurationVar(&ciStatusPollIntervalFlag, "poll-interval", 0, "Polling interval override while waiting (default: internal ci poll interval)")
+	ciStatusCmd.Flags().DurationVar(&ciStatusNoChecksGraceFlag, "no-checks-grace", 0, "No-checks grace override before returning no_checks_detected")
+	ciStatusCmd.Flags().BoolVar(&ciStatusJSONFlag, "json", false, "Output machine-readable JSON result")
+
 	ciCmd.AddCommand(ciPushCmd)
+	ciCmd.AddCommand(ciStatusCmd)
 	rootCmd.AddCommand(ciCmd)
 }
 
@@ -71,6 +100,24 @@ var defaultCIPushDeps = ciPushDeps{
 type ciPushRunOptions struct {
 	DryRun bool
 	JSON   bool
+}
+
+type ciStatusDeps struct {
+	getStatus     func(context.Context) (ci.StatusResult, error)
+	waitForChecks func(context.Context, ci.WaitOptions) (ci.StatusResult, error)
+}
+
+var defaultCIStatusDeps = ciStatusDeps{
+	getStatus:     ci.GetStatus,
+	waitForChecks: ci.WaitForChecks,
+}
+
+type ciStatusRunOptions struct {
+	Wait          bool
+	Timeout       time.Duration
+	PollInterval  time.Duration
+	NoChecksGrace time.Duration
+	JSON          bool
 }
 
 func runCIPush(cmd *cobra.Command, args []string) error {
@@ -175,6 +222,118 @@ func runCIPushWithDeps(ctx context.Context, opts ciPushRunOptions, out io.Writer
 		label = "Pull request (existing)"
 	}
 	fmt.Fprintf(out, "%s: %s\n", label, result.PullRequest.URL)
+	return nil
+}
+
+func runCIStatus(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		ctx = cmd.Context()
+	}
+
+	out := io.Writer(os.Stdout)
+	opts := ciStatusRunOptions{
+		Wait:          ciStatusWaitFlag,
+		Timeout:       ciStatusTimeoutFlag,
+		PollInterval:  ciStatusPollIntervalFlag,
+		NoChecksGrace: ciStatusNoChecksGraceFlag,
+		JSON:          ciStatusJSONFlag,
+	}
+
+	if cmd != nil {
+		out = cmd.OutOrStdout()
+		if flags := cmd.Flags(); flags != nil {
+			if flags.Lookup("wait") != nil {
+				v, err := flags.GetBool("wait")
+				if err != nil {
+					return err
+				}
+				opts.Wait = v
+			}
+			if flags.Lookup("timeout") != nil {
+				v, err := flags.GetDuration("timeout")
+				if err != nil {
+					return err
+				}
+				opts.Timeout = v
+			}
+			if flags.Lookup("poll-interval") != nil {
+				v, err := flags.GetDuration("poll-interval")
+				if err != nil {
+					return err
+				}
+				opts.PollInterval = v
+			}
+			if flags.Lookup("no-checks-grace") != nil {
+				v, err := flags.GetDuration("no-checks-grace")
+				if err != nil {
+					return err
+				}
+				opts.NoChecksGrace = v
+			}
+			if flags.Lookup("json") != nil {
+				v, err := flags.GetBool("json")
+				if err != nil {
+					return err
+				}
+				opts.JSON = v
+			}
+		}
+	}
+
+	return runCIStatusWithDeps(ctx, opts, out, defaultCIStatusDeps)
+}
+
+func runCIStatusWithDeps(ctx context.Context, opts ciStatusRunOptions, out io.Writer, deps ciStatusDeps) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+	if deps.getStatus == nil {
+		deps.getStatus = defaultCIStatusDeps.getStatus
+	}
+	if deps.waitForChecks == nil {
+		deps.waitForChecks = defaultCIStatusDeps.waitForChecks
+	}
+
+	var (
+		result ci.StatusResult
+		err    error
+	)
+
+	if opts.Wait {
+		result, err = deps.waitForChecks(ctx, ci.WaitOptions{
+			PollInterval:  opts.PollInterval,
+			Timeout:       opts.Timeout,
+			NoChecksGrace: opts.NoChecksGrace,
+		})
+	} else {
+		result, err = deps.getStatus(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	if opts.JSON {
+		data, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal ci status result: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	if opts.Wait && strings.TrimSpace(result.WaitTerminalReason) != "" {
+		fmt.Fprintf(out, "Wait terminal reason: %s\n", result.WaitTerminalReason)
+	}
+	if strings.TrimSpace(result.Summary) != "" {
+		fmt.Fprintln(out, result.Summary)
+		return nil
+	}
+
+	fmt.Fprintf(out, "status=%s\n", result.Status)
 	return nil
 }
 

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	ci "github.com/jywlabs/hal/internal/ci"
+	"github.com/jywlabs/hal/internal/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,10 @@ var (
 	ciStatusPollIntervalFlag  time.Duration
 	ciStatusNoChecksGraceFlag time.Duration
 	ciStatusJSONFlag          bool
+
+	ciFixMaxAttemptsFlag int
+	ciFixEngineFlag      string
+	ciFixJSONFlag        bool
 )
 
 var ciCmd = &cobra.Command{
@@ -72,6 +77,22 @@ Use --json for machine-readable output.`,
 	RunE: runCIStatus,
 }
 
+var ciFixCmd = &cobra.Command{
+	Use:   "fix",
+	Short: "Auto-fix failing CI checks using an engine",
+	Args:  noArgsValidation(),
+	Long: `Apply focused CI fixes for failing checks using the configured engine.
+
+The command retries up to --max-attempts. Each attempt uses the shared
+single-attempt CI fix core operation and waits for fresh CI status before
+continuing. Use --json for machine-readable output.`,
+	Example: `  hal ci fix
+  hal ci fix --max-attempts 3
+  hal ci fix -e claude
+  hal ci fix --json`,
+	RunE: runCIFix,
+}
+
 func init() {
 	ciPushCmd.Flags().BoolVar(&ciPushDryRunFlag, "dry-run", false, "Preview push/PR behavior without remote side effects")
 	ciPushCmd.Flags().BoolVar(&ciPushJSONFlag, "json", false, "Output machine-readable JSON result")
@@ -82,8 +103,13 @@ func init() {
 	ciStatusCmd.Flags().DurationVar(&ciStatusNoChecksGraceFlag, "no-checks-grace", 0, "No-checks grace override before returning no_checks_detected")
 	ciStatusCmd.Flags().BoolVar(&ciStatusJSONFlag, "json", false, "Output machine-readable JSON result")
 
+	ciFixCmd.Flags().IntVar(&ciFixMaxAttemptsFlag, "max-attempts", 3, "Max fix attempts before stopping")
+	ciFixCmd.Flags().StringVarP(&ciFixEngineFlag, "engine", "e", "codex", "Engine to use (claude, codex, pi)")
+	ciFixCmd.Flags().BoolVar(&ciFixJSONFlag, "json", false, "Output machine-readable JSON result")
+
 	ciCmd.AddCommand(ciPushCmd)
 	ciCmd.AddCommand(ciStatusCmd)
+	ciCmd.AddCommand(ciFixCmd)
 	rootCmd.AddCommand(ciCmd)
 }
 
@@ -118,6 +144,26 @@ type ciStatusRunOptions struct {
 	PollInterval  time.Duration
 	NoChecksGrace time.Duration
 	JSON          bool
+}
+
+type ciFixDeps struct {
+	newEngine     func(string) (engine.Engine, error)
+	getStatus     func(context.Context) (ci.StatusResult, error)
+	waitForChecks func(context.Context, ci.WaitOptions) (ci.StatusResult, error)
+	fixWithEngine func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error)
+}
+
+var defaultCIFixDeps = ciFixDeps{
+	newEngine:     newEngine,
+	getStatus:     ci.GetStatus,
+	waitForChecks: ci.WaitForChecks,
+	fixWithEngine: ci.FixWithEngine,
+}
+
+type ciFixRunOptions struct {
+	MaxAttempts int
+	Engine      string
+	JSON        bool
 }
 
 func runCIPush(cmd *cobra.Command, args []string) error {
@@ -334,6 +380,174 @@ func runCIStatusWithDeps(ctx context.Context, opts ciStatusRunOptions, out io.Wr
 	}
 
 	fmt.Fprintf(out, "status=%s\n", result.Status)
+	return nil
+}
+
+func runCIFix(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		ctx = cmd.Context()
+	}
+
+	out := io.Writer(os.Stdout)
+	opts := ciFixRunOptions{
+		MaxAttempts: ciFixMaxAttemptsFlag,
+		Engine:      ciFixEngineFlag,
+		JSON:        ciFixJSONFlag,
+	}
+
+	if cmd != nil {
+		out = cmd.OutOrStdout()
+		if flags := cmd.Flags(); flags != nil {
+			if flags.Lookup("max-attempts") != nil {
+				v, err := flags.GetInt("max-attempts")
+				if err != nil {
+					return err
+				}
+				opts.MaxAttempts = v
+			}
+			if flags.Lookup("engine") != nil {
+				v, err := flags.GetString("engine")
+				if err != nil {
+					return err
+				}
+				opts.Engine = v
+			}
+			if flags.Lookup("json") != nil {
+				v, err := flags.GetBool("json")
+				if err != nil {
+					return err
+				}
+				opts.JSON = v
+			}
+		}
+	}
+
+	if opts.MaxAttempts <= 0 {
+		err := fmt.Errorf("--max-attempts must be greater than 0")
+		if cmd != nil {
+			return exitWithCode(cmd, ExitCodeValidation, err)
+		}
+		return err
+	}
+
+	resolvedEngine, err := resolveEngine(cmd, "engine", opts.Engine, ".")
+	if err != nil {
+		if cmd != nil {
+			return exitWithCode(cmd, ExitCodeValidation, err)
+		}
+		return err
+	}
+	opts.Engine = resolvedEngine
+
+	return runCIFixWithDeps(ctx, opts, out, defaultCIFixDeps)
+}
+
+func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, deps ciFixDeps) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+	if opts.MaxAttempts <= 0 {
+		return fmt.Errorf("--max-attempts must be greater than 0")
+	}
+
+	if deps.newEngine == nil {
+		deps.newEngine = defaultCIFixDeps.newEngine
+	}
+	if deps.getStatus == nil {
+		deps.getStatus = defaultCIFixDeps.getStatus
+	}
+	if deps.waitForChecks == nil {
+		deps.waitForChecks = defaultCIFixDeps.waitForChecks
+	}
+	if deps.fixWithEngine == nil {
+		deps.fixWithEngine = defaultCIFixDeps.fixWithEngine
+	}
+
+	var (
+		eng      engine.Engine
+		attempts int
+	)
+
+	for attempts < opts.MaxAttempts {
+		status, err := deps.getStatus(ctx)
+		if err != nil {
+			return err
+		}
+
+		if status.Status != ci.StatusFailing {
+			result := ci.FixResult{
+				ContractVersion: ci.FixContractVersion,
+				Attempt:         attempts,
+				MaxAttempts:     opts.MaxAttempts,
+				Applied:         false,
+				Branch:          status.Branch,
+				Pushed:          false,
+				Summary:         fmt.Sprintf("ci status is %s; no fix attempt needed", status.Status),
+			}
+			return writeCIFixResult(out, opts.JSON, result)
+		}
+
+		if eng == nil {
+			created, err := deps.newEngine(opts.Engine)
+			if err != nil {
+				return fmt.Errorf("failed to create engine: %w", err)
+			}
+			eng = created
+		}
+
+		attempt := attempts + 1
+		fixResult, err := deps.fixWithEngine(ctx, status, ci.FixOptions{
+			Engine:      eng,
+			Attempt:     attempt,
+			MaxAttempts: opts.MaxAttempts,
+		})
+		if err != nil {
+			return err
+		}
+
+		verified, err := deps.waitForChecks(ctx, ci.WaitOptions{})
+		if err != nil {
+			return err
+		}
+		if verified.Status == ci.StatusPassing {
+			return writeCIFixResult(out, opts.JSON, fixResult)
+		}
+		if verified.Status != ci.StatusFailing {
+			return fmt.Errorf("ci status is %s after attempt %d; run 'hal ci status --wait' for details", verified.Status, attempt)
+		}
+		if attempt >= opts.MaxAttempts {
+			return fmt.Errorf("ci status is %s after %d attempt(s); run 'hal ci status --wait' for details", verified.Status, attempt)
+		}
+
+		attempts = attempt
+	}
+
+	return fmt.Errorf("ci fix did not run")
+}
+
+func writeCIFixResult(out io.Writer, jsonMode bool, result ci.FixResult) error {
+	if jsonMode {
+		data, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal ci fix result: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	if strings.TrimSpace(result.Summary) != "" {
+		fmt.Fprintln(out, result.Summary)
+	}
+	if strings.TrimSpace(result.CommitSHA) != "" {
+		fmt.Fprintf(out, "Commit: %s\n", result.CommitSHA)
+	}
+	if len(result.FilesChanged) > 0 {
+		fmt.Fprintf(out, "Files changed: %s\n", strings.Join(result.FilesChanged, ", "))
+	}
 	return nil
 }
 

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -29,6 +29,12 @@ var (
 	ciFixMaxAttemptsFlag int
 	ciFixEngineFlag      string
 	ciFixJSONFlag        bool
+
+	ciMergeStrategyFlag      string
+	ciMergeDeleteBranchFlag  bool
+	ciMergeAllowNoChecksFlag bool
+	ciMergeDryRunFlag        bool
+	ciMergeJSONFlag          bool
 )
 
 var ciCmd = &cobra.Command{
@@ -40,11 +46,13 @@ Use subcommands to push branches, inspect CI status, apply fixes, and merge safe
 
 Examples:
   hal ci push
-  hal ci push --dry-run
-  hal ci push --json`,
+  hal ci status --wait
+  hal ci fix --max-attempts 2
+  hal ci merge --strategy squash`,
 	Example: `  hal ci push
-  hal ci push --dry-run
-  hal ci push --json`,
+  hal ci status --wait
+  hal ci fix --max-attempts 2
+  hal ci merge --strategy squash`,
 }
 
 var ciPushCmd = &cobra.Command{
@@ -93,6 +101,23 @@ continuing. Use --json for machine-readable output.`,
 	RunE: runCIFix,
 }
 
+var ciMergeCmd = &cobra.Command{
+	Use:   "merge",
+	Short: "Merge the open pull request for the current branch",
+	Args:  noArgsValidation(),
+	Long: `Merge the open pull request for the current branch with CI safety guards.
+
+By default this command uses the squash strategy and requires passing CI
+status. Use --allow-no-checks only when you intentionally want to override
+no-check safety guards. Use --dry-run to preview behavior without merge or
+remote branch deletion side effects. Use --json for machine-readable output.`,
+	Example: `  hal ci merge
+  hal ci merge --strategy rebase
+  hal ci merge --delete-branch
+  hal ci merge --dry-run --json`,
+	RunE: runCIMerge,
+}
+
 func init() {
 	ciPushCmd.Flags().BoolVar(&ciPushDryRunFlag, "dry-run", false, "Preview push/PR behavior without remote side effects")
 	ciPushCmd.Flags().BoolVar(&ciPushJSONFlag, "json", false, "Output machine-readable JSON result")
@@ -107,9 +132,16 @@ func init() {
 	ciFixCmd.Flags().StringVarP(&ciFixEngineFlag, "engine", "e", "codex", "Engine to use (claude, codex, pi)")
 	ciFixCmd.Flags().BoolVar(&ciFixJSONFlag, "json", false, "Output machine-readable JSON result")
 
+	ciMergeCmd.Flags().StringVar(&ciMergeStrategyFlag, "strategy", "squash", "Merge strategy (squash, merge, rebase)")
+	ciMergeCmd.Flags().BoolVar(&ciMergeDeleteBranchFlag, "delete-branch", false, "Delete remote branch after successful merge")
+	ciMergeCmd.Flags().BoolVar(&ciMergeAllowNoChecksFlag, "allow-no-checks", false, "Allow merge when no CI checks are discovered")
+	ciMergeCmd.Flags().BoolVar(&ciMergeDryRunFlag, "dry-run", false, "Preview merge behavior without merge or remote branch deletion side effects")
+	ciMergeCmd.Flags().BoolVar(&ciMergeJSONFlag, "json", false, "Output machine-readable JSON result")
+
 	ciCmd.AddCommand(ciPushCmd)
 	ciCmd.AddCommand(ciStatusCmd)
 	ciCmd.AddCommand(ciFixCmd)
+	ciCmd.AddCommand(ciMergeCmd)
 	rootCmd.AddCommand(ciCmd)
 }
 
@@ -164,6 +196,24 @@ type ciFixRunOptions struct {
 	MaxAttempts int
 	Engine      string
 	JSON        bool
+}
+
+type ciMergeDeps struct {
+	mergePR       func(context.Context, ci.MergeOptions) (ci.MergeResult, error)
+	currentBranch func(context.Context) (string, error)
+}
+
+var defaultCIMergeDeps = ciMergeDeps{
+	mergePR:       ci.MergePR,
+	currentBranch: ciCurrentBranch,
+}
+
+type ciMergeRunOptions struct {
+	Strategy      string
+	DeleteBranch  bool
+	AllowNoChecks bool
+	DryRun        bool
+	JSON          bool
 }
 
 func runCIPush(cmd *cobra.Command, args []string) error {
@@ -527,6 +577,144 @@ func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, 
 	}
 
 	return fmt.Errorf("ci fix did not run")
+}
+
+func runCIMerge(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		ctx = cmd.Context()
+	}
+
+	out := io.Writer(os.Stdout)
+	opts := ciMergeRunOptions{
+		Strategy:      ciMergeStrategyFlag,
+		DeleteBranch:  ciMergeDeleteBranchFlag,
+		AllowNoChecks: ciMergeAllowNoChecksFlag,
+		DryRun:        ciMergeDryRunFlag,
+		JSON:          ciMergeJSONFlag,
+	}
+
+	if cmd != nil {
+		out = cmd.OutOrStdout()
+		if flags := cmd.Flags(); flags != nil {
+			if flags.Lookup("strategy") != nil {
+				v, err := flags.GetString("strategy")
+				if err != nil {
+					return err
+				}
+				opts.Strategy = v
+			}
+			if flags.Lookup("delete-branch") != nil {
+				v, err := flags.GetBool("delete-branch")
+				if err != nil {
+					return err
+				}
+				opts.DeleteBranch = v
+			}
+			if flags.Lookup("allow-no-checks") != nil {
+				v, err := flags.GetBool("allow-no-checks")
+				if err != nil {
+					return err
+				}
+				opts.AllowNoChecks = v
+			}
+			if flags.Lookup("dry-run") != nil {
+				v, err := flags.GetBool("dry-run")
+				if err != nil {
+					return err
+				}
+				opts.DryRun = v
+			}
+			if flags.Lookup("json") != nil {
+				v, err := flags.GetBool("json")
+				if err != nil {
+					return err
+				}
+				opts.JSON = v
+			}
+		}
+	}
+
+	return runCIMergeWithDeps(ctx, opts, out, defaultCIMergeDeps)
+}
+
+func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writer, deps ciMergeDeps) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+	if deps.mergePR == nil {
+		deps.mergePR = defaultCIMergeDeps.mergePR
+	}
+	if deps.currentBranch == nil {
+		deps.currentBranch = defaultCIMergeDeps.currentBranch
+	}
+
+	strategy := strings.ToLower(strings.TrimSpace(opts.Strategy))
+	if strategy == "" {
+		strategy = "squash"
+	}
+
+	var (
+		result ci.MergeResult
+		err    error
+	)
+
+	if opts.DryRun {
+		branch, branchErr := deps.currentBranch(ctx)
+		if branchErr != nil {
+			return branchErr
+		}
+		branch = strings.TrimSpace(branch)
+		if branch == "" {
+			return fmt.Errorf("get current branch: empty branch name")
+		}
+
+		summary := fmt.Sprintf("dry-run: would merge pull request for branch %s using %s strategy", branch, strategy)
+		if opts.DeleteBranch {
+			summary += " and delete the remote branch"
+		}
+
+		result = ci.MergeResult{
+			ContractVersion: ci.MergeContractVersion,
+			Strategy:        strategy,
+			DryRun:          true,
+			Merged:          false,
+			BranchDeleted:   false,
+			Summary:         summary,
+		}
+	} else {
+		result, err = deps.mergePR(ctx, ci.MergeOptions{
+			Strategy:      strategy,
+			DeleteBranch:  opts.DeleteBranch,
+			AllowNoChecks: opts.AllowNoChecks,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.JSON {
+		data, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal ci merge result: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	if strings.TrimSpace(result.Summary) != "" {
+		fmt.Fprintln(out, result.Summary)
+	}
+	if !result.DryRun && strings.TrimSpace(result.MergeCommitSHA) != "" {
+		fmt.Fprintf(out, "Merge commit: %s\n", result.MergeCommitSHA)
+	}
+	if !result.DryRun && strings.TrimSpace(result.DeleteWarning) != "" {
+		fmt.Fprintf(out, "Warning: %s\n", result.DeleteWarning)
+	}
+	return nil
 }
 
 func writeCIFixResult(out io.Writer, jsonMode bool, result ci.FixResult) error {

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	ci "github.com/jywlabs/hal/internal/ci"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ciPushDryRunFlag bool
+	ciPushJSONFlag   bool
+)
+
+var ciCmd = &cobra.Command{
+	Use:   "ci",
+	Short: "Run CI workflow commands",
+	Long: `Run CI-aware workflow commands.
+
+Use subcommands to push branches, inspect CI status, apply fixes, and merge safely.
+
+Examples:
+  hal ci push
+  hal ci push --dry-run
+  hal ci push --json`,
+	Example: `  hal ci push
+  hal ci push --dry-run
+  hal ci push --json`,
+}
+
+var ciPushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Push current branch and create or reuse a pull request",
+	Args:  noArgsValidation(),
+	Long: `Push the current branch to origin and create or reuse an open pull request.
+
+By default, this command delegates to the shared CI core operation.
+Use --dry-run to preview behavior with no remote side effects.
+Use --json for machine-readable output.`,
+	Example: `  hal ci push
+  hal ci push --dry-run
+  hal ci push --json`,
+	RunE: runCIPush,
+}
+
+func init() {
+	ciPushCmd.Flags().BoolVar(&ciPushDryRunFlag, "dry-run", false, "Preview push/PR behavior without remote side effects")
+	ciPushCmd.Flags().BoolVar(&ciPushJSONFlag, "json", false, "Output machine-readable JSON result")
+
+	ciCmd.AddCommand(ciPushCmd)
+	rootCmd.AddCommand(ciCmd)
+}
+
+type ciPushDeps struct {
+	pushAndCreatePR func(context.Context, ci.PushOptions) (ci.PushResult, error)
+	currentBranch   func(context.Context) (string, error)
+}
+
+var defaultCIPushDeps = ciPushDeps{
+	pushAndCreatePR: ci.PushAndCreatePR,
+	currentBranch:   ciCurrentBranch,
+}
+
+type ciPushRunOptions struct {
+	DryRun bool
+	JSON   bool
+}
+
+func runCIPush(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	if cmd != nil && cmd.Context() != nil {
+		ctx = cmd.Context()
+	}
+
+	out := io.Writer(os.Stdout)
+	opts := ciPushRunOptions{
+		DryRun: ciPushDryRunFlag,
+		JSON:   ciPushJSONFlag,
+	}
+
+	if cmd != nil {
+		out = cmd.OutOrStdout()
+		if flags := cmd.Flags(); flags != nil {
+			if flags.Lookup("dry-run") != nil {
+				v, err := flags.GetBool("dry-run")
+				if err != nil {
+					return err
+				}
+				opts.DryRun = v
+			}
+			if flags.Lookup("json") != nil {
+				v, err := flags.GetBool("json")
+				if err != nil {
+					return err
+				}
+				opts.JSON = v
+			}
+		}
+	}
+
+	return runCIPushWithDeps(ctx, opts, out, defaultCIPushDeps)
+}
+
+func runCIPushWithDeps(ctx context.Context, opts ciPushRunOptions, out io.Writer, deps ciPushDeps) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if out == nil {
+		out = os.Stdout
+	}
+	if deps.pushAndCreatePR == nil {
+		deps.pushAndCreatePR = defaultCIPushDeps.pushAndCreatePR
+	}
+	if deps.currentBranch == nil {
+		deps.currentBranch = defaultCIPushDeps.currentBranch
+	}
+
+	var (
+		result ci.PushResult
+		err    error
+	)
+
+	if opts.DryRun {
+		branch, branchErr := deps.currentBranch(ctx)
+		if branchErr != nil {
+			return branchErr
+		}
+		result = ci.PushResult{
+			ContractVersion: ci.PushContractVersion,
+			Branch:          branch,
+			Pushed:          false,
+			DryRun:          true,
+			PullRequest: ci.PullRequest{
+				HeadRef:  branch,
+				Draft:    true,
+				Existing: false,
+			},
+			Summary: fmt.Sprintf("dry-run: would push branch %s and create or reuse a pull request", branch),
+		}
+	} else {
+		result, err = deps.pushAndCreatePR(ctx, ci.PushOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.JSON {
+		data, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal ci push result: %w", marshalErr)
+		}
+		fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	if result.DryRun {
+		fmt.Fprintf(out, "Dry run: would push branch %s and create or reuse a pull request.\n", result.Branch)
+		return nil
+	}
+
+	fmt.Fprintln(out, result.Summary)
+	if result.PullRequest.URL == "" {
+		return nil
+	}
+
+	label := "Pull request"
+	if result.PullRequest.Existing {
+		label = "Pull request (existing)"
+	}
+	fmt.Fprintf(out, "%s: %s\n", label, result.PullRequest.URL)
+	return nil
+}
+
+func ciCurrentBranch(ctx context.Context) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "branch", "--show-current")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return "", fmt.Errorf("get current branch failed: %s: %w", stderrText, err)
+		}
+		return "", fmt.Errorf("get current branch failed: %w", err)
+	}
+
+	branch := strings.TrimSpace(stdout.String())
+	if branch == "" {
+		return "", fmt.Errorf("get current branch: empty branch name")
+	}
+
+	return branch, nil
+}

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -217,6 +217,65 @@ type ciMergeRunOptions struct {
 	JSON          bool
 }
 
+const ciFieldValueColumn = 10
+
+func ciWriteField(out io.Writer, label string, value string) {
+	padding := ciFieldValueColumn - len(label)
+	if padding < 1 {
+		padding = 1
+	}
+	fmt.Fprintf(out, "%s%s%s\n", engine.StyleBold.Render(label), strings.Repeat(" ", padding), value)
+}
+
+func ciShortSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > 7 {
+		sha = sha[:7]
+	}
+	return sha
+}
+
+func ciRenderStatusValue(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case ci.StatusPassing:
+		return engine.StyleSuccess.Render("✓ passing")
+	case ci.StatusFailing:
+		return engine.StyleError.Render("✗ failing")
+	case ci.StatusPending:
+		return engine.StyleWarning.Render("⚠ pending")
+	default:
+		return engine.StyleMuted.Render(strings.TrimSpace(status))
+	}
+}
+
+func ciRenderCheckIcon(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case ci.StatusPassing:
+		return engine.StyleSuccess.Render("✓")
+	case ci.StatusFailing:
+		return engine.StyleError.Render("✗")
+	default:
+		return engine.StyleWarning.Render("⚠")
+	}
+}
+
+func ciRenderTotals(totals ci.StatusTotals) string {
+	parts := make([]string, 0, 3)
+	if totals.Passing > 0 {
+		parts = append(parts, fmt.Sprintf("%d passing", totals.Passing))
+	}
+	if totals.Failing > 0 {
+		parts = append(parts, fmt.Sprintf("%d failing", totals.Failing))
+	}
+	if totals.Pending > 0 {
+		parts = append(parts, fmt.Sprintf("%d pending", totals.Pending))
+	}
+	if len(parts) == 0 {
+		return "0 checks"
+	}
+	return strings.Join(parts, " · ")
+}
+
 func runCIPush(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	if cmd != nil && cmd.Context() != nil {
@@ -305,20 +364,38 @@ func runCIPushWithDeps(ctx context.Context, opts ciPushRunOptions, out io.Writer
 	}
 
 	if result.DryRun {
-		fmt.Fprintf(out, "Dry run: would push branch %s and create or reuse a pull request.\n", result.Branch)
+		fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Push (dry run)"))
+		ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would push branch and create or reuse a pull request."))
 		return nil
 	}
 
-	fmt.Fprintln(out, result.Summary)
+	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Push"))
+	ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
+	ciWriteField(out, "Status:", engine.StyleSuccess.Render("✓ Pushed"))
+
 	if result.PullRequest.URL == "" {
 		return nil
 	}
 
-	label := "Pull request"
-	if result.PullRequest.Existing {
-		label = "Pull request (existing)"
+	fmt.Fprintln(out)
+	prLabel := "PR:"
+	if result.PullRequest.Number > 0 {
+		prLabel = fmt.Sprintf("PR #%d:", result.PullRequest.Number)
 	}
-	fmt.Fprintf(out, "%s: %s\n", label, result.PullRequest.URL)
+	ciWriteField(out, prLabel, engine.StyleInfo.Render(result.PullRequest.URL))
+
+	prDetail := "Draft"
+	if !result.PullRequest.Draft {
+		prDetail = "Ready for review"
+	}
+	if result.PullRequest.Existing {
+		prDetail += " · Existing"
+	} else {
+		prDetail += " · New"
+	}
+	fmt.Fprintf(out, "%s%s\n", strings.Repeat(" ", ciFieldValueColumn), engine.StyleMuted.Render(prDetail))
 	return nil
 }
 
@@ -422,15 +499,36 @@ func runCIStatusWithDeps(ctx context.Context, opts ciStatusRunOptions, out io.Wr
 		return nil
 	}
 
+	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Status"))
+	ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
+	ciWriteField(out, "SHA:", engine.StyleMuted.Render(ciShortSHA(result.SHA)))
+	ciWriteField(out, "Status:", ciRenderStatusValue(result.Status))
+
 	if opts.Wait && strings.TrimSpace(result.WaitTerminalReason) != "" {
-		fmt.Fprintf(out, "Wait terminal reason: %s\n", result.WaitTerminalReason)
+		ciWriteField(out, "Wait:", engine.StyleMuted.Render(result.WaitTerminalReason))
 	}
-	if strings.TrimSpace(result.Summary) != "" {
-		fmt.Fprintln(out, result.Summary)
+
+	if !result.ChecksDiscovered {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("No CI checks discovered."))
 		return nil
 	}
 
-	fmt.Fprintf(out, "status=%s\n", result.Status)
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s\n", engine.StyleBold.Render("Checks:"))
+	for _, check := range result.Checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			name = strings.TrimSpace(check.Key)
+		}
+		if name == "" {
+			name = "(unnamed check)"
+		}
+		fmt.Fprintf(out, "  %s  %s\n", ciRenderCheckIcon(check.Status), name)
+	}
+
+	fmt.Fprintln(out)
+	ciWriteField(out, "Totals:", engine.StyleMuted.Render(ciRenderTotals(result.Totals)))
 	return nil
 }
 
@@ -723,14 +821,40 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 		return nil
 	}
 
-	if strings.TrimSpace(result.Summary) != "" {
-		fmt.Fprintln(out, result.Summary)
+	if result.DryRun {
+		fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Merge (dry run)"))
+		ciWriteField(out, "Strategy:", result.Strategy)
+		fmt.Fprintln(out)
+		if opts.DeleteBranch {
+			fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would merge pull request and delete the remote branch."))
+		} else {
+			fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would merge pull request."))
+		}
+		return nil
 	}
-	if !result.DryRun && strings.TrimSpace(result.MergeCommitSHA) != "" {
-		fmt.Fprintf(out, "Merge commit: %s\n", result.MergeCommitSHA)
+
+	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Merge"))
+	if result.PRNumber > 0 {
+		ciWriteField(out, "PR:", engine.StyleInfo.Render(fmt.Sprintf("#%d", result.PRNumber)))
 	}
-	if !result.DryRun && strings.TrimSpace(result.DeleteWarning) != "" {
-		fmt.Fprintf(out, "Warning: %s\n", result.DeleteWarning)
+	ciWriteField(out, "Strategy:", result.Strategy)
+	statusValue := engine.StyleMuted.Render("Not merged")
+	if result.Merged {
+		statusValue = engine.StyleSuccess.Render("✓ Merged")
+	}
+	ciWriteField(out, "Status:", statusValue)
+
+	sha := ciShortSHA(result.MergeCommitSHA)
+	if sha != "" {
+		fmt.Fprintln(out)
+		ciWriteField(out, "Commit:", engine.StyleMuted.Render(sha))
+	}
+	if result.BranchDeleted {
+		ciWriteField(out, "Branch:", engine.StyleSuccess.Render("✓ Deleted"))
+	} else if strings.TrimSpace(result.DeleteWarning) != "" {
+		ciWriteField(out, "Branch:", engine.StyleWarning.Render("⚠ "+result.DeleteWarning))
+	} else if opts.DeleteBranch {
+		ciWriteField(out, "Branch:", engine.StyleMuted.Render("Already absent"))
 	}
 	return nil
 }
@@ -745,14 +869,46 @@ func writeCIFixResult(out io.Writer, jsonMode bool, result ci.FixResult) error {
 		return nil
 	}
 
-	if strings.TrimSpace(result.Summary) != "" {
-		fmt.Fprintln(out, result.Summary)
+	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Fix"))
+
+	if !result.Applied {
+		summary := strings.TrimSpace(result.Summary)
+		if summary == "" {
+			summary = "no fix attempt needed"
+		}
+
+		lower := strings.ToLower(summary)
+		render := engine.StyleMuted.Render
+		if strings.Contains(lower, "status is passing") {
+			render = engine.StyleSuccess.Render
+			summary = "✓ " + summary
+		} else if strings.Contains(lower, "status is pending") {
+			render = engine.StyleWarning.Render
+			summary = "⚠ " + summary
+		}
+
+		ciWriteField(out, "Status:", render(summary))
+		return nil
 	}
-	if strings.TrimSpace(result.CommitSHA) != "" {
-		fmt.Fprintf(out, "Commit: %s\n", result.CommitSHA)
+
+	if strings.TrimSpace(result.Branch) != "" {
+		ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
+	}
+	if result.MaxAttempts > 0 {
+		ciWriteField(out, "Attempt:", fmt.Sprintf("%d/%d", result.Attempt, result.MaxAttempts))
+	}
+	ciWriteField(out, "Status:", engine.StyleSuccess.Render("✓ Fix applied"))
+
+	sha := ciShortSHA(result.CommitSHA)
+	if sha != "" {
+		fmt.Fprintln(out)
+		ciWriteField(out, "Commit:", engine.StyleMuted.Render(sha))
+	}
+	if result.Pushed {
+		ciWriteField(out, "Pushed:", engine.StyleSuccess.Render("✓"))
 	}
 	if len(result.FilesChanged) > 0 {
-		fmt.Fprintf(out, "Files changed: %s\n", strings.Join(result.FilesChanged, ", "))
+		ciWriteField(out, "Files:", engine.StyleMuted.Render(strings.Join(result.FilesChanged, ", ")))
 	}
 	return nil
 }

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -792,12 +792,13 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 	}
 
 	var (
-		result         ci.MergeResult
-		dryRunBranch   string
-		dryRunBase     string
-		dryRunPRNumber int
-		mergeBranch    string
-		mergeBase      string
+		result               ci.MergeResult
+		dryRunBranch         string
+		dryRunBase           string
+		dryRunPRNumber       int
+		mergeBranch          string
+		mergeBase            string
+		mergePRLookupWarning string
 	)
 
 	if opts.DryRun {
@@ -810,7 +811,11 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 			return fmt.Errorf("get current branch: empty branch name")
 		}
 		dryRunBranch = branch
-		if pr, prErr := deps.findOpenPR(ctx, branch); prErr == nil && pr != nil {
+		pr, prErr := deps.findOpenPR(ctx, branch)
+		if prErr != nil {
+			return fmt.Errorf("find open pull request for branch %s: %w", branch, prErr)
+		}
+		if pr != nil {
 			dryRunPRNumber = pr.Number
 			dryRunBase = strings.TrimSpace(pr.BaseRef)
 		}
@@ -835,7 +840,10 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 				branch = strings.TrimSpace(branch)
 				if branch != "" {
 					mergeBranch = branch
-					if pr, prErr := deps.findOpenPR(ctx, branch); prErr == nil && pr != nil {
+					pr, prErr := deps.findOpenPR(ctx, branch)
+					if prErr != nil {
+						mergePRLookupWarning = fmt.Sprintf("unable to resolve pull request metadata: %v", prErr)
+					} else if pr != nil {
 						mergeBase = strings.TrimSpace(pr.BaseRef)
 					}
 				}
@@ -896,6 +904,9 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 	}
 	if mergeBase != "" {
 		ciWriteField(out, "Base:", engine.StyleInfo.Render(mergeBase))
+	}
+	if strings.TrimSpace(mergePRLookupWarning) != "" {
+		ciWriteField(out, "Warning:", engine.StyleWarning.Render("⚠ "+mergePRLookupWarning))
 	}
 	ciWriteField(out, "Strategy:", result.Strategy)
 	statusValue := engine.StyleMuted.Render("Not merged")

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -815,10 +815,11 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 		if prErr != nil {
 			return fmt.Errorf("find open pull request for branch %s: %w", branch, prErr)
 		}
-		if pr != nil {
-			dryRunPRNumber = pr.Number
-			dryRunBase = strings.TrimSpace(pr.BaseRef)
+		if pr == nil {
+			return fmt.Errorf("%w: branch %q", ci.ErrMergePRNotFound, branch)
 		}
+		dryRunPRNumber = pr.Number
+		dryRunBase = strings.TrimSpace(pr.BaseRef)
 
 		summary := fmt.Sprintf("dry-run: would merge pull request for branch %s using %s strategy", branch, strategy)
 		if opts.DeleteBranch {

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -202,11 +202,13 @@ type ciFixRunOptions struct {
 type ciMergeDeps struct {
 	mergePR       func(context.Context, ci.MergeOptions) (ci.MergeResult, error)
 	currentBranch func(context.Context) (string, error)
+	findOpenPR    func(context.Context, string) (*ci.PullRequest, error)
 }
 
 var defaultCIMergeDeps = ciMergeDeps{
 	mergePR:       ci.MergePR,
 	currentBranch: ciCurrentBranch,
+	findOpenPR:    ci.FindOpenPullRequestForBranch,
 }
 
 type ciMergeRunOptions struct {
@@ -366,6 +368,11 @@ func runCIPushWithDeps(ctx context.Context, opts ciPushRunOptions, out io.Writer
 	if result.DryRun {
 		fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Push (dry run)"))
 		ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
+		prMode := "Create or reuse draft pull request"
+		if !result.PullRequest.Draft {
+			prMode = "Create or reuse ready-for-review pull request"
+		}
+		ciWriteField(out, "PR:", engine.StyleMuted.Render(prMode))
 		fmt.Fprintln(out)
 		fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would push branch and create or reuse a pull request."))
 		return nil
@@ -374,6 +381,9 @@ func runCIPushWithDeps(ctx context.Context, opts ciPushRunOptions, out io.Writer
 	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Push"))
 	ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
 	ciWriteField(out, "Status:", engine.StyleSuccess.Render("✓ Pushed"))
+	if base := strings.TrimSpace(result.PullRequest.BaseRef); base != "" {
+		ciWriteField(out, "Base:", engine.StyleInfo.Render(base))
+	}
 
 	if result.PullRequest.URL == "" {
 		return nil
@@ -770,13 +780,25 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 	if deps.currentBranch == nil {
 		deps.currentBranch = defaultCIMergeDeps.currentBranch
 	}
+	if deps.findOpenPR == nil {
+		deps.findOpenPR = func(context.Context, string) (*ci.PullRequest, error) {
+			return nil, nil
+		}
+	}
 
 	strategy, err := ci.NormalizeMergeStrategy(opts.Strategy)
 	if err != nil {
 		return err
 	}
 
-	var result ci.MergeResult
+	var (
+		result         ci.MergeResult
+		dryRunBranch   string
+		dryRunBase     string
+		dryRunPRNumber int
+		mergeBranch    string
+		mergeBase      string
+	)
 
 	if opts.DryRun {
 		branch, branchErr := deps.currentBranch(ctx)
@@ -787,6 +809,11 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 		if branch == "" {
 			return fmt.Errorf("get current branch: empty branch name")
 		}
+		dryRunBranch = branch
+		if pr, prErr := deps.findOpenPR(ctx, branch); prErr == nil && pr != nil {
+			dryRunPRNumber = pr.Number
+			dryRunBase = strings.TrimSpace(pr.BaseRef)
+		}
 
 		summary := fmt.Sprintf("dry-run: would merge pull request for branch %s using %s strategy", branch, strategy)
 		if opts.DeleteBranch {
@@ -795,6 +822,7 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 
 		result = ci.MergeResult{
 			ContractVersion: ci.MergeContractVersion,
+			PRNumber:        dryRunPRNumber,
 			Strategy:        strategy,
 			DryRun:          true,
 			Merged:          false,
@@ -802,6 +830,18 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 			Summary:         summary,
 		}
 	} else {
+		if !opts.JSON {
+			if branch, branchErr := deps.currentBranch(ctx); branchErr == nil {
+				branch = strings.TrimSpace(branch)
+				if branch != "" {
+					mergeBranch = branch
+					if pr, prErr := deps.findOpenPR(ctx, branch); prErr == nil && pr != nil {
+						mergeBase = strings.TrimSpace(pr.BaseRef)
+					}
+				}
+			}
+		}
+
 		result, err = deps.mergePR(ctx, ci.MergeOptions{
 			Strategy:      strategy,
 			DeleteBranch:  opts.DeleteBranch,
@@ -823,7 +863,21 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 
 	if result.DryRun {
 		fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Merge (dry run)"))
+		ciWriteField(out, "Branch:", engine.StyleInfo.Render(dryRunBranch))
+		if dryRunPRNumber > 0 {
+			ciWriteField(out, "PR:", engine.StyleInfo.Render(fmt.Sprintf("#%d", dryRunPRNumber)))
+		}
+		baseValue := engine.StyleMuted.Render("Not resolved")
+		if dryRunBase != "" {
+			baseValue = engine.StyleInfo.Render(dryRunBase)
+		}
+		ciWriteField(out, "Base:", baseValue)
 		ciWriteField(out, "Strategy:", result.Strategy)
+		deleteValue := engine.StyleMuted.Render("No")
+		if opts.DeleteBranch {
+			deleteValue = engine.StyleSuccess.Render("Yes")
+		}
+		ciWriteField(out, "Delete:", deleteValue)
 		fmt.Fprintln(out)
 		if opts.DeleteBranch {
 			fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would merge pull request and delete the remote branch."))
@@ -834,8 +888,14 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 	}
 
 	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Merge"))
+	if mergeBranch != "" {
+		ciWriteField(out, "Branch:", engine.StyleInfo.Render(mergeBranch))
+	}
 	if result.PRNumber > 0 {
 		ciWriteField(out, "PR:", engine.StyleInfo.Render(fmt.Sprintf("#%d", result.PRNumber)))
+	}
+	if mergeBase != "" {
+		ciWriteField(out, "Base:", engine.StyleInfo.Render(mergeBase))
 	}
 	ciWriteField(out, "Strategy:", result.Strategy)
 	statusValue := engine.StyleMuted.Render("Not merged")
@@ -887,6 +947,9 @@ func writeCIFixResult(out io.Writer, jsonMode bool, result ci.FixResult) error {
 			summary = "⚠ " + summary
 		}
 
+		if strings.TrimSpace(result.Branch) != "" {
+			ciWriteField(out, "Branch:", engine.StyleInfo.Render(result.Branch))
+		}
 		ciWriteField(out, "Status:", render(summary))
 		return nil
 	}

--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -180,6 +180,7 @@ type ciStatusRunOptions struct {
 
 type ciFixDeps struct {
 	newEngine     func(string) (engine.Engine, error)
+	resolveEngine func(string) (string, error)
 	getStatus     func(context.Context) (ci.StatusResult, error)
 	waitForChecks func(context.Context, ci.WaitOptions) (ci.StatusResult, error)
 	fixWithEngine func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error)
@@ -481,16 +482,19 @@ func runCIFix(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resolvedEngine, err := resolveEngine(cmd, "engine", opts.Engine, ".")
-	if err != nil {
-		if cmd != nil {
-			return exitWithCode(cmd, ExitCodeValidation, err)
+	deps := defaultCIFixDeps
+	deps.resolveEngine = func(engineName string) (string, error) {
+		resolvedEngine, err := resolveEngine(cmd, "engine", engineName, ".")
+		if err != nil {
+			if cmd != nil {
+				return "", exitWithCode(cmd, ExitCodeValidation, err)
+			}
+			return "", err
 		}
-		return err
+		return resolvedEngine, nil
 	}
-	opts.Engine = resolvedEngine
 
-	return runCIFixWithDeps(ctx, opts, out, defaultCIFixDeps)
+	return runCIFixWithDeps(ctx, opts, out, deps)
 }
 
 func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, deps ciFixDeps) error {
@@ -518,8 +522,9 @@ func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, 
 	}
 
 	var (
-		eng      engine.Engine
-		attempts int
+		eng           engine.Engine
+		attempts      int
+		lastFixResult ci.FixResult
 	)
 
 	for attempts < opts.MaxAttempts {
@@ -529,6 +534,12 @@ func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, 
 		}
 
 		if status.Status != ci.StatusFailing {
+			if attempts > 0 {
+				if status.Status == ci.StatusPassing {
+					return writeCIFixResult(out, opts.JSON, lastFixResult)
+				}
+				return fmt.Errorf("ci status is %s after attempt %d; run 'hal ci status --wait' for details", status.Status, attempts)
+			}
 			result := ci.FixResult{
 				ContractVersion: ci.FixContractVersion,
 				Attempt:         attempts,
@@ -542,6 +553,15 @@ func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, 
 		}
 
 		if eng == nil {
+			if deps.resolveEngine != nil {
+				resolvedEngine, err := deps.resolveEngine(opts.Engine)
+				if err != nil {
+					return err
+				}
+				opts.Engine = resolvedEngine
+				deps.resolveEngine = nil
+			}
+
 			created, err := deps.newEngine(opts.Engine)
 			if err != nil {
 				return fmt.Errorf("failed to create engine: %w", err)
@@ -558,6 +578,7 @@ func runCIFixWithDeps(ctx context.Context, opts ciFixRunOptions, out io.Writer, 
 		if err != nil {
 			return err
 		}
+		lastFixResult = fixResult
 
 		verified, err := deps.waitForChecks(ctx, ci.WaitOptions{})
 		if err != nil {
@@ -652,15 +673,12 @@ func runCIMergeWithDeps(ctx context.Context, opts ciMergeRunOptions, out io.Writ
 		deps.currentBranch = defaultCIMergeDeps.currentBranch
 	}
 
-	strategy := strings.ToLower(strings.TrimSpace(opts.Strategy))
-	if strategy == "" {
-		strategy = "squash"
+	strategy, err := ci.NormalizeMergeStrategy(opts.Strategy)
+	if err != nil {
+		return err
 	}
 
-	var (
-		result ci.MergeResult
-		err    error
-	)
+	var result ci.MergeResult
 
 	if opts.DryRun {
 		branch, branchErr := deps.currentBranch(ctx)

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -4,13 +4,32 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	ci "github.com/jywlabs/hal/internal/ci"
+	"github.com/jywlabs/hal/internal/engine"
 	"github.com/spf13/cobra"
 )
+
+type ciFakeEngine struct{}
+
+func (ciFakeEngine) Name() string { return "fake" }
+
+func (ciFakeEngine) Execute(context.Context, string, *engine.Display) engine.Result {
+	return engine.Result{}
+}
+
+func (ciFakeEngine) Prompt(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (ciFakeEngine) StreamPrompt(context.Context, string, *engine.Display) (string, error) {
+	return "", nil
+}
 
 func preserveCIPushGlobals(t *testing.T) {
 	t.Helper()
@@ -25,6 +44,11 @@ func preserveCIPushGlobals(t *testing.T) {
 	origStatusJSON := ciStatusJSONFlag
 	origStatusDeps := defaultCIStatusDeps
 
+	origFixMaxAttempts := ciFixMaxAttemptsFlag
+	origFixEngine := ciFixEngineFlag
+	origFixJSON := ciFixJSONFlag
+	origFixDeps := defaultCIFixDeps
+
 	t.Cleanup(func() {
 		ciPushDryRunFlag = origDryRun
 		ciPushJSONFlag = origJSON
@@ -36,6 +60,11 @@ func preserveCIPushGlobals(t *testing.T) {
 		ciStatusNoChecksGraceFlag = origStatusNoChecksGrace
 		ciStatusJSONFlag = origStatusJSON
 		defaultCIStatusDeps = origStatusDeps
+
+		ciFixMaxAttemptsFlag = origFixMaxAttempts
+		ciFixEngineFlag = origFixEngine
+		ciFixJSONFlag = origFixJSON
+		defaultCIFixDeps = origFixDeps
 	})
 }
 
@@ -129,6 +158,44 @@ func TestCICommandMetadataAndFlags(t *testing.T) {
 	}
 	if err := ciStatusCmd.Args(ciStatusCmd, []string{"unexpected"}); err == nil {
 		t.Fatal("ci status command should fail on positional arguments")
+	}
+
+	if ciFixCmd.Use != "fix" {
+		t.Fatalf("ciFixCmd.Use = %q, want %q", ciFixCmd.Use, "fix")
+	}
+	if !strings.Contains(ciFixCmd.Example, "hal ci fix") {
+		t.Fatalf("ciFixCmd.Example should include command path, got %q", ciFixCmd.Example)
+	}
+
+	maxAttemptsFlag := ciFixCmd.Flags().Lookup("max-attempts")
+	if maxAttemptsFlag == nil {
+		t.Fatal("ci fix command missing --max-attempts flag")
+	}
+	if maxAttemptsFlag.DefValue != "3" {
+		t.Fatalf("ci fix --max-attempts default = %q, want %q", maxAttemptsFlag.DefValue, "3")
+	}
+
+	fixEngineFlag := ciFixCmd.Flags().Lookup("engine")
+	if fixEngineFlag == nil {
+		t.Fatal("ci fix command missing --engine flag")
+	}
+	if fixEngineFlag.DefValue != "codex" {
+		t.Fatalf("ci fix --engine default = %q, want %q", fixEngineFlag.DefValue, "codex")
+	}
+
+	fixJSONFlag := ciFixCmd.Flags().Lookup("json")
+	if fixJSONFlag == nil {
+		t.Fatal("ci fix command missing --json flag")
+	}
+	if fixJSONFlag.DefValue != "false" {
+		t.Fatalf("ci fix --json default = %q, want %q", fixJSONFlag.DefValue, "false")
+	}
+
+	if ciFixCmd.Args == nil {
+		t.Fatal("ci fix command should reject positional arguments")
+	}
+	if err := ciFixCmd.Args(ciFixCmd, []string{"unexpected"}); err == nil {
+		t.Fatal("ci fix command should fail on positional arguments")
 	}
 }
 
@@ -407,5 +474,269 @@ func TestRunCIStatus_UsesCommandFlagValues(t *testing.T) {
 	}
 	if got.Branch != "hal/from-flags" {
 		t.Fatalf("got.Branch = %q, want %q", got.Branch, "hal/from-flags")
+	}
+}
+
+func TestRunCIFixWithDeps_JSONOnlyOutput(t *testing.T) {
+	want := ci.FixResult{
+		ContractVersion: ci.FixContractVersion,
+		Attempt:         1,
+		MaxAttempts:     3,
+		Applied:         true,
+		Branch:          "hal/ci-fix",
+		CommitSHA:       "deadbeef",
+		Pushed:          true,
+		FilesChanged:    []string{"cmd/ci.go", "cmd/ci_test.go"},
+		Summary:         "applied ci fix attempt 1 on branch hal/ci-fix and pushed 2 files",
+	}
+
+	newEngineCalls := 0
+	fixCalls := 0
+	waitCalls := 0
+
+	var buf bytes.Buffer
+	err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 3, Engine: "codex", JSON: true}, &buf, ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			newEngineCalls++
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalls++
+			return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/ci-fix"}, nil
+		},
+		fixWithEngine: func(_ context.Context, status ci.StatusResult, opts ci.FixOptions) (ci.FixResult, error) {
+			fixCalls++
+			if status.Status != ci.StatusFailing {
+				t.Fatalf("status.Status = %q, want %q", status.Status, ci.StatusFailing)
+			}
+			if opts.Attempt != 1 {
+				t.Fatalf("opts.Attempt = %d, want %d", opts.Attempt, 1)
+			}
+			if opts.MaxAttempts != 3 {
+				t.Fatalf("opts.MaxAttempts = %d, want %d", opts.MaxAttempts, 3)
+			}
+			return want, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIFixWithDeps() error = %v", err)
+	}
+	if newEngineCalls != 1 {
+		t.Fatalf("newEngine calls = %d, want 1", newEngineCalls)
+	}
+	if fixCalls != 1 {
+		t.Fatalf("fixWithEngine calls = %d, want 1", fixCalls)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("waitForChecks calls = %d, want 1", waitCalls)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	if !strings.HasPrefix(output, "{") || !strings.HasSuffix(output, "}") {
+		t.Fatalf("expected JSON-only output, got %q", output)
+	}
+	if strings.Contains(output, "Commit:") {
+		t.Fatalf("JSON output should not include human text, got %q", output)
+	}
+
+	var got ci.FixResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+	if got.ContractVersion != ci.FixContractVersion {
+		t.Fatalf("contractVersion = %q, want %q", got.ContractVersion, ci.FixContractVersion)
+	}
+	if got.Attempt != want.Attempt {
+		t.Fatalf("attempt = %d, want %d", got.Attempt, want.Attempt)
+	}
+	if got.CommitSHA != want.CommitSHA {
+		t.Fatalf("commitSha = %q, want %q", got.CommitSHA, want.CommitSHA)
+	}
+}
+
+func TestRunCIFixWithDeps_StopsWithoutAttemptWhenStatusNotFailing(t *testing.T) {
+	newEngineCalled := false
+	fixCalled := false
+	waitCalled := false
+
+	var buf bytes.Buffer
+	err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 3, Engine: "codex", JSON: true}, &buf, ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			newEngineCalled = true
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/ci-fix"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalled = true
+			return ci.StatusResult{}, nil
+		},
+		fixWithEngine: func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error) {
+			fixCalled = true
+			return ci.FixResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIFixWithDeps() error = %v", err)
+	}
+	if newEngineCalled {
+		t.Fatal("newEngine should not be called when status is not failing")
+	}
+	if fixCalled {
+		t.Fatal("fixWithEngine should not be called when status is not failing")
+	}
+	if waitCalled {
+		t.Fatal("waitForChecks should not be called when no attempt is made")
+	}
+
+	var got ci.FixResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+	if got.Attempt != 0 {
+		t.Fatalf("attempt = %d, want 0", got.Attempt)
+	}
+	if got.Applied {
+		t.Fatal("applied = true, want false")
+	}
+	if !strings.Contains(got.Summary, "no fix attempt needed") {
+		t.Fatalf("summary = %q, want no-attempt text", got.Summary)
+	}
+}
+
+func TestRunCIFixWithDeps_StopsAtMaxAttempts(t *testing.T) {
+	fixAttempts := make([]int, 0, 2)
+	waitCalls := 0
+	newEngineCalls := 0
+
+	err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 2, Engine: "codex"}, io.Discard, ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			newEngineCalls++
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalls++
+			return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+		},
+		fixWithEngine: func(_ context.Context, _ ci.StatusResult, opts ci.FixOptions) (ci.FixResult, error) {
+			fixAttempts = append(fixAttempts, opts.Attempt)
+			return ci.FixResult{ContractVersion: ci.FixContractVersion, Attempt: opts.Attempt, MaxAttempts: opts.MaxAttempts, Applied: true, Branch: "hal/ci-fix", Pushed: true, Summary: "attempt"}, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("runCIFixWithDeps() error = nil, want max-attempts error")
+	}
+	wantErr := "ci status is failing after 2 attempt(s); run 'hal ci status --wait' for details"
+	if err.Error() != wantErr {
+		t.Fatalf("error = %q, want %q", err.Error(), wantErr)
+	}
+	if newEngineCalls != 1 {
+		t.Fatalf("newEngine calls = %d, want 1", newEngineCalls)
+	}
+	if waitCalls != 2 {
+		t.Fatalf("waitForChecks calls = %d, want 2", waitCalls)
+	}
+	if !reflect.DeepEqual(fixAttempts, []int{1, 2}) {
+		t.Fatalf("fix attempts = %v, want [1 2]", fixAttempts)
+	}
+}
+
+func TestRunCIFix_UsesCommandFlagValues(t *testing.T) {
+	preserveCIPushGlobals(t)
+
+	ciFixMaxAttemptsFlag = 3
+	ciFixEngineFlag = "codex"
+	ciFixJSONFlag = false
+
+	newEngineName := ""
+	fixOptions := ci.FixOptions{}
+	getStatusCalls := 0
+	waitCalls := 0
+	defaultCIFixDeps = ciFixDeps{
+		newEngine: func(name string) (engine.Engine, error) {
+			newEngineName = name
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			getStatusCalls++
+			return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/from-flags"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalls++
+			return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/from-flags"}, nil
+		},
+		fixWithEngine: func(_ context.Context, status ci.StatusResult, opts ci.FixOptions) (ci.FixResult, error) {
+			fixOptions = opts
+			return ci.FixResult{
+				ContractVersion: ci.FixContractVersion,
+				Attempt:         opts.Attempt,
+				MaxAttempts:     opts.MaxAttempts,
+				Applied:         true,
+				Branch:          status.Branch,
+				CommitSHA:       "deadbeef",
+				Pushed:          true,
+				FilesChanged:    []string{"cmd/ci.go"},
+				Summary:         "fixed",
+			}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "fix"}
+	cmd.SetOut(&out)
+	cmd.Flags().Int("max-attempts", 3, "")
+	cmd.Flags().String("engine", "codex", "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("max-attempts", "2"); err != nil {
+		t.Fatalf("set --max-attempts: %v", err)
+	}
+	if err := cmd.Flags().Set("engine", "claude"); err != nil {
+		t.Fatalf("set --engine: %v", err)
+	}
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	if err := runCIFix(cmd, nil); err != nil {
+		t.Fatalf("runCIFix() error = %v", err)
+	}
+	if newEngineName != "claude" {
+		t.Fatalf("newEngine name = %q, want %q", newEngineName, "claude")
+	}
+	if getStatusCalls != 1 {
+		t.Fatalf("getStatus calls = %d, want 1", getStatusCalls)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("waitForChecks calls = %d, want 1", waitCalls)
+	}
+	if fixOptions.Attempt != 1 {
+		t.Fatalf("fix attempt = %d, want 1", fixOptions.Attempt)
+	}
+	if fixOptions.MaxAttempts != 2 {
+		t.Fatalf("fix max attempts = %d, want 2", fixOptions.MaxAttempts)
+	}
+
+	var got ci.FixResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("runCIFix JSON output parse failed: %v\noutput: %s", err, out.String())
+	}
+	if got.ContractVersion != ci.FixContractVersion {
+		t.Fatalf("contractVersion = %q, want %q", got.ContractVersion, ci.FixContractVersion)
+	}
+	if got.Attempt != 1 {
+		t.Fatalf("attempt = %d, want 1", got.Attempt)
+	}
+	if got.MaxAttempts != 2 {
+		t.Fatalf("maxAttempts = %d, want 2", got.MaxAttempts)
+	}
+	if got.Branch != "hal/from-flags" {
+		t.Fatalf("branch = %q, want %q", got.Branch, "hal/from-flags")
 	}
 }

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -49,6 +49,13 @@ func preserveCIPushGlobals(t *testing.T) {
 	origFixJSON := ciFixJSONFlag
 	origFixDeps := defaultCIFixDeps
 
+	origMergeStrategy := ciMergeStrategyFlag
+	origMergeDeleteBranch := ciMergeDeleteBranchFlag
+	origMergeAllowNoChecks := ciMergeAllowNoChecksFlag
+	origMergeDryRun := ciMergeDryRunFlag
+	origMergeJSON := ciMergeJSONFlag
+	origMergeDeps := defaultCIMergeDeps
+
 	t.Cleanup(func() {
 		ciPushDryRunFlag = origDryRun
 		ciPushJSONFlag = origJSON
@@ -65,6 +72,13 @@ func preserveCIPushGlobals(t *testing.T) {
 		ciFixEngineFlag = origFixEngine
 		ciFixJSONFlag = origFixJSON
 		defaultCIFixDeps = origFixDeps
+
+		ciMergeStrategyFlag = origMergeStrategy
+		ciMergeDeleteBranchFlag = origMergeDeleteBranch
+		ciMergeAllowNoChecksFlag = origMergeAllowNoChecks
+		ciMergeDryRunFlag = origMergeDryRun
+		ciMergeJSONFlag = origMergeJSON
+		defaultCIMergeDeps = origMergeDeps
 	})
 }
 
@@ -196,6 +210,60 @@ func TestCICommandMetadataAndFlags(t *testing.T) {
 	}
 	if err := ciFixCmd.Args(ciFixCmd, []string{"unexpected"}); err == nil {
 		t.Fatal("ci fix command should fail on positional arguments")
+	}
+
+	if ciMergeCmd.Use != "merge" {
+		t.Fatalf("ciMergeCmd.Use = %q, want %q", ciMergeCmd.Use, "merge")
+	}
+	if !strings.Contains(ciMergeCmd.Example, "hal ci merge") {
+		t.Fatalf("ciMergeCmd.Example should include command path, got %q", ciMergeCmd.Example)
+	}
+
+	strategyFlag := ciMergeCmd.Flags().Lookup("strategy")
+	if strategyFlag == nil {
+		t.Fatal("ci merge command missing --strategy flag")
+	}
+	if strategyFlag.DefValue != "squash" {
+		t.Fatalf("ci merge --strategy default = %q, want %q", strategyFlag.DefValue, "squash")
+	}
+
+	deleteBranchFlag := ciMergeCmd.Flags().Lookup("delete-branch")
+	if deleteBranchFlag == nil {
+		t.Fatal("ci merge command missing --delete-branch flag")
+	}
+	if deleteBranchFlag.DefValue != "false" {
+		t.Fatalf("ci merge --delete-branch default = %q, want %q", deleteBranchFlag.DefValue, "false")
+	}
+
+	allowNoChecksFlag := ciMergeCmd.Flags().Lookup("allow-no-checks")
+	if allowNoChecksFlag == nil {
+		t.Fatal("ci merge command missing --allow-no-checks flag")
+	}
+	if allowNoChecksFlag.DefValue != "false" {
+		t.Fatalf("ci merge --allow-no-checks default = %q, want %q", allowNoChecksFlag.DefValue, "false")
+	}
+
+	mergeDryRunFlag := ciMergeCmd.Flags().Lookup("dry-run")
+	if mergeDryRunFlag == nil {
+		t.Fatal("ci merge command missing --dry-run flag")
+	}
+	if mergeDryRunFlag.DefValue != "false" {
+		t.Fatalf("ci merge --dry-run default = %q, want %q", mergeDryRunFlag.DefValue, "false")
+	}
+
+	mergeJSONFlag := ciMergeCmd.Flags().Lookup("json")
+	if mergeJSONFlag == nil {
+		t.Fatal("ci merge command missing --json flag")
+	}
+	if mergeJSONFlag.DefValue != "false" {
+		t.Fatalf("ci merge --json default = %q, want %q", mergeJSONFlag.DefValue, "false")
+	}
+
+	if ciMergeCmd.Args == nil {
+		t.Fatal("ci merge command should reject positional arguments")
+	}
+	if err := ciMergeCmd.Args(ciMergeCmd, []string{"unexpected"}); err == nil {
+		t.Fatal("ci merge command should fail on positional arguments")
 	}
 }
 
@@ -738,5 +806,178 @@ func TestRunCIFix_UsesCommandFlagValues(t *testing.T) {
 	}
 	if got.Branch != "hal/from-flags" {
 		t.Fatalf("branch = %q, want %q", got.Branch, "hal/from-flags")
+	}
+}
+
+func TestRunCIMergeWithDeps_JSONOnlyOutput(t *testing.T) {
+	want := ci.MergeResult{
+		ContractVersion: ci.MergeContractVersion,
+		PRNumber:        77,
+		Strategy:        "rebase",
+		DryRun:          false,
+		Merged:          true,
+		MergeCommitSHA:  "deadbeef",
+		BranchDeleted:   true,
+		Summary:         "merged pull request #77 using rebase strategy and deleted the remote branch",
+	}
+
+	var buf bytes.Buffer
+	err := runCIMergeWithDeps(context.Background(), ciMergeRunOptions{Strategy: "rebase", DeleteBranch: true, JSON: true}, &buf, ciMergeDeps{
+		mergePR: func(_ context.Context, opts ci.MergeOptions) (ci.MergeResult, error) {
+			if opts.Strategy != "rebase" {
+				t.Fatalf("opts.Strategy = %q, want %q", opts.Strategy, "rebase")
+			}
+			if !opts.DeleteBranch {
+				t.Fatal("opts.DeleteBranch = false, want true")
+			}
+			return want, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			t.Fatal("currentBranch should not be called when dry-run=false")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIMergeWithDeps() error = %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	if !strings.HasPrefix(output, "{") || !strings.HasSuffix(output, "}") {
+		t.Fatalf("expected JSON-only output, got %q", output)
+	}
+	if strings.Contains(output, "Merge commit:") {
+		t.Fatalf("JSON output should not include human text, got %q", output)
+	}
+
+	var got ci.MergeResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+	if got.ContractVersion != ci.MergeContractVersion {
+		t.Fatalf("contractVersion = %q, want %q", got.ContractVersion, ci.MergeContractVersion)
+	}
+	if got.PRNumber != want.PRNumber {
+		t.Fatalf("prNumber = %d, want %d", got.PRNumber, want.PRNumber)
+	}
+	if got.Strategy != want.Strategy {
+		t.Fatalf("strategy = %q, want %q", got.Strategy, want.Strategy)
+	}
+	if got.MergeCommitSHA != want.MergeCommitSHA {
+		t.Fatalf("mergeCommitSha = %q, want %q", got.MergeCommitSHA, want.MergeCommitSHA)
+	}
+}
+
+func TestRunCIMergeWithDeps_DryRunSkipsSideEffects(t *testing.T) {
+	mergeCalls := 0
+
+	var buf bytes.Buffer
+	err := runCIMergeWithDeps(context.Background(), ciMergeRunOptions{Strategy: "merge", DeleteBranch: true, DryRun: true}, &buf, ciMergeDeps{
+		mergePR: func(context.Context, ci.MergeOptions) (ci.MergeResult, error) {
+			mergeCalls++
+			return ci.MergeResult{}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-merge", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIMergeWithDeps() error = %v", err)
+	}
+	if mergeCalls != 0 {
+		t.Fatalf("mergePR called %d times, want 0 in dry-run", mergeCalls)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "dry-run: would merge pull request for branch hal/ci-merge using merge strategy and delete the remote branch") {
+		t.Fatalf("dry-run output %q missing expected preview text", output)
+	}
+	if strings.Contains(strings.TrimSpace(output), "{") {
+		t.Fatalf("dry-run human output should not be JSON, got %q", output)
+	}
+}
+
+func TestRunCIMerge_UsesCommandFlagValues(t *testing.T) {
+	preserveCIPushGlobals(t)
+
+	ciMergeStrategyFlag = "squash"
+	ciMergeDeleteBranchFlag = false
+	ciMergeAllowNoChecksFlag = false
+	ciMergeDryRunFlag = false
+	ciMergeJSONFlag = false
+
+	mergeCalled := false
+	captured := ci.MergeOptions{}
+	defaultCIMergeDeps = ciMergeDeps{
+		mergePR: func(_ context.Context, opts ci.MergeOptions) (ci.MergeResult, error) {
+			mergeCalled = true
+			captured = opts
+			return ci.MergeResult{
+				ContractVersion: ci.MergeContractVersion,
+				PRNumber:        88,
+				Strategy:        opts.Strategy,
+				DryRun:          false,
+				Merged:          true,
+				MergeCommitSHA:  "cafebabe",
+				BranchDeleted:   opts.DeleteBranch,
+				Summary:         "merged pull request #88",
+			}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/unused", nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "merge"}
+	cmd.SetOut(&out)
+	cmd.Flags().String("strategy", "squash", "")
+	cmd.Flags().Bool("delete-branch", false, "")
+	cmd.Flags().Bool("allow-no-checks", false, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("strategy", "rebase"); err != nil {
+		t.Fatalf("set --strategy: %v", err)
+	}
+	if err := cmd.Flags().Set("delete-branch", "true"); err != nil {
+		t.Fatalf("set --delete-branch: %v", err)
+	}
+	if err := cmd.Flags().Set("allow-no-checks", "true"); err != nil {
+		t.Fatalf("set --allow-no-checks: %v", err)
+	}
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	if err := runCIMerge(cmd, nil); err != nil {
+		t.Fatalf("runCIMerge() error = %v", err)
+	}
+	if !mergeCalled {
+		t.Fatal("runCIMerge should call mergePR when dry-run=false")
+	}
+	if captured.Strategy != "rebase" {
+		t.Fatalf("merge options strategy = %q, want %q", captured.Strategy, "rebase")
+	}
+	if !captured.DeleteBranch {
+		t.Fatal("merge options deleteBranch = false, want true")
+	}
+	if !captured.AllowNoChecks {
+		t.Fatal("merge options allowNoChecks = false, want true")
+	}
+
+	var got ci.MergeResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("runCIMerge JSON output parse failed: %v\noutput: %s", err, out.String())
+	}
+	if got.ContractVersion != ci.MergeContractVersion {
+		t.Fatalf("contractVersion = %q, want %q", got.ContractVersion, ci.MergeContractVersion)
+	}
+	if got.Strategy != "rebase" {
+		t.Fatalf("strategy = %q, want %q", got.Strategy, "rebase")
+	}
+	if got.PRNumber != 88 {
+		t.Fatalf("prNumber = %d, want 88", got.PRNumber)
+	}
+	if got.DryRun {
+		t.Fatal("dryRun = true, want false")
 	}
 }

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -1,0 +1,198 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	ci "github.com/jywlabs/hal/internal/ci"
+	"github.com/spf13/cobra"
+)
+
+func preserveCIPushGlobals(t *testing.T) {
+	t.Helper()
+	origDryRun := ciPushDryRunFlag
+	origJSON := ciPushJSONFlag
+	origDeps := defaultCIPushDeps
+	t.Cleanup(func() {
+		ciPushDryRunFlag = origDryRun
+		ciPushJSONFlag = origJSON
+		defaultCIPushDeps = origDeps
+	})
+}
+
+func TestCIPushCommandMetadataAndFlags(t *testing.T) {
+	if ciCmd.Use != "ci" {
+		t.Fatalf("ciCmd.Use = %q, want %q", ciCmd.Use, "ci")
+	}
+	if ciPushCmd.Use != "push" {
+		t.Fatalf("ciPushCmd.Use = %q, want %q", ciPushCmd.Use, "push")
+	}
+	if strings.TrimSpace(ciCmd.Long) == "" {
+		t.Fatal("ciCmd.Long should not be empty")
+	}
+	if !strings.Contains(ciPushCmd.Example, "hal ci push") {
+		t.Fatalf("ciPushCmd.Example should include command path, got %q", ciPushCmd.Example)
+	}
+
+	dryRun := ciPushCmd.Flags().Lookup("dry-run")
+	if dryRun == nil {
+		t.Fatal("ci push command missing --dry-run flag")
+	}
+	if dryRun.DefValue != "false" {
+		t.Fatalf("--dry-run default = %q, want %q", dryRun.DefValue, "false")
+	}
+
+	jsonFlag := ciPushCmd.Flags().Lookup("json")
+	if jsonFlag == nil {
+		t.Fatal("ci push command missing --json flag")
+	}
+	if jsonFlag.DefValue != "false" {
+		t.Fatalf("--json default = %q, want %q", jsonFlag.DefValue, "false")
+	}
+
+	if ciPushCmd.Args == nil {
+		t.Fatal("ci push command should reject positional arguments")
+	}
+	if err := ciPushCmd.Args(ciPushCmd, []string{"unexpected"}); err == nil {
+		t.Fatal("ci push command should fail on positional arguments")
+	}
+}
+
+func TestRunCIPushWithDeps_JSONOnlyOutput(t *testing.T) {
+	want := ci.PushResult{
+		ContractVersion: ci.PushContractVersion,
+		Branch:          "hal/ci-push",
+		Pushed:          true,
+		DryRun:          false,
+		PullRequest: ci.PullRequest{
+			Number:   42,
+			URL:      "https://github.com/acme/repo/pull/42",
+			Title:    "ci push",
+			HeadRef:  "hal/ci-push",
+			BaseRef:  "main",
+			Draft:    true,
+			Existing: false,
+		},
+		Summary: "pushed branch hal/ci-push and created pull request",
+	}
+
+	var buf bytes.Buffer
+	err := runCIPushWithDeps(context.Background(), ciPushRunOptions{JSON: true}, &buf, ciPushDeps{
+		pushAndCreatePR: func(context.Context, ci.PushOptions) (ci.PushResult, error) {
+			return want, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIPushWithDeps() error = %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	if !strings.HasPrefix(output, "{") || !strings.HasSuffix(output, "}") {
+		t.Fatalf("expected JSON-only output, got %q", output)
+	}
+	if strings.Contains(output, "Pull request:") {
+		t.Fatalf("JSON output should not include human text, got %q", output)
+	}
+
+	var got ci.PushResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+
+	if got.ContractVersion != ci.PushContractVersion {
+		t.Fatalf("contractVersion = %q, want %q", got.ContractVersion, ci.PushContractVersion)
+	}
+	if got.Branch != want.Branch {
+		t.Fatalf("branch = %q, want %q", got.Branch, want.Branch)
+	}
+	if got.PullRequest.URL != want.PullRequest.URL {
+		t.Fatalf("pullRequest.url = %q, want %q", got.PullRequest.URL, want.PullRequest.URL)
+	}
+}
+
+func TestRunCIPushWithDeps_DryRunSkipsSideEffects(t *testing.T) {
+	pushCalls := 0
+
+	var buf bytes.Buffer
+	err := runCIPushWithDeps(context.Background(), ciPushRunOptions{DryRun: true}, &buf, ciPushDeps{
+		pushAndCreatePR: func(context.Context, ci.PushOptions) (ci.PushResult, error) {
+			pushCalls++
+			return ci.PushResult{}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/preview", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIPushWithDeps() error = %v", err)
+	}
+
+	if pushCalls != 0 {
+		t.Fatalf("pushAndCreatePR called %d times, want 0 in dry-run", pushCalls)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Dry run: would push branch hal/preview") {
+		t.Fatalf("dry-run output %q missing expected preview text", output)
+	}
+	if strings.Contains(strings.TrimSpace(output), "{") {
+		t.Fatalf("dry-run human output should not be JSON, got %q", output)
+	}
+}
+
+func TestRunCIPush_UsesCommandFlagValues(t *testing.T) {
+	preserveCIPushGlobals(t)
+
+	ciPushDryRunFlag = false
+	ciPushJSONFlag = false
+
+	pushCalled := false
+	defaultCIPushDeps = ciPushDeps{
+		pushAndCreatePR: func(context.Context, ci.PushOptions) (ci.PushResult, error) {
+			pushCalled = true
+			return ci.PushResult{}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/from-flags", nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "push"}
+	cmd.SetOut(&out)
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("set --dry-run: %v", err)
+	}
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	if err := runCIPush(cmd, nil); err != nil {
+		t.Fatalf("runCIPush() error = %v", err)
+	}
+	if pushCalled {
+		t.Fatal("runCIPush should not call pushAndCreatePR when command dry-run flag is true")
+	}
+
+	var got ci.PushResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("runCIPush JSON output parse failed: %v\noutput: %s", err, out.String())
+	}
+	if !got.DryRun {
+		t.Fatal("got.DryRun = false, want true")
+	}
+	if got.Pushed {
+		t.Fatal("got.Pushed = true, want false for dry-run")
+	}
+	if got.Branch != "hal/from-flags" {
+		t.Fatalf("got.Branch = %q, want %q", got.Branch, "hal/from-flags")
+	}
+}

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -82,6 +82,118 @@ func preserveCIPushGlobals(t *testing.T) {
 	})
 }
 
+func TestCICommandHelpMetadata(t *testing.T) {
+	tests := []struct {
+		name                 string
+		cmd                  *cobra.Command
+		requiredLongPhrases  []string
+		requiredExampleLines []string
+	}{
+		{
+			name: "ci root command",
+			cmd:  ciCmd,
+			requiredLongPhrases: []string{
+				"Run CI-aware workflow commands",
+				"push branches",
+				"merge safely",
+			},
+			requiredExampleLines: []string{
+				"hal ci push",
+				"hal ci status --wait",
+				"hal ci fix --max-attempts 2",
+				"hal ci merge --strategy squash",
+			},
+		},
+		{
+			name: "ci push command",
+			cmd:  ciPushCmd,
+			requiredLongPhrases: []string{
+				"create or reuse an open pull request",
+				"--dry-run",
+				"--json",
+			},
+			requiredExampleLines: []string{
+				"hal ci push",
+				"hal ci push --dry-run",
+				"hal ci push --json",
+			},
+		},
+		{
+			name: "ci status command",
+			cmd:  ciStatusCmd,
+			requiredLongPhrases: []string{
+				"Use --wait",
+				"no checks are detected",
+				"--json",
+			},
+			requiredExampleLines: []string{
+				"hal ci status",
+				"hal ci status --wait",
+				"hal ci status --wait --json",
+			},
+		},
+		{
+			name: "ci fix command",
+			cmd:  ciFixCmd,
+			requiredLongPhrases: []string{
+				"--max-attempts",
+				"single-attempt CI fix core operation",
+				"--json",
+			},
+			requiredExampleLines: []string{
+				"hal ci fix",
+				"hal ci fix --max-attempts 3",
+				"hal ci fix -e claude",
+				"hal ci fix --json",
+			},
+		},
+		{
+			name: "ci merge command",
+			cmd:  ciMergeCmd,
+			requiredLongPhrases: []string{
+				"--allow-no-checks",
+				"--dry-run",
+				"--json",
+			},
+			requiredExampleLines: []string{
+				"hal ci merge",
+				"hal ci merge --strategy rebase",
+				"hal ci merge --delete-branch",
+				"hal ci merge --dry-run --json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cmd == nil {
+				t.Fatal("command is nil")
+			}
+			if missing := missingCommandMetadataFields(tt.cmd); len(missing) > 0 {
+				t.Fatalf("command %q is missing metadata fields: %s", commandPathLabel(tt.cmd), strings.Join(missing, ", "))
+			}
+
+			commandPath := commandPathLabel(tt.cmd)
+			if !strings.Contains(tt.cmd.Example, commandPath) {
+				t.Fatalf("command %q example must include %q, got %q", commandPath, commandPath, tt.cmd.Example)
+			}
+
+			for _, phrase := range tt.requiredLongPhrases {
+				if !strings.Contains(tt.cmd.Long, phrase) {
+					t.Fatalf("command %q long help must include %q, got %q", commandPath, phrase, tt.cmd.Long)
+				}
+			}
+
+			for _, line := range tt.requiredExampleLines {
+				if !strings.Contains(tt.cmd.Example, line) {
+					t.Fatalf("command %q example must include %q, got %q", commandPath, line, tt.cmd.Example)
+				}
+			}
+		})
+	}
+}
+
 func TestCICommandMetadataAndFlags(t *testing.T) {
 	if ciCmd.Use != "ci" {
 		t.Fatalf("ciCmd.Use = %q, want %q", ciCmd.Use, "ci")

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	ci "github.com/jywlabs/hal/internal/ci"
 	"github.com/spf13/cobra"
@@ -15,23 +16,39 @@ func preserveCIPushGlobals(t *testing.T) {
 	t.Helper()
 	origDryRun := ciPushDryRunFlag
 	origJSON := ciPushJSONFlag
-	origDeps := defaultCIPushDeps
+	origPushDeps := defaultCIPushDeps
+
+	origStatusWait := ciStatusWaitFlag
+	origStatusTimeout := ciStatusTimeoutFlag
+	origStatusPollInterval := ciStatusPollIntervalFlag
+	origStatusNoChecksGrace := ciStatusNoChecksGraceFlag
+	origStatusJSON := ciStatusJSONFlag
+	origStatusDeps := defaultCIStatusDeps
+
 	t.Cleanup(func() {
 		ciPushDryRunFlag = origDryRun
 		ciPushJSONFlag = origJSON
-		defaultCIPushDeps = origDeps
+		defaultCIPushDeps = origPushDeps
+
+		ciStatusWaitFlag = origStatusWait
+		ciStatusTimeoutFlag = origStatusTimeout
+		ciStatusPollIntervalFlag = origStatusPollInterval
+		ciStatusNoChecksGraceFlag = origStatusNoChecksGrace
+		ciStatusJSONFlag = origStatusJSON
+		defaultCIStatusDeps = origStatusDeps
 	})
 }
 
-func TestCIPushCommandMetadataAndFlags(t *testing.T) {
+func TestCICommandMetadataAndFlags(t *testing.T) {
 	if ciCmd.Use != "ci" {
 		t.Fatalf("ciCmd.Use = %q, want %q", ciCmd.Use, "ci")
 	}
-	if ciPushCmd.Use != "push" {
-		t.Fatalf("ciPushCmd.Use = %q, want %q", ciPushCmd.Use, "push")
-	}
 	if strings.TrimSpace(ciCmd.Long) == "" {
 		t.Fatal("ciCmd.Long should not be empty")
+	}
+
+	if ciPushCmd.Use != "push" {
+		t.Fatalf("ciPushCmd.Use = %q, want %q", ciPushCmd.Use, "push")
 	}
 	if !strings.Contains(ciPushCmd.Example, "hal ci push") {
 		t.Fatalf("ciPushCmd.Example should include command path, got %q", ciPushCmd.Example)
@@ -42,15 +59,15 @@ func TestCIPushCommandMetadataAndFlags(t *testing.T) {
 		t.Fatal("ci push command missing --dry-run flag")
 	}
 	if dryRun.DefValue != "false" {
-		t.Fatalf("--dry-run default = %q, want %q", dryRun.DefValue, "false")
+		t.Fatalf("ci push --dry-run default = %q, want %q", dryRun.DefValue, "false")
 	}
 
-	jsonFlag := ciPushCmd.Flags().Lookup("json")
-	if jsonFlag == nil {
+	pushJSON := ciPushCmd.Flags().Lookup("json")
+	if pushJSON == nil {
 		t.Fatal("ci push command missing --json flag")
 	}
-	if jsonFlag.DefValue != "false" {
-		t.Fatalf("--json default = %q, want %q", jsonFlag.DefValue, "false")
+	if pushJSON.DefValue != "false" {
+		t.Fatalf("ci push --json default = %q, want %q", pushJSON.DefValue, "false")
 	}
 
 	if ciPushCmd.Args == nil {
@@ -58,6 +75,60 @@ func TestCIPushCommandMetadataAndFlags(t *testing.T) {
 	}
 	if err := ciPushCmd.Args(ciPushCmd, []string{"unexpected"}); err == nil {
 		t.Fatal("ci push command should fail on positional arguments")
+	}
+
+	if ciStatusCmd.Use != "status" {
+		t.Fatalf("ciStatusCmd.Use = %q, want %q", ciStatusCmd.Use, "status")
+	}
+	if !strings.Contains(ciStatusCmd.Example, "hal ci status") {
+		t.Fatalf("ciStatusCmd.Example should include command path, got %q", ciStatusCmd.Example)
+	}
+
+	waitFlag := ciStatusCmd.Flags().Lookup("wait")
+	if waitFlag == nil {
+		t.Fatal("ci status command missing --wait flag")
+	}
+	if waitFlag.DefValue != "false" {
+		t.Fatalf("ci status --wait default = %q, want %q", waitFlag.DefValue, "false")
+	}
+
+	timeoutFlag := ciStatusCmd.Flags().Lookup("timeout")
+	if timeoutFlag == nil {
+		t.Fatal("ci status command missing --timeout flag")
+	}
+	if timeoutFlag.DefValue != "0s" {
+		t.Fatalf("ci status --timeout default = %q, want %q", timeoutFlag.DefValue, "0s")
+	}
+
+	pollFlag := ciStatusCmd.Flags().Lookup("poll-interval")
+	if pollFlag == nil {
+		t.Fatal("ci status command missing --poll-interval flag")
+	}
+	if pollFlag.DefValue != "0s" {
+		t.Fatalf("ci status --poll-interval default = %q, want %q", pollFlag.DefValue, "0s")
+	}
+
+	noChecksFlag := ciStatusCmd.Flags().Lookup("no-checks-grace")
+	if noChecksFlag == nil {
+		t.Fatal("ci status command missing --no-checks-grace flag")
+	}
+	if noChecksFlag.DefValue != "0s" {
+		t.Fatalf("ci status --no-checks-grace default = %q, want %q", noChecksFlag.DefValue, "0s")
+	}
+
+	statusJSON := ciStatusCmd.Flags().Lookup("json")
+	if statusJSON == nil {
+		t.Fatal("ci status command missing --json flag")
+	}
+	if statusJSON.DefValue != "false" {
+		t.Fatalf("ci status --json default = %q, want %q", statusJSON.DefValue, "false")
+	}
+
+	if ciStatusCmd.Args == nil {
+		t.Fatal("ci status command should reject positional arguments")
+	}
+	if err := ciStatusCmd.Args(ciStatusCmd, []string{"unexpected"}); err == nil {
+		t.Fatal("ci status command should fail on positional arguments")
 	}
 }
 
@@ -191,6 +262,148 @@ func TestRunCIPush_UsesCommandFlagValues(t *testing.T) {
 	}
 	if got.Pushed {
 		t.Fatal("got.Pushed = true, want false for dry-run")
+	}
+	if got.Branch != "hal/from-flags" {
+		t.Fatalf("got.Branch = %q, want %q", got.Branch, "hal/from-flags")
+	}
+}
+
+func TestRunCIStatusWithDeps_JSONOnlyOutput(t *testing.T) {
+	want := ci.StatusResult{
+		ContractVersion:    ci.StatusContractVersion,
+		Branch:             "hal/ci-status",
+		SHA:                "deadbeef",
+		Status:             ci.StatusPending,
+		ChecksDiscovered:   false,
+		Wait:               true,
+		WaitTerminalReason: ci.WaitTerminalReasonNoChecksDetected,
+		Checks:             []ci.StatusCheck{},
+		Totals:             ci.StatusTotals{},
+		Summary:            "no CI contexts discovered; status pending",
+	}
+
+	var buf bytes.Buffer
+	err := runCIStatusWithDeps(context.Background(), ciStatusRunOptions{Wait: true, JSON: true}, &buf, ciStatusDeps{
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			t.Fatal("getStatus should not be called when wait=true")
+			return ci.StatusResult{}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			return want, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIStatusWithDeps() error = %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	if !strings.HasPrefix(output, "{") || !strings.HasSuffix(output, "}") {
+		t.Fatalf("expected JSON-only output, got %q", output)
+	}
+	if strings.Contains(output, "Wait terminal reason:") {
+		t.Fatalf("JSON output should not include human text, got %q", output)
+	}
+
+	var got ci.StatusResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+
+	if got.ContractVersion != ci.StatusContractVersion {
+		t.Fatalf("contractVersion = %q, want %q", got.ContractVersion, ci.StatusContractVersion)
+	}
+	if got.WaitTerminalReason != ci.WaitTerminalReasonNoChecksDetected {
+		t.Fatalf("waitTerminalReason = %q, want %q", got.WaitTerminalReason, ci.WaitTerminalReasonNoChecksDetected)
+	}
+	if !got.Wait {
+		t.Fatal("wait = false, want true")
+	}
+}
+
+func TestRunCIStatus_UsesCommandFlagValues(t *testing.T) {
+	preserveCIPushGlobals(t)
+
+	ciStatusWaitFlag = false
+	ciStatusTimeoutFlag = 0
+	ciStatusPollIntervalFlag = 0
+	ciStatusNoChecksGraceFlag = 0
+	ciStatusJSONFlag = false
+
+	getCalled := false
+	waitCalled := false
+	capturedOpts := ci.WaitOptions{}
+	defaultCIStatusDeps = ciStatusDeps{
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			getCalled = true
+			return ci.StatusResult{}, nil
+		},
+		waitForChecks: func(_ context.Context, opts ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalled = true
+			capturedOpts = opts
+			return ci.StatusResult{
+				ContractVersion:    ci.StatusContractVersion,
+				Branch:             "hal/from-flags",
+				Status:             ci.StatusPending,
+				ChecksDiscovered:   false,
+				Wait:               true,
+				WaitTerminalReason: ci.WaitTerminalReasonNoChecksDetected,
+				Summary:            "no CI contexts discovered; status pending",
+			}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetOut(&out)
+	cmd.Flags().Bool("wait", false, "")
+	cmd.Flags().Duration("timeout", 0, "")
+	cmd.Flags().Duration("poll-interval", 0, "")
+	cmd.Flags().Duration("no-checks-grace", 0, "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("wait", "true"); err != nil {
+		t.Fatalf("set --wait: %v", err)
+	}
+	if err := cmd.Flags().Set("timeout", "2m"); err != nil {
+		t.Fatalf("set --timeout: %v", err)
+	}
+	if err := cmd.Flags().Set("poll-interval", "5s"); err != nil {
+		t.Fatalf("set --poll-interval: %v", err)
+	}
+	if err := cmd.Flags().Set("no-checks-grace", "45s"); err != nil {
+		t.Fatalf("set --no-checks-grace: %v", err)
+	}
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	if err := runCIStatus(cmd, nil); err != nil {
+		t.Fatalf("runCIStatus() error = %v", err)
+	}
+	if getCalled {
+		t.Fatal("runCIStatus should not call getStatus when command wait flag is true")
+	}
+	if !waitCalled {
+		t.Fatal("runCIStatus should call waitForChecks when command wait flag is true")
+	}
+	if capturedOpts.Timeout != 2*time.Minute {
+		t.Fatalf("wait timeout = %s, want %s", capturedOpts.Timeout, 2*time.Minute)
+	}
+	if capturedOpts.PollInterval != 5*time.Second {
+		t.Fatalf("wait poll interval = %s, want %s", capturedOpts.PollInterval, 5*time.Second)
+	}
+	if capturedOpts.NoChecksGrace != 45*time.Second {
+		t.Fatalf("wait no-checks grace = %s, want %s", capturedOpts.NoChecksGrace, 45*time.Second)
+	}
+
+	var got ci.StatusResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("runCIStatus JSON output parse failed: %v\noutput: %s", err, out.String())
+	}
+	if !got.Wait {
+		t.Fatal("got.Wait = false, want true")
+	}
+	if got.WaitTerminalReason != ci.WaitTerminalReasonNoChecksDetected {
+		t.Fatalf("got.WaitTerminalReason = %q, want %q", got.WaitTerminalReason, ci.WaitTerminalReasonNoChecksDetected)
 	}
 	if got.Branch != "hal/from-flags" {
 		t.Fatalf("got.Branch = %q, want %q", got.Branch, "hal/from-flags")

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -1379,6 +1380,30 @@ func TestRunCIMergeWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 	}
 	if strings.Contains(strings.TrimSpace(output), "{") {
 		t.Fatalf("dry-run human output should not be JSON, got %q", output)
+	}
+}
+
+func TestRunCIMergeWithDeps_DryRunRequiresOpenPR(t *testing.T) {
+	mergeCalls := 0
+
+	var buf bytes.Buffer
+	err := runCIMergeWithDeps(context.Background(), ciMergeRunOptions{Strategy: "merge", DryRun: true}, &buf, ciMergeDeps{
+		mergePR: func(context.Context, ci.MergeOptions) (ci.MergeResult, error) {
+			mergeCalls++
+			return ci.MergeResult{}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-merge", nil
+		},
+		findOpenPR: func(context.Context, string) (*ci.PullRequest, error) {
+			return nil, nil
+		},
+	})
+	if !errors.Is(err, ci.ErrMergePRNotFound) {
+		t.Fatalf("errors.Is(err, ci.ErrMergePRNotFound) = false, err=%v", err)
+	}
+	if mergeCalls != 0 {
+		t.Fatalf("mergePR called %d times, want 0 when open pull request is missing", mergeCalls)
 	}
 }
 

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -458,8 +458,17 @@ func TestRunCIPushWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "Dry run: would push branch hal/preview") {
+	if !strings.Contains(output, "CI Push (dry run)") {
+		t.Fatalf("dry-run output %q missing title", output)
+	}
+	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "hal/preview") {
+		t.Fatalf("dry-run output %q missing branch details", output)
+	}
+	if !strings.Contains(output, "Would push branch and create or reuse a pull request.") {
 		t.Fatalf("dry-run output %q missing expected preview text", output)
+	}
+	if strings.Contains(output, "dry-run: would push branch") {
+		t.Fatalf("dry-run output %q should use fixed human copy, not summary text", output)
 	}
 	if strings.Contains(strings.TrimSpace(output), "{") {
 		t.Fatalf("dry-run human output should not be JSON, got %q", output)
@@ -656,6 +665,51 @@ func TestRunCIStatus_UsesCommandFlagValues(t *testing.T) {
 	}
 	if got.Branch != "hal/from-flags" {
 		t.Fatalf("got.Branch = %q, want %q", got.Branch, "hal/from-flags")
+	}
+}
+
+func TestRunCIStatusWithDeps_WaitRendersChecksWhenDiscovered(t *testing.T) {
+	want := ci.StatusResult{
+		ContractVersion:    ci.StatusContractVersion,
+		Branch:             "hal/ci-status",
+		SHA:                "deadbeefcafebabe",
+		Status:             ci.StatusPassing,
+		ChecksDiscovered:   true,
+		Wait:               true,
+		WaitTerminalReason: ci.WaitTerminalReasonCompleted,
+		Checks: []ci.StatusCheck{
+			{Key: "check:tests", Name: "tests", Status: ci.StatusPassing},
+			{Key: "status:lint", Name: "lint", Status: ci.StatusFailing},
+		},
+		Totals: ci.StatusTotals{Passing: 1, Failing: 1},
+	}
+
+	var buf bytes.Buffer
+	err := runCIStatusWithDeps(context.Background(), ciStatusRunOptions{Wait: true}, &buf, ciStatusDeps{
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			t.Fatal("getStatus should not be called when wait=true")
+			return ci.StatusResult{}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			return want, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIStatusWithDeps() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Wait:") || !strings.Contains(output, ci.WaitTerminalReasonCompleted) {
+		t.Fatalf("wait output %q missing terminal reason", output)
+	}
+	if !strings.Contains(output, "Checks:") {
+		t.Fatalf("wait output %q missing checks section", output)
+	}
+	if !strings.Contains(output, "tests") || !strings.Contains(output, "lint") {
+		t.Fatalf("wait output %q missing check names", output)
+	}
+	if !strings.Contains(output, "Totals:") || !strings.Contains(output, "1 passing") || !strings.Contains(output, "1 failing") {
+		t.Fatalf("wait output %q missing totals", output)
 	}
 }
 
@@ -1207,11 +1261,59 @@ func TestRunCIMergeWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "dry-run: would merge pull request for branch hal/ci-merge using merge strategy and delete the remote branch") {
+	if !strings.Contains(output, "CI Merge (dry run)") {
+		t.Fatalf("dry-run output %q missing title", output)
+	}
+	if !strings.Contains(output, "Strategy:") || !strings.Contains(output, "merge") {
+		t.Fatalf("dry-run output %q missing strategy", output)
+	}
+	if !strings.Contains(output, "Would merge pull request and delete the remote branch.") {
 		t.Fatalf("dry-run output %q missing expected preview text", output)
+	}
+	if strings.Contains(output, "dry-run: would merge pull request for branch") {
+		t.Fatalf("dry-run output %q should use fixed human copy, not summary text", output)
 	}
 	if strings.Contains(strings.TrimSpace(output), "{") {
 		t.Fatalf("dry-run human output should not be JSON, got %q", output)
+	}
+}
+
+func TestRunCIMergeWithDeps_HumanOutputShowsBranchAlreadyAbsent(t *testing.T) {
+	var buf bytes.Buffer
+	err := runCIMergeWithDeps(context.Background(), ciMergeRunOptions{Strategy: "squash", DeleteBranch: true}, &buf, ciMergeDeps{
+		mergePR: func(context.Context, ci.MergeOptions) (ci.MergeResult, error) {
+			return ci.MergeResult{
+				ContractVersion: ci.MergeContractVersion,
+				PRNumber:        42,
+				Strategy:        "squash",
+				Merged:          true,
+				MergeCommitSHA:  "deadbeef",
+				BranchDeleted:   false,
+				DeleteWarning:   "",
+				Summary:         "merged pull request #42 using squash strategy; remote branch already absent",
+			}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			t.Fatal("currentBranch should not be called when dry-run=false")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIMergeWithDeps() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CI Merge") {
+		t.Fatalf("human output %q missing title", output)
+	}
+	if !strings.Contains(output, "PR:") || !strings.Contains(output, "#42") {
+		t.Fatalf("human output %q missing PR details", output)
+	}
+	if !strings.Contains(output, "Commit:") || !strings.Contains(output, "deadbee") {
+		t.Fatalf("human output %q missing shortened commit sha", output)
+	}
+	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "Already absent") {
+		t.Fatalf("human output %q missing already-absent branch outcome", output)
 	}
 }
 

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -737,6 +739,131 @@ func TestRunCIFixWithDeps_JSONOnlyOutput(t *testing.T) {
 	}
 }
 
+func TestRunCIFixWithDeps_ReturnsLastFixResultWhenStatusClearsBeforeNextAttempt(t *testing.T) {
+	want := ci.FixResult{
+		ContractVersion: ci.FixContractVersion,
+		Attempt:         1,
+		MaxAttempts:     3,
+		Applied:         true,
+		Branch:          "hal/ci-fix",
+		CommitSHA:       "deadbeef",
+		Pushed:          true,
+		FilesChanged:    []string{"cmd/ci.go"},
+		Summary:         "applied ci fix attempt 1 on branch hal/ci-fix and pushed 1 file",
+	}
+
+	statusCalls := 0
+	newEngineCalls := 0
+	fixCalls := 0
+	waitCalls := 0
+
+	var buf bytes.Buffer
+	err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 3, Engine: "codex", JSON: true}, &buf, ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			newEngineCalls++
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			statusCalls++
+			if statusCalls == 1 {
+				return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+			}
+			return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/ci-fix"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalls++
+			return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+		},
+		fixWithEngine: func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error) {
+			fixCalls++
+			return want, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIFixWithDeps() error = %v", err)
+	}
+	if statusCalls != 2 {
+		t.Fatalf("getStatus calls = %d, want 2", statusCalls)
+	}
+	if newEngineCalls != 1 {
+		t.Fatalf("newEngine calls = %d, want 1", newEngineCalls)
+	}
+	if fixCalls != 1 {
+		t.Fatalf("fixWithEngine calls = %d, want 1", fixCalls)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("waitForChecks calls = %d, want 1", waitCalls)
+	}
+
+	var got ci.FixResult
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal JSON output: %v", err)
+	}
+	if got.Attempt != want.Attempt {
+		t.Fatalf("attempt = %d, want %d", got.Attempt, want.Attempt)
+	}
+	if !got.Applied {
+		t.Fatal("applied = false, want true")
+	}
+	if got.CommitSHA != want.CommitSHA {
+		t.Fatalf("commitSha = %q, want %q", got.CommitSHA, want.CommitSHA)
+	}
+	if got.Summary != want.Summary {
+		t.Fatalf("summary = %q, want %q", got.Summary, want.Summary)
+	}
+}
+
+func TestRunCIFixWithDeps_ReturnsErrorWhenStatusPendingBeforeNextAttempt(t *testing.T) {
+	statusCalls := 0
+	fixCalls := 0
+	waitCalls := 0
+
+	err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 3, Engine: "codex"}, io.Discard, ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			statusCalls++
+			if statusCalls == 1 {
+				return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+			}
+			return ci.StatusResult{Status: ci.StatusPending, Branch: "hal/ci-fix"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			waitCalls++
+			return ci.StatusResult{Status: ci.StatusFailing, Branch: "hal/ci-fix"}, nil
+		},
+		fixWithEngine: func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error) {
+			fixCalls++
+			return ci.FixResult{
+				ContractVersion: ci.FixContractVersion,
+				Attempt:         1,
+				MaxAttempts:     3,
+				Applied:         true,
+				Branch:          "hal/ci-fix",
+				Pushed:          true,
+				Summary:         "attempt",
+			}, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("runCIFixWithDeps() error = nil, want pending-status error")
+	}
+	wantErr := "ci status is pending after attempt 1; run 'hal ci status --wait' for details"
+	if err.Error() != wantErr {
+		t.Fatalf("error = %q, want %q", err.Error(), wantErr)
+	}
+	if statusCalls != 2 {
+		t.Fatalf("getStatus calls = %d, want 2", statusCalls)
+	}
+	if fixCalls != 1 {
+		t.Fatalf("fixWithEngine calls = %d, want 1", fixCalls)
+	}
+	if waitCalls != 1 {
+		t.Fatalf("waitForChecks calls = %d, want 1", waitCalls)
+	}
+}
+
 func TestRunCIFixWithDeps_StopsWithoutAttemptWhenStatusNotFailing(t *testing.T) {
 	newEngineCalled := false
 	fixCalled := false
@@ -918,6 +1045,86 @@ func TestRunCIFix_UsesCommandFlagValues(t *testing.T) {
 	}
 	if got.Branch != "hal/from-flags" {
 		t.Fatalf("branch = %q, want %q", got.Branch, "hal/from-flags")
+	}
+}
+
+func TestRunCIFix_DefersEngineResolutionWhenStatusNotFailing(t *testing.T) {
+	preserveCIPushGlobals(t)
+
+	ciFixMaxAttemptsFlag = 3
+	ciFixEngineFlag = "codex"
+	ciFixJSONFlag = true
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir temp dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	halDir := filepath.Join(tmpDir, ".hal")
+	if err := os.MkdirAll(halDir, 0o755); err != nil {
+		t.Fatalf("mkdir .hal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(halDir, "config.yaml"), []byte("engine: ["), 0o644); err != nil {
+		t.Fatalf("write malformed config: %v", err)
+	}
+
+	newEngineCalled := false
+	statusCalls := 0
+	defaultCIFixDeps = ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			newEngineCalled = true
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			statusCalls++
+			return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/noop"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			t.Fatal("waitForChecks should not be called when status is not failing")
+			return ci.StatusResult{}, nil
+		},
+		fixWithEngine: func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error) {
+			t.Fatal("fixWithEngine should not be called when status is not failing")
+			return ci.FixResult{}, nil
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "fix"}
+	cmd.SetOut(&out)
+	cmd.Flags().Int("max-attempts", 3, "")
+	cmd.Flags().String("engine", "codex", "")
+	cmd.Flags().Bool("json", false, "")
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+
+	if err := runCIFix(cmd, nil); err != nil {
+		t.Fatalf("runCIFix() error = %v", err)
+	}
+	if statusCalls != 1 {
+		t.Fatalf("getStatus calls = %d, want 1", statusCalls)
+	}
+	if newEngineCalled {
+		t.Fatal("newEngine should not be called when status is not failing")
+	}
+
+	var got ci.FixResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("runCIFix JSON output parse failed: %v\noutput: %s", err, out.String())
+	}
+	if got.Attempt != 0 {
+		t.Fatalf("attempt = %d, want 0", got.Attempt)
+	}
+	if !strings.Contains(got.Summary, "no fix attempt needed") {
+		t.Fatalf("summary = %q, want no-attempt text", got.Summary)
 	}
 }
 

--- a/cmd/ci_test.go
+++ b/cmd/ci_test.go
@@ -464,6 +464,9 @@ func TestRunCIPushWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "hal/preview") {
 		t.Fatalf("dry-run output %q missing branch details", output)
 	}
+	if !strings.Contains(output, "PR:") || !strings.Contains(output, "draft pull request") {
+		t.Fatalf("dry-run output %q missing pull request mode", output)
+	}
 	if !strings.Contains(output, "Would push branch and create or reuse a pull request.") {
 		t.Fatalf("dry-run output %q missing expected preview text", output)
 	}
@@ -472,6 +475,49 @@ func TestRunCIPushWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 	}
 	if strings.Contains(strings.TrimSpace(output), "{") {
 		t.Fatalf("dry-run human output should not be JSON, got %q", output)
+	}
+}
+
+func TestRunCIPushWithDeps_HumanOutputIncludesBaseBranch(t *testing.T) {
+	var buf bytes.Buffer
+	err := runCIPushWithDeps(context.Background(), ciPushRunOptions{}, &buf, ciPushDeps{
+		pushAndCreatePR: func(context.Context, ci.PushOptions) (ci.PushResult, error) {
+			return ci.PushResult{
+				ContractVersion: ci.PushContractVersion,
+				Branch:          "hal/ci-push",
+				Pushed:          true,
+				DryRun:          false,
+				PullRequest: ci.PullRequest{
+					Number:   7,
+					URL:      "https://github.com/acme/repo/pull/7",
+					BaseRef:  "main",
+					Draft:    false,
+					Existing: true,
+				},
+				Summary: "pushed branch hal/ci-push and reused existing pull request",
+			}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			t.Fatal("currentBranch should not be called when dry-run=false")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIPushWithDeps() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CI Push") {
+		t.Fatalf("human output %q missing title", output)
+	}
+	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "hal/ci-push") {
+		t.Fatalf("human output %q missing branch", output)
+	}
+	if !strings.Contains(output, "Base:") || !strings.Contains(output, "main") {
+		t.Fatalf("human output %q missing base branch", output)
+	}
+	if !strings.Contains(output, "PR #7:") || !strings.Contains(output, "https://github.com/acme/repo/pull/7") {
+		t.Fatalf("human output %q missing PR URL", output)
 	}
 }
 
@@ -969,6 +1015,49 @@ func TestRunCIFixWithDeps_StopsWithoutAttemptWhenStatusNotFailing(t *testing.T) 
 	}
 }
 
+func TestRunCIFixWithDeps_HumanOutputIncludesBranchWhenNoAttemptNeeded(t *testing.T) {
+	newEngineCalled := false
+
+	var buf bytes.Buffer
+	err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 3, Engine: "codex"}, &buf, ciFixDeps{
+		newEngine: func(string) (engine.Engine, error) {
+			newEngineCalled = true
+			return ciFakeEngine{}, nil
+		},
+		getStatus: func(context.Context) (ci.StatusResult, error) {
+			return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/ci-fix"}, nil
+		},
+		waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+			t.Fatal("waitForChecks should not be called when no attempt is made")
+			return ci.StatusResult{}, nil
+		},
+		fixWithEngine: func(context.Context, ci.StatusResult, ci.FixOptions) (ci.FixResult, error) {
+			t.Fatal("fixWithEngine should not be called when no attempt is made")
+			return ci.FixResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runCIFixWithDeps() error = %v", err)
+	}
+	if newEngineCalled {
+		t.Fatal("newEngine should not be called when status is not failing")
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "CI Fix") {
+		t.Fatalf("human output %q missing title", output)
+	}
+	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "hal/ci-fix") {
+		t.Fatalf("human output %q missing branch", output)
+	}
+	if !strings.Contains(output, "Status:") || !strings.Contains(output, "no fix attempt needed") {
+		t.Fatalf("human output %q missing no-attempt status", output)
+	}
+	if strings.Contains(strings.TrimSpace(output), "{") {
+		t.Fatalf("human output should not be JSON, got %q", output)
+	}
+}
+
 func TestRunCIFixWithDeps_StopsAtMaxAttempts(t *testing.T) {
 	fixAttempts := make([]int, 0, 2)
 	waitCalls := 0
@@ -1252,6 +1341,9 @@ func TestRunCIMergeWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 		currentBranch: func(context.Context) (string, error) {
 			return "hal/ci-merge", nil
 		},
+		findOpenPR: func(context.Context, string) (*ci.PullRequest, error) {
+			return &ci.PullRequest{Number: 21, BaseRef: "main"}, nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("runCIMergeWithDeps() error = %v", err)
@@ -1264,8 +1356,20 @@ func TestRunCIMergeWithDeps_DryRunSkipsSideEffects(t *testing.T) {
 	if !strings.Contains(output, "CI Merge (dry run)") {
 		t.Fatalf("dry-run output %q missing title", output)
 	}
+	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "hal/ci-merge") {
+		t.Fatalf("dry-run output %q missing branch", output)
+	}
+	if !strings.Contains(output, "PR:") || !strings.Contains(output, "#21") {
+		t.Fatalf("dry-run output %q missing PR details", output)
+	}
+	if !strings.Contains(output, "Base:") || !strings.Contains(output, "main") {
+		t.Fatalf("dry-run output %q missing base branch", output)
+	}
 	if !strings.Contains(output, "Strategy:") || !strings.Contains(output, "merge") {
 		t.Fatalf("dry-run output %q missing strategy", output)
+	}
+	if !strings.Contains(output, "Delete:") || !strings.Contains(output, "Yes") {
+		t.Fatalf("dry-run output %q missing delete intent", output)
 	}
 	if !strings.Contains(output, "Would merge pull request and delete the remote branch.") {
 		t.Fatalf("dry-run output %q missing expected preview text", output)
@@ -1294,8 +1398,10 @@ func TestRunCIMergeWithDeps_HumanOutputShowsBranchAlreadyAbsent(t *testing.T) {
 			}, nil
 		},
 		currentBranch: func(context.Context) (string, error) {
-			t.Fatal("currentBranch should not be called when dry-run=false")
-			return "", nil
+			return "hal/ci-merge", nil
+		},
+		findOpenPR: func(context.Context, string) (*ci.PullRequest, error) {
+			return &ci.PullRequest{Number: 42, BaseRef: "main"}, nil
 		},
 	})
 	if err != nil {
@@ -1306,8 +1412,14 @@ func TestRunCIMergeWithDeps_HumanOutputShowsBranchAlreadyAbsent(t *testing.T) {
 	if !strings.Contains(output, "CI Merge") {
 		t.Fatalf("human output %q missing title", output)
 	}
+	if !strings.Contains(output, "Branch:") || !strings.Contains(output, "hal/ci-merge") {
+		t.Fatalf("human output %q missing source branch", output)
+	}
 	if !strings.Contains(output, "PR:") || !strings.Contains(output, "#42") {
 		t.Fatalf("human output %q missing PR details", output)
+	}
+	if !strings.Contains(output, "Base:") || !strings.Contains(output, "main") {
+		t.Fatalf("human output %q missing base branch", output)
 	}
 	if !strings.Contains(output, "Commit:") || !strings.Contains(output, "deadbee") {
 		t.Fatalf("human output %q missing shortened commit sha", output)

--- a/cmd/continue.go
+++ b/cmd/continue.go
@@ -17,8 +17,8 @@ var continueJSONFlag bool
 
 // ContinueResult is the machine-readable output of hal continue --json.
 type ContinueResult struct {
-	ContractVersion int                `json:"contractVersion"`
-	Ready           bool               `json:"ready"`
+	ContractVersion int                 `json:"contractVersion"`
+	Ready           bool                `json:"ready"`
 	Status          status.StatusResult `json:"status"`
 	Doctor          doctor.DoctorResult `json:"doctor"`
 	NextCommand     string              `json:"nextCommand"`
@@ -80,18 +80,19 @@ func runContinueFn(dir string, jsonMode bool, out io.Writer) error {
 		Engine: engine,
 	})
 
-	// Determine what to do: doctor issues take priority over workflow actions
-	ready := doctorResult.OverallStatus == doctor.StatusPass
+	// Determine what to do: only doctor failures should block workflow progress.
+	hasDoctorFailures := doctorResult.OverallStatus == doctor.StatusFail || len(doctorResult.Failures) > 0
+	ready := !hasDoctorFailures
 	nextCmd := statusResult.NextAction.Command
 	nextDesc := statusResult.NextAction.Description
 
-	if !ready && doctorResult.PrimaryRemediation != nil {
+	if hasDoctorFailures && doctorResult.PrimaryRemediation != nil {
 		nextCmd = doctorResult.PrimaryRemediation.Command
 		nextDesc = "Fix environment issues first: " + doctorResult.Summary
 	}
 
 	summary := statusResult.Summary
-	if !ready {
+	if hasDoctorFailures {
 		summary = doctorResult.Summary + " " + statusResult.Summary
 	}
 

--- a/cmd/continue_test.go
+++ b/cmd/continue_test.go
@@ -181,8 +181,8 @@ func TestRunContinueFn_JSONContainsBothStatusAndDoctor(t *testing.T) {
 
 func TestRunContinueFn_ReadyField(t *testing.T) {
 	tests := []struct {
-		name     string
-		setup    func(string)
+		name      string
+		setup     func(string)
 		wantReady bool
 	}{
 		{
@@ -233,6 +233,49 @@ func TestRunContinueFn_ReadyField(t *testing.T) {
 				t.Fatalf("ready = %v, want %v", result.Ready, tt.wantReady)
 			}
 		})
+	}
+}
+
+func TestRunContinueFn_WarningsDoNotBlockReadiness(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
+	halDir := filepath.Join(dir, template.HalDir)
+	os.MkdirAll(halDir, 0755)
+
+	// Intentionally omit .hal/config.yaml to trigger a warning-only doctor result.
+	os.WriteFile(filepath.Join(halDir, template.PromptFile), []byte("# Agent\n"), 0644)
+	os.WriteFile(filepath.Join(halDir, template.ProgressFile), []byte("## Patterns\n"), 0644)
+
+	for _, name := range skills.ManagedSkillNames {
+		os.MkdirAll(filepath.Join(halDir, "skills", name), 0755)
+		os.WriteFile(filepath.Join(halDir, "skills", name, "SKILL.md"), []byte("# "+name), 0644)
+	}
+	commandsDir := filepath.Join(halDir, template.CommandsDir)
+	os.MkdirAll(commandsDir, 0755)
+	for _, name := range skills.CommandNames {
+		os.WriteFile(filepath.Join(commandsDir, name+".md"), []byte("# "+name), 0644)
+	}
+
+	var buf bytes.Buffer
+	if err := runContinueFn(dir, true, &buf); err != nil {
+		t.Fatalf("runContinueFn() error = %v", err)
+	}
+
+	var result ContinueResult
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("JSON unmarshal error: %v\noutput: %s", err, buf.String())
+	}
+
+	if result.Doctor.OverallStatus != "warn" {
+		t.Fatalf("doctor.overallStatus = %q, want %q", result.Doctor.OverallStatus, "warn")
+	}
+	if !result.Ready {
+		t.Fatal("ready = false, want true when doctor only has warnings")
+	}
+	if result.NextCommand != result.Status.NextAction.Command {
+		t.Fatalf("nextCommand = %q, want workflow next action %q", result.NextCommand, result.Status.NextAction.Command)
 	}
 }
 

--- a/cmd/contracts_doc_test.go
+++ b/cmd/contracts_doc_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jywlabs/hal/internal/ci"
 	"github.com/jywlabs/hal/internal/doctor"
 	"github.com/jywlabs/hal/internal/status"
 	"github.com/jywlabs/hal/internal/template"
@@ -24,6 +25,10 @@ func TestContractDocsExist(t *testing.T) {
 		{"doctor-v1", "../docs/contracts/doctor-v1.md"},
 		{"continue-v1", "../docs/contracts/continue-v1.md"},
 		{"sandbox-list-v1", "../docs/contracts/sandbox-list-v1.md"},
+		{"ci-push-v1", "../docs/contracts/ci-push-v1.md"},
+		{"ci-status-v1", "../docs/contracts/ci-status-v1.md"},
+		{"ci-fix-v1", "../docs/contracts/ci-fix-v1.md"},
+		{"ci-merge-v1", "../docs/contracts/ci-merge-v1.md"},
 	}
 
 	for _, doc := range requiredDocs {
@@ -137,5 +142,86 @@ func TestContractDocsIncludeCheckIDs(t *testing.T) {
 		if !strings.Contains(content, check.ID) {
 			t.Errorf("doctor-v1.md missing check ID %q", check.ID)
 		}
+	}
+}
+
+func TestContractDocsIncludeCIFields(t *testing.T) {
+	docs := []struct {
+		name           string
+		path           string
+		contractValue  string
+		requiredFields []string
+		requiredValues []string
+	}{
+		{
+			name:          "ci-push-v1",
+			path:          "../docs/contracts/ci-push-v1.md",
+			contractValue: ci.PushContractVersion,
+			requiredFields: []string{
+				"contractVersion", "branch", "pushed", "dryRun", "pullRequest", "summary",
+				"number", "url", "title", "headRef", "headSha", "baseRef", "draft", "existing",
+			},
+		},
+		{
+			name:          "ci-status-v1",
+			path:          "../docs/contracts/ci-status-v1.md",
+			contractValue: ci.StatusContractVersion,
+			requiredFields: []string{
+				"contractVersion", "branch", "sha", "status", "checksDiscovered", "wait", "waitTerminalReason", "checks", "totals", "summary",
+				"key", "source", "name", "url", "pending", "failing", "passing",
+			},
+			requiredValues: []string{
+				ci.StatusPending,
+				ci.StatusFailing,
+				ci.StatusPassing,
+				ci.WaitTerminalReasonCompleted,
+				ci.WaitTerminalReasonTimeout,
+				ci.WaitTerminalReasonNoChecksDetected,
+				ci.CheckSourceCheckRun,
+				ci.CheckSourceStatus,
+			},
+		},
+		{
+			name:          "ci-fix-v1",
+			path:          "../docs/contracts/ci-fix-v1.md",
+			contractValue: ci.FixContractVersion,
+			requiredFields: []string{
+				"contractVersion", "attempt", "maxAttempts", "applied", "branch", "commitSha", "pushed", "filesChanged", "summary",
+			},
+		},
+		{
+			name:          "ci-merge-v1",
+			path:          "../docs/contracts/ci-merge-v1.md",
+			contractValue: ci.MergeContractVersion,
+			requiredFields: []string{
+				"contractVersion", "prNumber", "strategy", "dryRun", "merged", "mergeCommitSha", "branchDeleted", "deleteWarning", "summary",
+			},
+		},
+	}
+
+	for _, doc := range docs {
+		t.Run(doc.name, func(t *testing.T) {
+			data, err := os.ReadFile(doc.path)
+			if err != nil {
+				t.Fatalf("cannot read %s: %v", doc.path, err)
+			}
+			content := string(data)
+
+			if !strings.Contains(content, doc.contractValue) {
+				t.Errorf("%s missing contract value %q", doc.name, doc.contractValue)
+			}
+
+			for _, field := range doc.requiredFields {
+				if !strings.Contains(content, "`"+field+"`") {
+					t.Errorf("%s missing field %q", doc.name, field)
+				}
+			}
+
+			for _, value := range doc.requiredValues {
+				if !strings.Contains(content, value) {
+					t.Errorf("%s missing value %q", doc.name, value)
+				}
+			}
+		})
 	}
 }

--- a/cmd/contracts_doc_test.go
+++ b/cmd/contracts_doc_test.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jywlabs/hal/internal/doctor"
 	"github.com/jywlabs/hal/internal/status"
+	"github.com/jywlabs/hal/internal/template"
 )
 
 // TestContractDocsExist verifies that contract documentation exists for
@@ -119,9 +121,17 @@ func TestContractDocsIncludeCheckIDs(t *testing.T) {
 	}
 	content := string(data)
 
-	// Run doctor to get check IDs
+	// Run doctor in a repo with .hal present so all checks are emitted.
 	dir := t.TempDir()
-	result := doctor.Run(doctor.Options{Dir: dir, Engine: "codex"})
+	halDir := filepath.Join(dir, template.HalDir)
+	if err := os.MkdirAll(halDir, 0755); err != nil {
+		t.Fatalf("mkdir .hal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(halDir, template.ConfigFile), []byte("engine: pi\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := doctor.Run(doctor.Options{Dir: dir, Engine: "pi"})
 
 	for _, check := range result.Checks {
 		if !strings.Contains(content, check.ID) {

--- a/cmd/docs_metadata_archive_sandbox_test.go
+++ b/cmd/docs_metadata_archive_sandbox_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestArchiveAndSandboxCommandFamiliesHaveCompleteMetadata(t *testing.T) {
+func TestCommandFamiliesHaveCompleteMetadata(t *testing.T) {
 	// Not parallel: walks shared global Root() command tree
 
 	root := Root()
@@ -23,6 +23,11 @@ func TestArchiveAndSandboxCommandFamiliesHaveCompleteMetadata(t *testing.T) {
 		{
 			name:     "archive command family",
 			family:   "archive",
+			required: true,
+		},
+		{
+			name:     "ci command family",
+			family:   "ci",
 			required: true,
 		},
 		{

--- a/cmd/docs_metadata_core_test.go
+++ b/cmd/docs_metadata_core_test.go
@@ -93,6 +93,11 @@ func TestCoreCommandsHaveCompleteMetadata(t *testing.T) {
 			exampleContains: "hal continue",
 		},
 		{
+			name:            "ci command",
+			path:            []string{"ci"},
+			exampleContains: "hal ci",
+		},
+		{
 			name:            "version command",
 			path:            []string{"version"},
 			exampleContains: "hal version",

--- a/cmd/machine_contracts_test.go
+++ b/cmd/machine_contracts_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	ci "github.com/jywlabs/hal/internal/ci"
 	"github.com/jywlabs/hal/internal/loop"
 	"github.com/jywlabs/hal/internal/skills"
 	"github.com/jywlabs/hal/internal/template"
@@ -154,6 +156,169 @@ func TestMachineContractFields(t *testing.T) {
 
 		if v, ok := raw["contractVersion"].(float64); !ok || int(v) != 1 {
 			t.Fatalf("contractVersion = %v, want 1", raw["contractVersion"])
+		}
+	})
+}
+
+func TestMachineContractFields_CICommandOutputs(t *testing.T) {
+	parseJSON := func(t *testing.T, data []byte) map[string]interface{} {
+		t.Helper()
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("JSON parse error: %v\n%s", err, string(data))
+		}
+		return raw
+	}
+
+	requireFields := func(t *testing.T, name string, raw map[string]interface{}, required []string) {
+		t.Helper()
+		for _, f := range required {
+			if _, ok := raw[f]; !ok {
+				t.Errorf("%s JSON missing required field %q", name, f)
+			}
+		}
+	}
+
+	t.Run("ci push contract fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runCIPushWithDeps(context.Background(), ciPushRunOptions{JSON: true}, &buf, ciPushDeps{
+			pushAndCreatePR: func(context.Context, ci.PushOptions) (ci.PushResult, error) {
+				return ci.PushResult{
+					ContractVersion: ci.PushContractVersion,
+					Branch:          "hal/ci-contract-push",
+					Pushed:          true,
+					DryRun:          false,
+					PullRequest: ci.PullRequest{
+						Number:   101,
+						URL:      "https://github.com/acme/repo/pull/101",
+						Title:    "hal ci: hal/ci-contract-push",
+						HeadRef:  "hal/ci-contract-push",
+						HeadSHA:  "abc123",
+						BaseRef:  "main",
+						Draft:    true,
+						Existing: false,
+					},
+					Summary: "pushed branch hal/ci-contract-push and created pull request",
+				}, nil
+			},
+			currentBranch: func(context.Context) (string, error) {
+				return "", nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("runCIPushWithDeps error: %v", err)
+		}
+
+		raw := parseJSON(t, buf.Bytes())
+		requireFields(t, "ci push", raw, []string{"contractVersion", "branch", "pushed", "dryRun", "pullRequest", "summary"})
+		if raw["contractVersion"] != ci.PushContractVersion {
+			t.Fatalf("ci push contractVersion = %v, want %q", raw["contractVersion"], ci.PushContractVersion)
+		}
+
+		pr, ok := raw["pullRequest"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("ci push pullRequest should be object, got %T", raw["pullRequest"])
+		}
+		requireFields(t, "ci push pullRequest", pr, []string{"number", "url", "title", "headRef", "headSha", "baseRef", "draft", "existing"})
+	})
+
+	t.Run("ci status contract fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runCIStatusWithDeps(context.Background(), ciStatusRunOptions{Wait: true, JSON: true}, &buf, ciStatusDeps{
+			getStatus: func(context.Context) (ci.StatusResult, error) {
+				t.Fatal("getStatus should not be called when wait=true")
+				return ci.StatusResult{}, nil
+			},
+			waitForChecks: func(context.Context, ci.WaitOptions) (ci.StatusResult, error) {
+				return ci.StatusResult{
+					ContractVersion:    ci.StatusContractVersion,
+					Branch:             "hal/ci-contract-status",
+					SHA:                "def456",
+					Status:             ci.StatusPending,
+					ChecksDiscovered:   true,
+					Wait:               true,
+					WaitTerminalReason: ci.WaitTerminalReasonTimeout,
+					Checks: []ci.StatusCheck{
+						{Key: "check:test", Source: ci.CheckSourceCheckRun, Name: "test", Status: ci.StatusPending, URL: "https://github.com/acme/repo/actions/runs/1"},
+					},
+					Totals:  ci.StatusTotals{Pending: 1, Failing: 0, Passing: 0},
+					Summary: "status=pending (passing=0, failing=0, pending=1)",
+				}, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("runCIStatusWithDeps error: %v", err)
+		}
+
+		raw := parseJSON(t, buf.Bytes())
+		requireFields(t, "ci status", raw, []string{"contractVersion", "branch", "sha", "status", "checksDiscovered", "wait", "waitTerminalReason", "checks", "totals", "summary"})
+		if raw["contractVersion"] != ci.StatusContractVersion {
+			t.Fatalf("ci status contractVersion = %v, want %q", raw["contractVersion"], ci.StatusContractVersion)
+		}
+
+		checks, ok := raw["checks"].([]interface{})
+		if !ok || len(checks) == 0 {
+			t.Fatalf("ci status checks should be non-empty array, got %T", raw["checks"])
+		}
+		check0, ok := checks[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("ci status checks[0] should be object, got %T", checks[0])
+		}
+		requireFields(t, "ci status checks[0]", check0, []string{"key", "source", "name", "status", "url"})
+
+		totals, ok := raw["totals"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("ci status totals should be object, got %T", raw["totals"])
+		}
+		requireFields(t, "ci status totals", totals, []string{"pending", "failing", "passing"})
+	})
+
+	t.Run("ci fix contract fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runCIFixWithDeps(context.Background(), ciFixRunOptions{MaxAttempts: 2, Engine: "codex", JSON: true}, &buf, ciFixDeps{
+			getStatus: func(context.Context) (ci.StatusResult, error) {
+				return ci.StatusResult{Status: ci.StatusPassing, Branch: "hal/ci-contract-fix"}, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("runCIFixWithDeps error: %v", err)
+		}
+
+		raw := parseJSON(t, buf.Bytes())
+		requireFields(t, "ci fix", raw, []string{"contractVersion", "attempt", "maxAttempts", "applied", "branch", "pushed", "summary"})
+		if raw["contractVersion"] != ci.FixContractVersion {
+			t.Fatalf("ci fix contractVersion = %v, want %q", raw["contractVersion"], ci.FixContractVersion)
+		}
+	})
+
+	t.Run("ci merge contract fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := runCIMergeWithDeps(context.Background(), ciMergeRunOptions{Strategy: "rebase", DeleteBranch: true, JSON: true}, &buf, ciMergeDeps{
+			mergePR: func(context.Context, ci.MergeOptions) (ci.MergeResult, error) {
+				return ci.MergeResult{
+					ContractVersion: ci.MergeContractVersion,
+					PRNumber:        33,
+					Strategy:        "rebase",
+					DryRun:          false,
+					Merged:          true,
+					MergeCommitSHA:  "bead999",
+					BranchDeleted:   false,
+					DeleteWarning:   "delete remote branch \"hal/ci-contract-merge\": permission denied",
+					Summary:         "merged pull request #33 using rebase strategy; warning: delete failed",
+				}, nil
+			},
+			currentBranch: func(context.Context) (string, error) {
+				return "", nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("runCIMergeWithDeps error: %v", err)
+		}
+
+		raw := parseJSON(t, buf.Bytes())
+		requireFields(t, "ci merge", raw, []string{"contractVersion", "prNumber", "strategy", "dryRun", "merged", "mergeCommitSha", "branchDeleted", "deleteWarning", "summary"})
+		if raw["contractVersion"] != ci.MergeContractVersion {
+			t.Fatalf("ci merge contractVersion = %v, want %q", raw["contractVersion"], ci.MergeContractVersion)
 		}
 	})
 }

--- a/docs/cli/hal.md
+++ b/docs/cli/hal.md
@@ -63,6 +63,7 @@ Quick Start:
 * [hal analyze](hal_analyze.md)	 - Analyze a report to identify the highest priority item
 * [hal archive](hal_archive.md)	 - Archive current feature state
 * [hal auto](hal_auto.md)	 - Run the full compound engineering pipeline
+* [hal ci](hal_ci.md)	 - Run CI workflow commands
 * [hal cleanup](hal_cleanup.md)	 - Remove orphaned and deprecated files
 * [hal config](hal_config.md)	 - Show current configuration
 * [hal continue](hal_continue.md)	 - Show what to do next

--- a/docs/cli/hal_ci.md
+++ b/docs/cli/hal_ci.md
@@ -1,0 +1,39 @@
+## hal ci
+
+Run CI workflow commands
+
+### Synopsis
+
+Run CI-aware workflow commands.
+
+Use subcommands to push branches, inspect CI status, apply fixes, and merge safely.
+
+Examples:
+  hal ci push
+  hal ci status --wait
+  hal ci fix --max-attempts 2
+  hal ci merge --strategy squash
+
+### Examples
+
+```
+  hal ci push
+  hal ci status --wait
+  hal ci fix --max-attempts 2
+  hal ci merge --strategy squash
+```
+
+### Options
+
+```
+  -h, --help   help for ci
+```
+
+### SEE ALSO
+
+* [hal](hal.md)	 - Hal - Autonomous task executor using AI coding agents
+* [hal ci fix](hal_ci_fix.md)	 - Auto-fix failing CI checks using an engine
+* [hal ci merge](hal_ci_merge.md)	 - Merge the open pull request for the current branch
+* [hal ci push](hal_ci_push.md)	 - Push current branch and create or reuse a pull request
+* [hal ci status](hal_ci_status.md)	 - Show aggregated CI status for the current branch
+

--- a/docs/cli/hal_ci_fix.md
+++ b/docs/cli/hal_ci_fix.md
@@ -1,0 +1,38 @@
+## hal ci fix
+
+Auto-fix failing CI checks using an engine
+
+### Synopsis
+
+Apply focused CI fixes for failing checks using the configured engine.
+
+The command retries up to --max-attempts. Each attempt uses the shared
+single-attempt CI fix core operation and waits for fresh CI status before
+continuing. Use --json for machine-readable output.
+
+```
+hal ci fix [flags]
+```
+
+### Examples
+
+```
+  hal ci fix
+  hal ci fix --max-attempts 3
+  hal ci fix -e claude
+  hal ci fix --json
+```
+
+### Options
+
+```
+  -e, --engine string      Engine to use (claude, codex, pi) (default "codex")
+  -h, --help               help for fix
+      --json               Output machine-readable JSON result
+      --max-attempts int   Max fix attempts before stopping (default 3)
+```
+
+### SEE ALSO
+
+* [hal ci](hal_ci.md)	 - Run CI workflow commands
+

--- a/docs/cli/hal_ci_merge.md
+++ b/docs/cli/hal_ci_merge.md
@@ -1,0 +1,41 @@
+## hal ci merge
+
+Merge the open pull request for the current branch
+
+### Synopsis
+
+Merge the open pull request for the current branch with CI safety guards.
+
+By default this command uses the squash strategy and requires passing CI
+status. Use --allow-no-checks only when you intentionally want to override
+no-check safety guards. Use --dry-run to preview behavior without merge or
+remote branch deletion side effects. Use --json for machine-readable output.
+
+```
+hal ci merge [flags]
+```
+
+### Examples
+
+```
+  hal ci merge
+  hal ci merge --strategy rebase
+  hal ci merge --delete-branch
+  hal ci merge --dry-run --json
+```
+
+### Options
+
+```
+      --allow-no-checks   Allow merge when no CI checks are discovered
+      --delete-branch     Delete remote branch after successful merge
+      --dry-run           Preview merge behavior without merge or remote branch deletion side effects
+  -h, --help              help for merge
+      --json              Output machine-readable JSON result
+      --strategy string   Merge strategy (squash, merge, rebase) (default "squash")
+```
+
+### SEE ALSO
+
+* [hal ci](hal_ci.md)	 - Run CI workflow commands
+

--- a/docs/cli/hal_ci_push.md
+++ b/docs/cli/hal_ci_push.md
@@ -1,0 +1,36 @@
+## hal ci push
+
+Push current branch and create or reuse a pull request
+
+### Synopsis
+
+Push the current branch to origin and create or reuse an open pull request.
+
+By default, this command delegates to the shared CI core operation.
+Use --dry-run to preview behavior with no remote side effects.
+Use --json for machine-readable output.
+
+```
+hal ci push [flags]
+```
+
+### Examples
+
+```
+  hal ci push
+  hal ci push --dry-run
+  hal ci push --json
+```
+
+### Options
+
+```
+      --dry-run   Preview push/PR behavior without remote side effects
+  -h, --help      help for push
+      --json      Output machine-readable JSON result
+```
+
+### SEE ALSO
+
+* [hal ci](hal_ci.md)	 - Run CI workflow commands
+

--- a/docs/cli/hal_ci_status.md
+++ b/docs/cli/hal_ci_status.md
@@ -1,0 +1,39 @@
+## hal ci status
+
+Show aggregated CI status for the current branch
+
+### Synopsis
+
+Show aggregated CI status for the current branch.
+
+By default, this command returns the latest aggregated status immediately.
+Use --wait to poll until checks complete, timeout, or no checks are detected.
+Use --json for machine-readable output.
+
+```
+hal ci status [flags]
+```
+
+### Examples
+
+```
+  hal ci status
+  hal ci status --wait
+  hal ci status --wait --json
+```
+
+### Options
+
+```
+  -h, --help                       help for status
+      --json                       Output machine-readable JSON result
+      --no-checks-grace duration   No-checks grace override before returning no_checks_detected
+      --poll-interval duration     Polling interval override while waiting (default: internal ci poll interval)
+      --timeout duration           Wait timeout override (default: internal ci wait timeout)
+      --wait                       Wait for checks to complete, timeout, or no-check detection
+```
+
+### SEE ALSO
+
+* [hal ci](hal_ci.md)	 - Run CI workflow commands
+

--- a/docs/cli/hal_sandbox_migrate.md
+++ b/docs/cli/hal_sandbox_migrate.md
@@ -5,14 +5,17 @@ Migrate legacy sandbox state to global config
 ### Synopsis
 
 Migrate legacy project sandbox configuration from .hal/config.yaml to the
-global sandbox config location (~/.config/hal/sandbox-config.yaml).
+global sandbox config location (~/.config/hal/sandbox-config.yaml), and migrate
+legacy .hal/sandbox.json state into the global sandbox registry.
 
 This command is non-interactive and safe to run repeatedly — if migration has
 already completed or there is nothing to migrate, it reports that and exits.
 
 Migration copies sandbox and daytona configuration sections from the local
 project config to the global path. The local .hal/config.yaml is preserved
-unchanged.
+unchanged. When a legacy .hal/sandbox.json exists, the command verifies the
+global registry entry was written successfully and then removes the local state
+file.
 
 ```
 hal sandbox migrate [flags]

--- a/docs/contracts/ci-fix-v1.md
+++ b/docs/contracts/ci-fix-v1.md
@@ -1,0 +1,57 @@
+# CI Fix Contract v1
+
+**Command:** `hal ci fix --json`  
+**Contract Version:** `ci-fix-v1`  
+**Stability:** Stable. New fields may be added with `omitempty`; existing fields will not be removed or renamed.
+
+## Top-Level Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contractVersion` | string | Always `"ci-fix-v1"` |
+| `attempt` | integer | Attempt number applied in this result (`0` means no attempt was needed) |
+| `applied` | boolean | `true` when a fix attempt was applied |
+| `branch` | string | Branch targeted by the fix flow |
+| `pushed` | boolean | `true` when a fix commit was pushed |
+| `summary` | string | Human-readable summary |
+
+## Optional Fields (`omitempty`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `maxAttempts` | integer | Configured retry cap |
+| `commitSha` | string | Commit SHA for the applied fix |
+| `filesChanged` | array | Changed file paths included in the fix commit |
+
+## Example: Applied Fix
+
+```json
+{
+  "contractVersion": "ci-fix-v1",
+  "attempt": 1,
+  "maxAttempts": 3,
+  "applied": true,
+  "branch": "hal/ci-gap-free-safety-v3",
+  "commitSha": "9f8e7d6",
+  "pushed": true,
+  "filesChanged": [
+    "cmd/ci.go",
+    "internal/ci/fix.go"
+  ],
+  "summary": "applied ci fix attempt 1 on branch hal/ci-gap-free-safety-v3 and pushed 2 files"
+}
+```
+
+## Example: No Attempt Needed
+
+```json
+{
+  "contractVersion": "ci-fix-v1",
+  "attempt": 0,
+  "maxAttempts": 3,
+  "applied": false,
+  "branch": "hal/ci-gap-free-safety-v3",
+  "pushed": false,
+  "summary": "ci status is passing; no fix attempt needed"
+}
+```

--- a/docs/contracts/ci-merge-v1.md
+++ b/docs/contracts/ci-merge-v1.md
@@ -1,0 +1,54 @@
+# CI Merge Contract v1
+
+**Command:** `hal ci merge --json`  
+**Contract Version:** `ci-merge-v1`  
+**Stability:** Stable. New fields may be added with `omitempty`; existing fields will not be removed or renamed.
+
+## Top-Level Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contractVersion` | string | Always `"ci-merge-v1"` |
+| `prNumber` | integer | Pull request number targeted for merge |
+| `strategy` | string | Merge strategy (`squash`, `merge`, `rebase`) |
+| `dryRun` | boolean | `true` when run with `--dry-run` |
+| `merged` | boolean | `true` when merge succeeded |
+| `branchDeleted` | boolean | `true` when remote branch deletion succeeded |
+| `summary` | string | Human-readable summary |
+
+## Optional Fields (`omitempty`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mergeCommitSha` | string | Merge commit SHA |
+| `deleteWarning` | string | Warning text when branch deletion failed non-fatally |
+
+## Example: Successful Merge With Delete Warning
+
+```json
+{
+  "contractVersion": "ci-merge-v1",
+  "prNumber": 124,
+  "strategy": "squash",
+  "dryRun": false,
+  "merged": true,
+  "mergeCommitSha": "abcd1234",
+  "branchDeleted": false,
+  "deleteWarning": "delete remote branch \"hal/ci-gap-free-safety-v3\": permission denied",
+  "summary": "merged pull request #124 using squash strategy; warning: delete remote branch \"hal/ci-gap-free-safety-v3\": permission denied"
+}
+```
+
+## Example: Dry Run
+
+```json
+{
+  "contractVersion": "ci-merge-v1",
+  "prNumber": 0,
+  "strategy": "rebase",
+  "dryRun": true,
+  "merged": false,
+  "branchDeleted": false,
+  "summary": "dry-run: would merge pull request for branch hal/ci-gap-free-safety-v3 using rebase strategy"
+}
+```

--- a/docs/contracts/ci-push-v1.md
+++ b/docs/contracts/ci-push-v1.md
@@ -1,0 +1,71 @@
+# CI Push Contract v1
+
+**Command:** `hal ci push --json`  
+**Contract Version:** `ci-push-v1`  
+**Stability:** Stable. New fields may be added with `omitempty`; existing fields will not be removed or renamed.
+
+## Top-Level Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contractVersion` | string | Always `"ci-push-v1"` |
+| `branch` | string | Current git branch that was pushed (or would be pushed in dry-run) |
+| `pushed` | boolean | `true` when branch push occurred |
+| `dryRun` | boolean | `true` when command ran with `--dry-run` |
+| `pullRequest` | object | Pull request metadata |
+| `summary` | string | Human-readable summary |
+
+## `pullRequest` Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `number` | integer | Pull request number (`0` when unknown in dry-run preview) |
+| `url` | string | Pull request URL (empty when unknown/not created) |
+| `title` | string | Pull request title |
+| `draft` | boolean | Draft state |
+| `existing` | boolean | `true` when an existing open PR was reused |
+| `headRef` | string | Source branch name (optional) |
+| `headSha` | string | Source head SHA (optional) |
+| `baseRef` | string | Target/base branch (optional) |
+
+## Example: Created PR
+
+```json
+{
+  "contractVersion": "ci-push-v1",
+  "branch": "hal/ci-gap-free-safety-v3",
+  "pushed": true,
+  "dryRun": false,
+  "pullRequest": {
+    "number": 124,
+    "url": "https://github.com/acme/repo/pull/124",
+    "title": "hal ci: hal/ci-gap-free-safety-v3",
+    "headRef": "hal/ci-gap-free-safety-v3",
+    "headSha": "b6f6f7f",
+    "baseRef": "main",
+    "draft": true,
+    "existing": false
+  },
+  "summary": "pushed branch hal/ci-gap-free-safety-v3 and created pull request"
+}
+```
+
+## Example: Dry Run
+
+```json
+{
+  "contractVersion": "ci-push-v1",
+  "branch": "hal/ci-gap-free-safety-v3",
+  "pushed": false,
+  "dryRun": true,
+  "pullRequest": {
+    "number": 0,
+    "url": "",
+    "title": "",
+    "headRef": "hal/ci-gap-free-safety-v3",
+    "draft": true,
+    "existing": false
+  },
+  "summary": "dry-run: would push branch hal/ci-gap-free-safety-v3 and create or reuse a pull request"
+}
+```

--- a/docs/contracts/ci-status-v1.md
+++ b/docs/contracts/ci-status-v1.md
@@ -1,0 +1,110 @@
+# CI Status Contract v1
+
+**Command:** `hal ci status --json` (and `hal ci status --wait --json`)  
+**Contract Version:** `ci-status-v1`  
+**Stability:** Stable. New fields may be added with `omitempty`; existing fields will not be removed or renamed.
+
+## Top-Level Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contractVersion` | string | Always `"ci-status-v1"` |
+| `branch` | string | Current git branch |
+| `sha` | string | Commit SHA used for aggregation |
+| `status` | string | Aggregated status (`pending`, `failing`, `passing`) |
+| `checksDiscovered` | boolean | `true` when at least one CI context was found |
+| `wait` | boolean | `true` when command executed wait mode |
+| `waitTerminalReason` | string | Wait terminal reason (`completed`, `timeout`, `no_checks_detected`) |
+| `checks` | array | Aggregated check contexts |
+| `totals` | object | Counts by outcome |
+| `summary` | string | Human-readable status summary |
+
+## `checks[]` Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Stable dedupe key (`check:<name>` or `status:<context>`) |
+| `source` | string | Source type: `check` or `status` |
+| `name` | string | Check-run name or status context |
+| `status` | string | Normalized status (`pending`, `failing`, `passing`) |
+| `url` | string | CI details URL (optional) |
+
+## `totals` Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pending` | integer | Number of pending contexts |
+| `failing` | integer | Number of failing contexts |
+| `passing` | integer | Number of passing contexts |
+
+## Enumerated Values
+
+### `status`
+- `pending`
+- `failing`
+- `passing`
+
+### `waitTerminalReason`
+- `completed`
+- `timeout`
+- `no_checks_detected`
+
+### `checks[].source`
+- `check`
+- `status`
+
+## Example: Wait Timeout
+
+```json
+{
+  "contractVersion": "ci-status-v1",
+  "branch": "hal/ci-gap-free-safety-v3",
+  "sha": "a1b2c3d4",
+  "status": "pending",
+  "checksDiscovered": true,
+  "wait": true,
+  "waitTerminalReason": "timeout",
+  "checks": [
+    {
+      "key": "check:test",
+      "source": "check",
+      "name": "test",
+      "status": "pending",
+      "url": "https://github.com/acme/repo/actions/runs/123"
+    },
+    {
+      "key": "status:lint",
+      "source": "status",
+      "name": "lint",
+      "status": "passing"
+    }
+  ],
+  "totals": {
+    "pending": 1,
+    "failing": 0,
+    "passing": 1
+  },
+  "summary": "status=pending (passing=1, failing=0, pending=1)"
+}
+```
+
+## Example: No Checks Detected
+
+```json
+{
+  "contractVersion": "ci-status-v1",
+  "branch": "hal/ci-gap-free-safety-v3",
+  "sha": "a1b2c3d4",
+  "status": "pending",
+  "checksDiscovered": false,
+  "wait": true,
+  "waitTerminalReason": "no_checks_detected",
+  "checks": [],
+  "totals": {
+    "pending": 0,
+    "failing": 0,
+    "passing": 0
+  },
+  "summary": "no CI contexts discovered; status pending"
+}
+```

--- a/docs/contracts/continue-v1.md
+++ b/docs/contracts/continue-v1.md
@@ -13,7 +13,7 @@
 | Field | Type | Description |
 |-------|------|-------------|
 | `contractVersion` | int | Always `1` |
-| `ready` | bool | `true` when doctor passes (no blockers) |
+| `ready` | bool | `true` when doctor has no failing checks (`overallStatus` is `pass` or `warn`) |
 | `status` | object | Full `hal status --json` result |
 | `doctor` | object | Full `hal doctor --json` result |
 | `nextCommand` | string | The one command to run next |
@@ -24,6 +24,7 @@
 
 - When `ready` is `true`: `nextCommand` is the workflow action (e.g., `hal run`)
 - When `ready` is `false`: `nextCommand` is the doctor remediation (e.g., `hal init`)
+- Doctor warnings are advisory only and do not block readiness; only failing doctor checks set `ready=false`
 
 ## Example: Healthy, Manual In-Progress
 

--- a/docs/contracts/doctor-v1.md
+++ b/docs/contracts/doctor-v1.md
@@ -44,6 +44,7 @@
 | `git_repo` | repo | Git repository detected |
 | `hal_dir` | repo | `.hal/` directory exists |
 | `config_yaml` | repo | Config file readable and valid YAML |
+| `github_auth` | repo | GitHub authentication available for GitHub origin remotes |
 | `default_engine_cli` | repo | Engine CLI in PATH |
 | `prompt_md` | repo | Agent prompt template exists and non-empty |
 | `progress_file` | repo | Progress file exists |
@@ -53,6 +54,7 @@
 | `local_skill_links` | engine_local | `.claude/skills/`, `.pi/skills/` links correct |
 | `codex_global_links` | engine_global | `~/.codex/skills/` links correct (codex only) |
 | `legacy_debris` | migration | No `.goralph/`, `ralph` links, or `rules/` |
+| `legacy_sandbox_state` | migration | No legacy `.hal/sandbox.json` state file |
 | `broken_skill_links` | migration | No broken symlinks in engine dirs |
 
 ## Example: Healthy Pi Repo
@@ -66,6 +68,7 @@
     {"id": "git_repo", "status": "pass", "severity": "info", "scope": "repo", "applicability": "required", "remediationId": "none", "message": "Git repository detected."},
     {"id": "hal_dir", "status": "pass", "severity": "info", "scope": "repo", "applicability": "required", "remediationId": "none", "message": "Found .hal/ directory."},
     {"id": "config_yaml", "status": "pass", "severity": "info", "scope": "repo", "applicability": "required", "remediationId": "none", "message": "Loaded .hal/config.yaml."},
+    {"id": "github_auth", "status": "skip", "severity": "info", "scope": "repo", "applicability": "not_applicable", "remediationId": "none", "message": "GitHub auth check is not applicable: origin remote is not configured."},
     {"id": "default_engine_cli", "status": "pass", "severity": "info", "scope": "repo", "applicability": "required", "remediationId": "none", "message": "The configured default engine CLI is available in PATH."},
     {"id": "prompt_md", "status": "pass", "severity": "info", "scope": "repo", "applicability": "required", "remediationId": "none", "message": "Loaded .hal/prompt.md."},
     {"id": "progress_file", "status": "pass", "severity": "info", "scope": "repo", "applicability": "required", "remediationId": "none", "message": "Found .hal/progress.txt."},
@@ -75,10 +78,11 @@
     {"id": "local_skill_links", "status": "pass", "severity": "info", "scope": "engine_local", "applicability": "optional", "remediationId": "none", "message": "Engine-local skill links are correct."},
     {"id": "codex_global_links", "status": "skip", "severity": "info", "scope": "engine_global", "applicability": "not_applicable", "remediationId": "none", "message": "Codex global links are not required because the configured engine is pi."},
     {"id": "legacy_debris", "status": "pass", "severity": "info", "scope": "migration", "applicability": "optional", "remediationId": "none", "message": "No legacy migration debris found."},
+    {"id": "legacy_sandbox_state", "status": "pass", "severity": "info", "scope": "migration", "applicability": "optional", "remediationId": "none", "message": "No legacy sandbox state found."},
     {"id": "broken_skill_links", "status": "pass", "severity": "info", "scope": "migration", "applicability": "optional", "remediationId": "none", "message": "No broken skill symlinks found."}
   ],
-  "totalChecks": 13,
-  "passedChecks": 11,
+  "totalChecks": 15,
+  "passedChecks": 12,
   "failures": [],
   "warnings": [],
   "summary": "Hal is ready to use."

--- a/docs/specs/ci-human-output-styling.md
+++ b/docs/specs/ci-human-output-styling.md
@@ -1,0 +1,458 @@
+# Spec: CI Command Human Output Styling
+
+## Problem
+
+All `hal ci` subcommands (`push`, `status`, `fix`, `merge`) use raw `fmt.Fprintf` for human output. Other hal commands (`status`, `doctor`, `continue`) already use the shared lipgloss style system from `internal/engine/styles.go`.
+
+## Goal
+
+Align CI human output with existing hal styling while keeping JSON (`--json`) output byte-identical.
+
+## Alignment Decisions (Locked)
+
+1. Dry-run human output uses deterministic command-owned copy and the title format `CI <Command> (dry run)`.
+2. In `cmd/ci.go`, keep the existing `engine` import and use `engine.Style*` (do not introduce a second alias for the same package).
+3. `ci fix` no-op (`Applied=false`) status color is inferred from summary text:
+   - `status is passing` -> success (`✓`)
+   - `status is pending` -> warning (`⚠`)
+   - otherwise -> muted (no icon)
+4. `ci merge` dry-run human output does not render `result.Summary`; it renders fixed copy based on `opts.DeleteBranch`.
+
+## Style System Reference
+
+`cmd/ci.go` already imports:
+
+```go
+import "github.com/jywlabs/hal/internal/engine"
+```
+
+Use these existing styles:
+
+| Style | Use for |
+|---|---|
+| `engine.StyleTitle` | Command header |
+| `engine.StyleBold` | Field labels |
+| `engine.StyleSuccess` | Pass states, `✓` |
+| `engine.StyleError` | Fail states, `✗` |
+| `engine.StyleWarning` | Pending states, `⚠` |
+| `engine.StyleInfo` | Branch names, URLs, commands |
+| `engine.StyleMuted` | Secondary detail, SHAs, timestamps |
+
+## Formatting Pattern
+
+- First line is always styled title.
+- Label/value lines align values at column 10.
+- Secondary detail lines are indented to align under the value column (`"          "`).
+
+---
+
+## Per-Command Output Spec
+
+### `hal ci push`
+
+**Target:**
+
+```
+CI Push
+Branch:   test/smoke
+Status:   ✓ Pushed
+
+PR #26:   https://github.com/j-yw/hal/pull/26
+          Draft · New
+```
+
+Existing PR:
+
+```
+CI Push
+Branch:   test/smoke
+Status:   ✓ Pushed
+
+PR #26:   https://github.com/j-yw/hal/pull/26
+          Draft · Existing
+```
+
+Dry-run:
+
+```
+CI Push (dry run)
+Branch:   test/smoke
+
+Would push branch and create or reuse a pull request.
+```
+
+**Fields from `PushResult`:**
+
+- `Branch`
+- `DryRun`
+- `PullRequest.Number`
+- `PullRequest.URL`
+- `PullRequest.Draft`
+- `PullRequest.Existing`
+
+**Implementation note (`runCIPushWithDeps` human block):**
+
+```go
+if result.DryRun {
+	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Push (dry run)"))
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Branch:"), engine.StyleInfo.Render(result.Branch))
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would push branch and create or reuse a pull request."))
+	return nil
+}
+
+fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Push"))
+fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Branch:"), engine.StyleInfo.Render(result.Branch))
+fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Status:"), engine.StyleSuccess.Render("✓ Pushed"))
+
+if result.PullRequest.URL != "" {
+	fmt.Fprintln(out)
+	prLabel := "PR:"
+	if result.PullRequest.Number > 0 {
+		prLabel = fmt.Sprintf("PR #%d:", result.PullRequest.Number)
+	}
+	padding := ""
+	if len(prLabel) < 9 {
+		padding = strings.Repeat(" ", 9-len(prLabel))
+	}
+	fmt.Fprintf(out, "%s%s %s\n", engine.StyleBold.Render(prLabel), padding, engine.StyleInfo.Render(result.PullRequest.URL))
+
+	prDetail := "Draft"
+	if !result.PullRequest.Draft {
+		prDetail = "Ready for review"
+	}
+	if result.PullRequest.Existing {
+		prDetail += " · Existing"
+	} else {
+		prDetail += " · New"
+	}
+	fmt.Fprintf(out, "          %s\n", engine.StyleMuted.Render(prDetail))
+}
+```
+
+---
+
+### `hal ci status`
+
+**Target (failing):**
+
+```
+CI Status
+Branch:   test/ci-fix-smoke-2
+SHA:      abc1234
+Status:   ✗ failing
+
+Checks:
+  ✓  checks
+  ✓  goreleaser-check
+  ✗  integration-test
+  ✓  sandbox-test
+
+Totals:   3 passing · 1 failing
+```
+
+**Target (passing):**
+
+```
+CI Status
+Branch:   test/ci-fix-smoke-2
+SHA:      abc1234
+Status:   ✓ passing
+
+Checks:
+  ✓  checks
+  ✓  goreleaser-check
+  ✓  integration-test
+  ✓  sandbox-test
+
+Totals:   4 passing
+```
+
+**Target (pending):**
+
+```
+CI Status
+Branch:   test/ci-fix-smoke-2
+SHA:      abc1234
+Status:   ⚠ pending
+
+Checks:
+  ✓  checks
+  ⚠  goreleaser-check
+  ✗  integration-test
+  ⚠  sandbox-test
+
+Totals:   1 passing · 1 failing · 2 pending
+```
+
+With `--wait` terminal reason:
+
+```
+CI Status
+Branch:   test/ci-fix-smoke-2
+SHA:      abc1234
+Status:   ✓ passing
+Wait:     completed
+```
+
+No checks discovered:
+
+```
+CI Status
+Branch:   test/ci-fix-smoke-2
+SHA:      abc1234
+Status:   ⚠ pending
+
+No CI checks discovered.
+```
+
+**Fields from `StatusResult`:**
+
+- `Branch`
+- `SHA` (display first 7 chars)
+- `Status`
+- `ChecksDiscovered`
+- `WaitTerminalReason` (only when `--wait`)
+- `Checks[]`
+- `Totals`
+
+Implementation remains the same shape as drafted, switching style calls to `engine.Style*`.
+
+---
+
+### `hal ci fix`
+
+**Target (no fix needed, pending):**
+
+```
+CI Fix
+Status:   ⚠ ci status is pending; no fix attempt needed
+```
+
+**Target (no fix needed, passing):**
+
+```
+CI Fix
+Status:   ✓ ci status is passing; no fix attempt needed
+```
+
+**Target (fix applied):**
+
+```
+CI Fix
+Branch:   test/ci-fix-smoke-2
+Attempt:  1/2
+Status:   ✓ Fix applied
+
+Commit:   abc1234
+Pushed:   ✓
+Files:    internal/ci/parse_test.go
+```
+
+**Fields from `FixResult`:**
+
+- `Applied`
+- `Summary`
+- `Branch`
+- `Attempt`
+- `MaxAttempts`
+- `CommitSHA` (display first 7 chars)
+- `Pushed`
+- `FilesChanged`
+
+**Implementation note (`writeCIFixResult` human block):**
+
+```go
+fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Fix"))
+
+if !result.Applied {
+	summary := strings.TrimSpace(result.Summary)
+	if summary == "" {
+		summary = "no fix attempt needed"
+	}
+	lower := strings.ToLower(summary)
+	render := engine.StyleMuted.Render
+	if strings.Contains(lower, "status is passing") {
+		render = engine.StyleSuccess.Render
+		summary = "✓ " + summary
+	} else if strings.Contains(lower, "status is pending") {
+		render = engine.StyleWarning.Render
+		summary = "⚠ " + summary
+	}
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Status:"), render(summary))
+	return nil
+}
+
+if result.Branch != "" {
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Branch:"), engine.StyleInfo.Render(result.Branch))
+}
+if result.MaxAttempts > 0 {
+	fmt.Fprintf(out, "%s  %s\n", engine.StyleBold.Render("Attempt:"), fmt.Sprintf("%d/%d", result.Attempt, result.MaxAttempts))
+}
+fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Status:"), engine.StyleSuccess.Render("✓ Fix applied"))
+
+sha := result.CommitSHA
+if len(sha) > 7 {
+	sha = sha[:7]
+}
+if sha != "" {
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Commit:"), engine.StyleMuted.Render(sha))
+}
+if result.Pushed {
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Pushed:"), engine.StyleSuccess.Render("✓"))
+}
+if len(result.FilesChanged) > 0 {
+	fmt.Fprintf(out, "%s    %s\n", engine.StyleBold.Render("Files:"), engine.StyleMuted.Render(strings.Join(result.FilesChanged, ", ")))
+}
+```
+
+---
+
+### `hal ci merge`
+
+**Target:**
+
+```
+CI Merge
+PR:       #26
+Strategy: squash
+Status:   ✓ Merged
+
+Commit:   abc1234
+Branch:   ✓ Deleted
+```
+
+Dry-run with `--delete-branch`:
+
+```
+CI Merge (dry run)
+Strategy: squash
+
+Would merge pull request and delete the remote branch.
+```
+
+Dry-run without `--delete-branch`:
+
+```
+CI Merge (dry run)
+Strategy: squash
+
+Would merge pull request.
+```
+
+With delete warning:
+
+```
+CI Merge
+PR:       #26
+Strategy: squash
+Status:   ✓ Merged
+
+Commit:   abc1234
+Branch:   ⚠ remote branch not found (already deleted?)
+```
+
+Without branch deletion requested:
+
+```
+CI Merge
+PR:       #26
+Strategy: squash
+Status:   ✓ Merged
+
+Commit:   abc1234
+```
+
+**Fields from `MergeResult`:**
+
+- `DryRun`
+- `PRNumber`
+- `Strategy`
+- `Merged`
+- `MergeCommitSHA` (display first 7 chars)
+- `BranchDeleted`
+- `DeleteWarning`
+
+**Implementation note (`runCIMergeWithDeps` human block):**
+
+```go
+if result.DryRun {
+	fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Merge (dry run)"))
+	fmt.Fprintf(out, "%s %s\n", engine.StyleBold.Render("Strategy:"), result.Strategy)
+	fmt.Fprintln(out)
+	if opts.DeleteBranch {
+		fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would merge pull request and delete the remote branch."))
+	} else {
+		fmt.Fprintf(out, "%s\n", engine.StyleMuted.Render("Would merge pull request."))
+	}
+	return nil
+}
+
+fmt.Fprintf(out, "%s\n", engine.StyleTitle.Render("CI Merge"))
+if result.PRNumber > 0 {
+	fmt.Fprintf(out, "%s       %s\n", engine.StyleBold.Render("PR:"), engine.StyleInfo.Render(fmt.Sprintf("#%d", result.PRNumber)))
+}
+fmt.Fprintf(out, "%s %s\n", engine.StyleBold.Render("Strategy:"), result.Strategy)
+fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Status:"), engine.StyleSuccess.Render("✓ Merged"))
+
+sha := result.MergeCommitSHA
+if len(sha) > 7 {
+	sha = sha[:7]
+}
+if sha != "" {
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Commit:"), engine.StyleMuted.Render(sha))
+}
+if result.BranchDeleted {
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Branch:"), engine.StyleSuccess.Render("✓ Deleted"))
+} else if result.DeleteWarning != "" {
+	fmt.Fprintf(out, "%s   %s\n", engine.StyleBold.Render("Branch:"), engine.StyleWarning.Render("⚠ "+result.DeleteWarning))
+}
+```
+
+---
+
+## Alignment Reference
+
+All CI labels align values to column 10.
+
+| Label | Length | Padding | Total |
+|---|---|---|---|
+| `Branch:` | 7 | 3 | 10 |
+| `Status:` | 7 | 3 | 10 |
+| `SHA:` | 4 | 6 | 10 |
+| `Wait:` | 5 | 5 | 10 |
+| `Totals:` | 7 | 3 | 10 |
+| `PR:` | 3 | 7 | 10 |
+| `Attempt:` | 8 | 2 | 10 |
+| `Commit:` | 7 | 3 | 10 |
+| `Pushed:` | 7 | 3 | 10 |
+| `Files:` | 6 | 4 | 10 |
+| `Strategy:` | 9 | 1 | 10 |
+| `PR #N:` | dynamic | dynamic | 10 |
+
+For `PR #N:`, when label width exceeds 9 chars (for example `PR #1000:`), skip extra padding.
+
+## Scope
+
+- Primary implementation file: `cmd/ci.go`.
+- Modify only human-output paths in:
+  - `runCIPushWithDeps`
+  - `runCIStatusWithDeps`
+  - `writeCIFixResult`
+  - `runCIMergeWithDeps`
+- Do not change JSON output, flag wiring, dependency injection, or `internal/ci/*` core logic.
+- Keep SHA truncation to 7 chars in human output only.
+
+## Tests
+
+- JSON contract tests in `cmd/ci_test.go` stay unchanged.
+- If branch-local human-output assertions exist (for example dry-run text checks), update only those expectations.
+- If exact plain-text matching is used on styled output, normalize ANSI in tests before asserting.
+
+## Acceptance
+
+- `hal ci push|status|fix|merge` human output uses shared style system consistently.
+- `hal ci * --json` output remains byte-identical to current behavior.
+- `make test` passes.

--- a/internal/ci/auth.go
+++ b/internal/ci/auth.go
@@ -1,0 +1,120 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const (
+	githubTokenEnv = "GITHUB_TOKEN"
+	ghTokenEnv     = "GH_TOKEN"
+)
+
+// ClientKind identifies which GitHub client path should be used.
+type ClientKind string
+
+const (
+	ClientKindAPI ClientKind = "api"
+	ClientKindGH  ClientKind = "gh"
+)
+
+var (
+	// ErrInvalidEnvToken is returned when an env token is present but invalid.
+	// This must remain exact so callers can provide deterministic corrective guidance.
+	ErrInvalidEnvToken = errors.New("invalid GitHub token in environment; set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it to use 'gh auth login'")
+
+	// ErrNoGitHubAuth is returned when neither env token auth nor gh auth is available.
+	ErrNoGitHubAuth = errors.New("no GitHub auth found: set $GITHUB_TOKEN/$GH_TOKEN or run 'gh auth login'")
+)
+
+// ClientSelection describes which client path should be used for GitHub operations.
+type ClientSelection struct {
+	Kind  ClientKind
+	Token string
+}
+
+type clientSelectorDeps struct {
+	getenv          func(string) string
+	validateToken   func(context.Context, string) error
+	ghAuthenticated func(context.Context) bool
+}
+
+// SelectGitHubClient resolves the deterministic auth/client path.
+//
+// Precedence:
+//   - Environment token ($GITHUB_TOKEN, then $GH_TOKEN) -> API client
+//   - Authenticated gh CLI -> gh client
+//   - Otherwise ErrNoGitHubAuth
+//
+// If an environment token is present but fails validation, ErrInvalidEnvToken is
+// returned and no gh fallback is attempted.
+func SelectGitHubClient(ctx context.Context) (ClientSelection, error) {
+	return selectGitHubClientWithDeps(ctx, clientSelectorDeps{
+		getenv:          os.Getenv,
+		validateToken:   validateEnvToken,
+		ghAuthenticated: isGHAuthenticated,
+	})
+}
+
+func selectGitHubClientWithDeps(ctx context.Context, deps clientSelectorDeps) (ClientSelection, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if deps.getenv == nil {
+		deps.getenv = os.Getenv
+	}
+	if deps.validateToken == nil {
+		deps.validateToken = validateEnvToken
+	}
+	if deps.ghAuthenticated == nil {
+		deps.ghAuthenticated = isGHAuthenticated
+	}
+
+	if token, ok := envToken(deps.getenv); ok {
+		if err := deps.validateToken(ctx, token); err != nil {
+			return ClientSelection{}, ErrInvalidEnvToken
+		}
+		return ClientSelection{Kind: ClientKindAPI, Token: token}, nil
+	}
+
+	if deps.ghAuthenticated(ctx) {
+		return ClientSelection{Kind: ClientKindGH}, nil
+	}
+
+	return ClientSelection{}, ErrNoGitHubAuth
+}
+
+func envToken(getenv func(string) string) (string, bool) {
+	for _, key := range []string{githubTokenEnv, ghTokenEnv} {
+		token := strings.TrimSpace(getenv(key))
+		if token != "" {
+			return token, true
+		}
+	}
+	return "", false
+}
+
+func validateEnvToken(_ context.Context, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ErrInvalidEnvToken
+	}
+	if strings.ContainsAny(token, " \t\n\r") {
+		return ErrInvalidEnvToken
+	}
+	if len(token) < 20 {
+		return ErrInvalidEnvToken
+	}
+	return nil
+}
+
+func isGHAuthenticated(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, "gh", "auth", "status")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
+}

--- a/internal/ci/auth.go
+++ b/internal/ci/auth.go
@@ -3,16 +3,19 @@ package ci
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 const (
-	githubTokenEnv = "GITHUB_TOKEN"
-	ghTokenEnv     = "GH_TOKEN"
+	githubTokenEnv                = "GITHUB_TOKEN"
+	ghTokenEnv                    = "GH_TOKEN"
+	gitHubTokenValidationTimeout  = 10 * time.Second
 )
 
 // ClientKind identifies which GitHub client path should be used.
@@ -24,6 +27,8 @@ const (
 )
 
 var (
+	gitHubTokenValidationHTTPClient = &http.Client{Timeout: gitHubTokenValidationTimeout}
+
 	// ErrInvalidEnvToken is returned when an env token is present but invalid.
 	// This must remain exact so callers can provide deterministic corrective guidance.
 	ErrInvalidEnvToken = errors.New("invalid GitHub token in environment; set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it to use 'gh auth login'")
@@ -81,7 +86,10 @@ func selectGitHubClientWithDeps(ctx context.Context, deps clientSelectorDeps) (C
 
 	if token, ok := envToken(deps.getenv); ok {
 		if err := deps.validateToken(ctx, token); err != nil {
-			return ClientSelection{}, ErrInvalidEnvToken
+			if errors.Is(err, ErrInvalidEnvToken) {
+				return ClientSelection{}, ErrInvalidEnvToken
+			}
+			return ClientSelection{}, err
 		}
 		return ClientSelection{Kind: ClientKindAPI, Token: token}, nil
 	}
@@ -140,7 +148,7 @@ func validateEnvTokenWithDeps(ctx context.Context, token string, deps tokenValid
 
 	resp, err := deps.validateRequest(req)
 	if err != nil {
-		return ErrInvalidEnvToken
+		return fmt.Errorf("validate GitHub token request: %w", err)
 	}
 	defer resp.Body.Close()
 	// Treat only 401 as definitively invalid. Other statuses (for example 403)
@@ -152,7 +160,7 @@ func validateEnvTokenWithDeps(ctx context.Context, token string, deps tokenValid
 }
 
 func validateGitHubTokenRequest(req *http.Request) (*http.Response, error) {
-	return http.DefaultClient.Do(req)
+	return gitHubTokenValidationHTTPClient.Do(req)
 }
 
 func isGHAuthenticated(ctx context.Context) bool {

--- a/internal/ci/auth.go
+++ b/internal/ci/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -41,6 +42,10 @@ type clientSelectorDeps struct {
 	getenv          func(string) string
 	validateToken   func(context.Context, string) error
 	ghAuthenticated func(context.Context) bool
+}
+
+type tokenValidatorDeps struct {
+	validateRequest func(*http.Request) (*http.Response, error)
 }
 
 // SelectGitHubClient resolves the deterministic auth/client path.
@@ -98,7 +103,16 @@ func envToken(getenv func(string) string) (string, bool) {
 	return "", false
 }
 
-func validateEnvToken(_ context.Context, token string) error {
+func validateEnvToken(ctx context.Context, token string) error {
+	return validateEnvTokenWithDeps(ctx, token, tokenValidatorDeps{
+		validateRequest: validateGitHubTokenRequest,
+	})
+}
+
+func validateEnvTokenWithDeps(ctx context.Context, token string, deps tokenValidatorDeps) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	token = strings.TrimSpace(token)
 	if token == "" {
 		return ErrInvalidEnvToken
@@ -109,12 +123,52 @@ func validateEnvToken(_ context.Context, token string) error {
 	if len(token) < 20 {
 		return ErrInvalidEnvToken
 	}
+
+	if deps.validateRequest == nil {
+		deps.validateRequest = validateGitHubTokenRequest
+	}
+
+	// /rate_limit is available to both user and non-user tokens while still
+	// returning 401 for invalid credentials.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/rate_limit", nil)
+	if err != nil {
+		return ErrInvalidEnvToken
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := deps.validateRequest(req)
+	if err != nil {
+		return ErrInvalidEnvToken
+	}
+	defer resp.Body.Close()
+	// Treat only 401 as definitively invalid. Other statuses (for example 403)
+	// can occur for valid tokens depending on org policy or temporary limits.
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrInvalidEnvToken
+	}
 	return nil
 }
 
+func validateGitHubTokenRequest(req *http.Request) (*http.Response, error) {
+	return http.DefaultClient.Do(req)
+}
+
 func isGHAuthenticated(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "gh", "auth", "status")
+	return isGHAuthenticatedWithRunner(ctx, runGHCommand)
+}
+
+func isGHAuthenticatedWithRunner(ctx context.Context, run func(context.Context, string, ...string) error) bool {
+	if run == nil {
+		run = runGHCommand
+	}
+	return run(ctx, "gh", "auth", "status", "--hostname", "github.com") == nil
+}
+
+func runGHCommand(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
-	return cmd.Run() == nil
+	return cmd.Run()
 }

--- a/internal/ci/auth_test.go
+++ b/internal/ci/auth_test.go
@@ -1,0 +1,165 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestSelectGitHubClientWithDeps_ValidEnvTokenUsesAPIClient(t *testing.T) {
+	var validateCalls, ghAuthCalls int
+
+	selection, err := selectGitHubClientWithDeps(context.Background(), clientSelectorDeps{
+		getenv: func(key string) string {
+			if key == githubTokenEnv {
+				return "ghp_12345678901234567890"
+			}
+			return ""
+		},
+		validateToken: func(_ context.Context, token string) error {
+			validateCalls++
+			if token != "ghp_12345678901234567890" {
+				t.Fatalf("token = %q, want %q", token, "ghp_12345678901234567890")
+			}
+			return nil
+		},
+		ghAuthenticated: func(context.Context) bool {
+			ghAuthCalls++
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("selectGitHubClientWithDeps() error = %v", err)
+	}
+
+	if selection.Kind != ClientKindAPI {
+		t.Fatalf("selection.Kind = %q, want %q", selection.Kind, ClientKindAPI)
+	}
+	if selection.Token != "ghp_12345678901234567890" {
+		t.Fatalf("selection.Token = %q, want %q", selection.Token, "ghp_12345678901234567890")
+	}
+	if validateCalls != 1 {
+		t.Fatalf("validateToken calls = %d, want 1", validateCalls)
+	}
+	if ghAuthCalls != 0 {
+		t.Fatalf("ghAuthenticated calls = %d, want 0", ghAuthCalls)
+	}
+}
+
+func TestSelectGitHubClientWithDeps_InvalidEnvTokenReturnsCorrectiveError(t *testing.T) {
+	var ghAuthCalls int
+
+	_, err := selectGitHubClientWithDeps(context.Background(), clientSelectorDeps{
+		getenv: func(key string) string {
+			if key == githubTokenEnv {
+				return "ghp_invalid"
+			}
+			return ""
+		},
+		validateToken: func(context.Context, string) error {
+			return errors.New("token rejected")
+		},
+		ghAuthenticated: func(context.Context) bool {
+			ghAuthCalls++
+			return true
+		},
+	})
+	if !errors.Is(err, ErrInvalidEnvToken) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidEnvToken)
+	}
+	if err.Error() != ErrInvalidEnvToken.Error() {
+		t.Fatalf("error text = %q, want %q", err.Error(), ErrInvalidEnvToken.Error())
+	}
+	if ghAuthCalls != 0 {
+		t.Fatalf("ghAuthenticated calls = %d, want 0 (no fallback on invalid env token)", ghAuthCalls)
+	}
+}
+
+func TestSelectGitHubClientWithDeps_FallsBackToGHWhenAuthenticated(t *testing.T) {
+	var validateCalls int
+
+	selection, err := selectGitHubClientWithDeps(context.Background(), clientSelectorDeps{
+		getenv: func(string) string { return "" },
+		validateToken: func(context.Context, string) error {
+			validateCalls++
+			return nil
+		},
+		ghAuthenticated: func(context.Context) bool {
+			return true
+		},
+	})
+	if err != nil {
+		t.Fatalf("selectGitHubClientWithDeps() error = %v", err)
+	}
+	if selection.Kind != ClientKindGH {
+		t.Fatalf("selection.Kind = %q, want %q", selection.Kind, ClientKindGH)
+	}
+	if selection.Token != "" {
+		t.Fatalf("selection.Token = %q, want empty", selection.Token)
+	}
+	if validateCalls != 0 {
+		t.Fatalf("validateToken calls = %d, want 0", validateCalls)
+	}
+}
+
+func TestSelectGitHubClientWithDeps_NoAuthReturnsError(t *testing.T) {
+	_, err := selectGitHubClientWithDeps(context.Background(), clientSelectorDeps{
+		getenv:          func(string) string { return "" },
+		validateToken:   func(context.Context, string) error { return nil },
+		ghAuthenticated: func(context.Context) bool { return false },
+	})
+	if !errors.Is(err, ErrNoGitHubAuth) {
+		t.Fatalf("error = %v, want %v", err, ErrNoGitHubAuth)
+	}
+	if err.Error() != ErrNoGitHubAuth.Error() {
+		t.Fatalf("error text = %q, want %q", err.Error(), ErrNoGitHubAuth.Error())
+	}
+}
+
+func TestSelectGitHubClientWithDeps_UsesGHTokenWhenGitHubTokenUnset(t *testing.T) {
+	selection, err := selectGitHubClientWithDeps(context.Background(), clientSelectorDeps{
+		getenv: func(key string) string {
+			if key == ghTokenEnv {
+				return "gho_12345678901234567890"
+			}
+			return ""
+		},
+		validateToken:   func(context.Context, string) error { return nil },
+		ghAuthenticated: func(context.Context) bool { return true },
+	})
+	if err != nil {
+		t.Fatalf("selectGitHubClientWithDeps() error = %v", err)
+	}
+	if selection.Kind != ClientKindAPI {
+		t.Fatalf("selection.Kind = %q, want %q", selection.Kind, ClientKindAPI)
+	}
+	if selection.Token != "gho_12345678901234567890" {
+		t.Fatalf("selection.Token = %q, want %q", selection.Token, "gho_12345678901234567890")
+	}
+}
+
+func TestValidateEnvToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{name: "valid token", token: "ghp_12345678901234567890", wantErr: false},
+		{name: "empty token", token: "", wantErr: true},
+		{name: "too short", token: "short-token", wantErr: true},
+		{name: "contains whitespace", token: "ghp_1234 5678901234567890", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEnvToken(context.Background(), tt.token)
+			gotErr := err != nil
+			if gotErr != tt.wantErr {
+				t.Fatalf("validateEnvToken(%q) error = %v, wantErr %v", tt.token, err, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, ErrInvalidEnvToken) {
+				t.Fatalf("error = %v, want %v", err, ErrInvalidEnvToken)
+			}
+		})
+	}
+}

--- a/internal/ci/auth_test.go
+++ b/internal/ci/auth_test.go
@@ -60,7 +60,7 @@ func TestSelectGitHubClientWithDeps_InvalidEnvTokenReturnsCorrectiveError(t *tes
 			return ""
 		},
 		validateToken: func(context.Context, string) error {
-			return errors.New("token rejected")
+			return ErrInvalidEnvToken
 		},
 		ghAuthenticated: func(context.Context) bool {
 			ghAuthCalls++
@@ -75,6 +75,36 @@ func TestSelectGitHubClientWithDeps_InvalidEnvTokenReturnsCorrectiveError(t *tes
 	}
 	if ghAuthCalls != 0 {
 		t.Fatalf("ghAuthenticated calls = %d, want 0 (no fallback on invalid env token)", ghAuthCalls)
+	}
+}
+
+func TestSelectGitHubClientWithDeps_TokenValidationTransportErrorPassesThrough(t *testing.T) {
+	var ghAuthCalls int
+	wantErr := errors.New("validate GitHub token request: context deadline exceeded")
+
+	_, err := selectGitHubClientWithDeps(context.Background(), clientSelectorDeps{
+		getenv: func(key string) string {
+			if key == githubTokenEnv {
+				return "ghp_12345678901234567890"
+			}
+			return ""
+		},
+		validateToken: func(context.Context, string) error {
+			return wantErr
+		},
+		ghAuthenticated: func(context.Context) bool {
+			ghAuthCalls++
+			return true
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, wantErr)
+	}
+	if errors.Is(err, ErrInvalidEnvToken) {
+		t.Fatalf("error = %v, should not be classified as %v", err, ErrInvalidEnvToken)
+	}
+	if ghAuthCalls != 0 {
+		t.Fatalf("ghAuthenticated calls = %d, want 0 (no fallback when env token validation fails)", ghAuthCalls)
 	}
 }
 
@@ -143,43 +173,48 @@ func TestSelectGitHubClientWithDeps_UsesGHTokenWhenGitHubTokenUnset(t *testing.T
 
 func TestValidateEnvToken(t *testing.T) {
 	tests := []struct {
-		name         string
-		token        string
-		responseCode int
-		requestErr   error
-		wantErr      bool
-		wantRequest  bool
+		name           string
+		token          string
+		responseCode   int
+		requestErr     error
+		wantErr        bool
+		wantRequest    bool
+		wantInvalidErr bool
 	}{
 		{
-			name:         "valid token",
-			token:        "ghp_12345678901234567890",
-			responseCode: http.StatusOK,
-			wantErr:      false,
-			wantRequest:  true,
+			name:           "valid token",
+			token:          "ghp_12345678901234567890",
+			responseCode:   http.StatusOK,
+			wantErr:        false,
+			wantRequest:    true,
+			wantInvalidErr: false,
 		},
 		{
-			name:         "forbidden can still be valid token",
-			token:        "ghp_12345678901234567890",
-			responseCode: http.StatusForbidden,
-			wantErr:      false,
-			wantRequest:  true,
+			name:           "forbidden can still be valid token",
+			token:          "ghp_12345678901234567890",
+			responseCode:   http.StatusForbidden,
+			wantErr:        false,
+			wantRequest:    true,
+			wantInvalidErr: false,
 		},
-		{name: "empty token", token: "", wantErr: true, wantRequest: false},
-		{name: "too short", token: "short-token", wantErr: true, wantRequest: false},
-		{name: "contains whitespace", token: "ghp_1234 5678901234567890", wantErr: true, wantRequest: false},
+		{name: "empty token", token: "", wantErr: true, wantRequest: false, wantInvalidErr: true},
+		{name: "too short", token: "short-token", wantErr: true, wantRequest: false, wantInvalidErr: true},
+		{name: "contains whitespace", token: "ghp_1234 5678901234567890", wantErr: true, wantRequest: false, wantInvalidErr: true},
 		{
-			name:         "auth rejected",
-			token:        "ghp_12345678901234567890",
-			responseCode: http.StatusUnauthorized,
-			wantErr:      true,
-			wantRequest:  true,
+			name:           "auth rejected",
+			token:          "ghp_12345678901234567890",
+			responseCode:   http.StatusUnauthorized,
+			wantErr:        true,
+			wantRequest:    true,
+			wantInvalidErr: true,
 		},
 		{
-			name:        "request error",
-			token:       "ghp_12345678901234567890",
-			requestErr:  errors.New("network failure"),
-			wantErr:     true,
-			wantRequest: true,
+			name:           "request error",
+			token:          "ghp_12345678901234567890",
+			requestErr:     errors.New("network failure"),
+			wantErr:        true,
+			wantRequest:    true,
+			wantInvalidErr: false,
 		},
 	}
 
@@ -215,12 +250,15 @@ func TestValidateEnvToken(t *testing.T) {
 			if !tt.wantRequest && requestCalls != 0 {
 				t.Fatalf("validate request calls = %d, want 0", requestCalls)
 			}
-			if tt.wantErr && !errors.Is(err, ErrInvalidEnvToken) {
-				t.Fatalf("error = %v, want %v", err, ErrInvalidEnvToken)
-			}
-		})
+				if tt.wantErr && tt.wantInvalidErr && !errors.Is(err, ErrInvalidEnvToken) {
+					t.Fatalf("error = %v, want %v", err, ErrInvalidEnvToken)
+				}
+				if tt.wantErr && !tt.wantInvalidErr && errors.Is(err, ErrInvalidEnvToken) {
+					t.Fatalf("error = %v, should not be classified as %v", err, ErrInvalidEnvToken)
+				}
+			})
+		}
 	}
-}
 
 func TestIsGHAuthenticatedWithRunner_ScopesAuthToGitHubDotCom(t *testing.T) {
 	var gotName string

--- a/internal/ci/auth_test.go
+++ b/internal/ci/auth_test.go
@@ -3,6 +3,9 @@ package ci
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -140,26 +143,116 @@ func TestSelectGitHubClientWithDeps_UsesGHTokenWhenGitHubTokenUnset(t *testing.T
 
 func TestValidateEnvToken(t *testing.T) {
 	tests := []struct {
-		name    string
-		token   string
-		wantErr bool
+		name         string
+		token        string
+		responseCode int
+		requestErr   error
+		wantErr      bool
+		wantRequest  bool
 	}{
-		{name: "valid token", token: "ghp_12345678901234567890", wantErr: false},
-		{name: "empty token", token: "", wantErr: true},
-		{name: "too short", token: "short-token", wantErr: true},
-		{name: "contains whitespace", token: "ghp_1234 5678901234567890", wantErr: true},
+		{
+			name:         "valid token",
+			token:        "ghp_12345678901234567890",
+			responseCode: http.StatusOK,
+			wantErr:      false,
+			wantRequest:  true,
+		},
+		{
+			name:         "forbidden can still be valid token",
+			token:        "ghp_12345678901234567890",
+			responseCode: http.StatusForbidden,
+			wantErr:      false,
+			wantRequest:  true,
+		},
+		{name: "empty token", token: "", wantErr: true, wantRequest: false},
+		{name: "too short", token: "short-token", wantErr: true, wantRequest: false},
+		{name: "contains whitespace", token: "ghp_1234 5678901234567890", wantErr: true, wantRequest: false},
+		{
+			name:         "auth rejected",
+			token:        "ghp_12345678901234567890",
+			responseCode: http.StatusUnauthorized,
+			wantErr:      true,
+			wantRequest:  true,
+		},
+		{
+			name:        "request error",
+			token:       "ghp_12345678901234567890",
+			requestErr:  errors.New("network failure"),
+			wantErr:     true,
+			wantRequest: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateEnvToken(context.Background(), tt.token)
+			requestCalls := 0
+			err := validateEnvTokenWithDeps(context.Background(), tt.token, tokenValidatorDeps{
+				validateRequest: func(req *http.Request) (*http.Response, error) {
+					requestCalls++
+					if req.URL == nil || req.URL.Path != "/rate_limit" {
+						t.Fatalf("request path = %v, want /rate_limit", req.URL)
+					}
+					if tt.requestErr != nil {
+						return nil, tt.requestErr
+					}
+					code := tt.responseCode
+					if code == 0 {
+						code = http.StatusOK
+					}
+					return &http.Response{
+						StatusCode: code,
+						Body:       io.NopCloser(strings.NewReader("{}")),
+					}, nil
+				},
+			})
 			gotErr := err != nil
 			if gotErr != tt.wantErr {
 				t.Fatalf("validateEnvToken(%q) error = %v, wantErr %v", tt.token, err, tt.wantErr)
+			}
+			if tt.wantRequest && requestCalls != 1 {
+				t.Fatalf("validate request calls = %d, want 1", requestCalls)
+			}
+			if !tt.wantRequest && requestCalls != 0 {
+				t.Fatalf("validate request calls = %d, want 0", requestCalls)
 			}
 			if tt.wantErr && !errors.Is(err, ErrInvalidEnvToken) {
 				t.Fatalf("error = %v, want %v", err, ErrInvalidEnvToken)
 			}
 		})
+	}
+}
+
+func TestIsGHAuthenticatedWithRunner_ScopesAuthToGitHubDotCom(t *testing.T) {
+	var gotName string
+	var gotArgs []string
+
+	ok := isGHAuthenticatedWithRunner(context.Background(), func(_ context.Context, name string, args ...string) error {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return nil
+	})
+	if !ok {
+		t.Fatalf("isGHAuthenticatedWithRunner() = false, want true")
+	}
+	if gotName != "gh" {
+		t.Fatalf("command name = %q, want %q", gotName, "gh")
+	}
+	wantArgs := []string{"auth", "status", "--hostname", "github.com"}
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("args len = %d, want %d (%v)", len(gotArgs), len(wantArgs), gotArgs)
+	}
+	for i := range wantArgs {
+		if gotArgs[i] != wantArgs[i] {
+			t.Fatalf("arg[%d] = %q, want %q", i, gotArgs[i], wantArgs[i])
+		}
+	}
+}
+
+func TestIsGHAuthenticatedWithRunner_ReturnsFalseOnError(t *testing.T) {
+	ok := isGHAuthenticatedWithRunner(context.Background(), func(context.Context, string, ...string) error {
+		return errors.New("not authenticated")
+	})
+	if ok {
+		t.Fatalf("isGHAuthenticatedWithRunner() = true, want false")
 	}
 }

--- a/internal/ci/fix.go
+++ b/internal/ci/fix.go
@@ -1,0 +1,289 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jywlabs/hal/internal/engine"
+)
+
+var (
+	// ErrFixRequiresFailingStatus is returned when FixWithEngine is called without failing aggregated status.
+	ErrFixRequiresFailingStatus = errors.New("ci fix requires failing status")
+
+	// ErrFixRequiresEngine is returned when FixWithEngine is called without an engine.
+	ErrFixRequiresEngine = errors.New("ci fix requires a non-nil engine")
+
+	// ErrFixDirtyWorkingTree is returned when fix starts with local git changes.
+	ErrFixDirtyWorkingTree = errors.New("ci fix requires a clean working tree (including untracked files)")
+
+	// ErrFixNoChanges is returned when the engine run produced no file changes.
+	ErrFixNoChanges = errors.New("ci fix engine run produced no file changes")
+)
+
+// FixOptions configures a single CI fix attempt.
+type FixOptions struct {
+	Engine      engine.Engine
+	Display     *engine.Display
+	Attempt     int
+	MaxAttempts int
+	AllowDirty  bool
+	Prompt      string
+}
+
+type fixDeps struct {
+	currentBranch      func(context.Context) (string, error)
+	workingTreeChanges func(context.Context) ([]string, error)
+	streamPrompt       func(context.Context, engine.Engine, string, *engine.Display) (string, error)
+	addAll             func(context.Context) error
+	commit             func(context.Context, string) error
+	currentHeadSHA     func(context.Context) (string, error)
+	pushBranch         func(context.Context, string) error
+}
+
+// FixWithEngine applies a single engine-driven fix attempt and pushes the resulting commit.
+func FixWithEngine(ctx context.Context, status StatusResult, opts FixOptions) (FixResult, error) {
+	return fixWithEngineWithDeps(ctx, status, opts, fixDeps{})
+}
+
+func fixWithEngineWithDeps(ctx context.Context, status StatusResult, opts FixOptions, deps fixDeps) (FixResult, error) {
+	if status.Status != StatusFailing {
+		return FixResult{}, fmt.Errorf("%w: got %q", ErrFixRequiresFailingStatus, status.Status)
+	}
+	if opts.Engine == nil {
+		return FixResult{}, ErrFixRequiresEngine
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if deps.currentBranch == nil {
+		deps.currentBranch = gitCurrentBranch
+	}
+	if deps.workingTreeChanges == nil {
+		deps.workingTreeChanges = gitWorkingTreeChanges
+	}
+	if deps.streamPrompt == nil {
+		deps.streamPrompt = streamFixPrompt
+	}
+	if deps.addAll == nil {
+		deps.addAll = gitAddAll
+	}
+	if deps.commit == nil {
+		deps.commit = gitCommit
+	}
+	if deps.currentHeadSHA == nil {
+		deps.currentHeadSHA = gitCurrentHEADSHA
+	}
+	if deps.pushBranch == nil {
+		deps.pushBranch = gitPushBranch
+	}
+
+	attempt := opts.Attempt
+	if attempt <= 0 {
+		attempt = 1
+	}
+
+	if !opts.AllowDirty {
+		changes, err := deps.workingTreeChanges(ctx)
+		if err != nil {
+			return FixResult{}, err
+		}
+		if len(changes) > 0 {
+			return FixResult{}, fmt.Errorf("%w: %s", ErrFixDirtyWorkingTree, strings.Join(changes, ", "))
+		}
+	}
+
+	branch, err := deps.currentBranch(ctx)
+	if err != nil {
+		return FixResult{}, err
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return FixResult{}, fmt.Errorf("get current branch: empty branch name")
+	}
+
+	failing := failingChecks(status)
+	prompt := strings.TrimSpace(opts.Prompt)
+	if prompt == "" {
+		prompt = buildFixPrompt(status, branch, attempt, failing)
+	}
+	if _, err := deps.streamPrompt(ctx, opts.Engine, prompt, opts.Display); err != nil {
+		return FixResult{}, fmt.Errorf("run ci fix prompt: %w", err)
+	}
+
+	changedFiles, err := deps.workingTreeChanges(ctx)
+	if err != nil {
+		return FixResult{}, err
+	}
+	changedFiles = uniqueSortedPaths(changedFiles)
+	if len(changedFiles) == 0 {
+		return FixResult{}, ErrFixNoChanges
+	}
+
+	if err := deps.addAll(ctx); err != nil {
+		return FixResult{}, err
+	}
+
+	commitMessage := defaultFixCommitMessage(attempt, failing)
+	if err := deps.commit(ctx, commitMessage); err != nil {
+		return FixResult{}, err
+	}
+
+	commitSHA, err := deps.currentHeadSHA(ctx)
+	if err != nil {
+		return FixResult{}, err
+	}
+
+	if err := deps.pushBranch(ctx, branch); err != nil {
+		return FixResult{}, err
+	}
+
+	return FixResult{
+		ContractVersion: FixContractVersion,
+		Attempt:         attempt,
+		MaxAttempts:     opts.MaxAttempts,
+		Applied:         true,
+		Branch:          branch,
+		CommitSHA:       strings.TrimSpace(commitSHA),
+		Pushed:          true,
+		FilesChanged:    changedFiles,
+		Summary:         fixSummary(branch, attempt, len(changedFiles)),
+	}, nil
+}
+
+func failingChecks(status StatusResult) []StatusCheck {
+	failing := make([]StatusCheck, 0)
+	for _, check := range status.Checks {
+		if check.Status == StatusFailing {
+			failing = append(failing, check)
+		}
+	}
+	return failing
+}
+
+func buildFixPrompt(status StatusResult, branch string, attempt int, failing []StatusCheck) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "CI status is failing for branch %q.\n", branch)
+	fmt.Fprintf(&sb, "This is fix attempt %d.\n\n", attempt)
+	fmt.Fprintf(&sb, "Summary: %s\n\n", strings.TrimSpace(status.Summary))
+
+	sb.WriteString("Failed CI contexts:\n")
+	if len(failing) == 0 {
+		sb.WriteString("- (none reported by aggregator; inspect failures from repository context)\n")
+	} else {
+		for _, check := range failing {
+			line := "- " + strings.TrimSpace(check.Name)
+			if strings.TrimSpace(check.Source) != "" {
+				line += " [" + strings.TrimSpace(check.Source) + "]"
+			}
+			if strings.TrimSpace(check.URL) != "" {
+				line += " " + strings.TrimSpace(check.URL)
+			}
+			sb.WriteString(line + "\n")
+		}
+	}
+
+	sb.WriteString("\nInstructions:\n")
+	sb.WriteString("1. Investigate the failing contexts and identify root causes.\n")
+	sb.WriteString("2. Apply the smallest safe code changes to resolve the failures.\n")
+	sb.WriteString("3. Do not disable, skip, or weaken tests/linters.\n")
+	sb.WriteString("4. Leave CI configuration unchanged unless it is clearly the root cause.\n")
+	sb.WriteString("5. Stop after applying fixes; commit/push is handled by the caller.\n")
+
+	return sb.String()
+}
+
+func defaultFixCommitMessage(attempt int, failing []StatusCheck) string {
+	primary := "failures"
+	if len(failing) > 0 {
+		primary = strings.TrimSpace(failing[0].Name)
+		if primary == "" {
+			primary = "failures"
+		}
+	}
+	return fmt.Sprintf("fix: ci %s (attempt %d)", primary, attempt)
+}
+
+func fixSummary(branch string, attempt int, changedFileCount int) string {
+	return fmt.Sprintf("applied ci fix attempt %d on branch %s and pushed %d files", attempt, branch, changedFileCount)
+}
+
+func streamFixPrompt(ctx context.Context, eng engine.Engine, prompt string, display *engine.Display) (string, error) {
+	return eng.StreamPrompt(ctx, prompt, display)
+}
+
+func gitWorkingTreeChanges(ctx context.Context) ([]string, error) {
+	out, err := runGit(ctx, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return nil, fmt.Errorf("read git working tree status: %w", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(out, "\n")
+	paths := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if path := parsePorcelainPath(line); path != "" {
+			paths = append(paths, path)
+		}
+	}
+	return uniqueSortedPaths(paths), nil
+}
+
+func parsePorcelainPath(line string) string {
+	line = strings.TrimRight(line, "\r\n")
+	if strings.TrimSpace(line) == "" || len(line) < 3 {
+		return ""
+	}
+
+	path := strings.TrimSpace(line[3:])
+	if path == "" {
+		return ""
+	}
+	if strings.Contains(path, " -> ") {
+		parts := strings.SplitN(path, " -> ", 2)
+		path = strings.TrimSpace(parts[1])
+	}
+	return strings.Trim(path, "\"")
+}
+
+func uniqueSortedPaths(paths []string) []string {
+	set := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		set[path] = struct{}{}
+	}
+
+	out := make([]string, 0, len(set))
+	for path := range set {
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func gitAddAll(ctx context.Context) error {
+	if _, err := runGit(ctx, "add", "-A"); err != nil {
+		return fmt.Errorf("stage fix changes: %w", err)
+	}
+	return nil
+}
+
+func gitCommit(ctx context.Context, message string) error {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return fmt.Errorf("commit fix changes: empty commit message")
+	}
+	if _, err := runGit(ctx, "commit", "-m", message); err != nil {
+		return fmt.Errorf("commit fix changes: %w", err)
+	}
+	return nil
+}

--- a/internal/ci/fix.go
+++ b/internal/ci/fix.go
@@ -217,7 +217,7 @@ func streamFixPrompt(ctx context.Context, eng engine.Engine, prompt string, disp
 }
 
 func gitWorkingTreeChanges(ctx context.Context) ([]string, error) {
-	out, err := runGit(ctx, "status", "--porcelain", "--untracked-files=all")
+	out, err := runGitRaw(ctx, "status", "--porcelain", "--untracked-files=all")
 	if err != nil {
 		return nil, fmt.Errorf("read git working tree status: %w", err)
 	}
@@ -241,15 +241,23 @@ func parsePorcelainPath(line string) string {
 		return ""
 	}
 
+	status := line[:2]
 	path := strings.TrimSpace(line[3:])
 	if path == "" {
 		return ""
 	}
-	if strings.Contains(path, " -> ") {
+	if isPorcelainRenameOrCopy(status) && strings.Contains(path, " -> ") {
 		parts := strings.SplitN(path, " -> ", 2)
 		path = strings.TrimSpace(parts[1])
 	}
 	return strings.Trim(path, "\"")
+}
+
+func isPorcelainRenameOrCopy(status string) bool {
+	if len(status) < 2 {
+		return false
+	}
+	return status[0] == 'R' || status[0] == 'C' || status[1] == 'R' || status[1] == 'C'
 }
 
 func uniqueSortedPaths(paths []string) []string {

--- a/internal/ci/fix_test.go
+++ b/internal/ci/fix_test.go
@@ -1,0 +1,305 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/engine"
+)
+
+type stubFixEngine struct{}
+
+func (stubFixEngine) Name() string { return "stub" }
+
+func (stubFixEngine) Execute(context.Context, string, *engine.Display) engine.Result {
+	return engine.Result{}
+}
+
+func (stubFixEngine) Prompt(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (stubFixEngine) StreamPrompt(context.Context, string, *engine.Display) (string, error) {
+	return "", nil
+}
+
+func TestFixWithEngineWithDeps_RejectsNonFailingStatus(t *testing.T) {
+	t.Parallel()
+
+	_, err := fixWithEngineWithDeps(context.Background(), StatusResult{Status: StatusPassing}, FixOptions{
+		Engine: stubFixEngine{},
+	}, fixDeps{})
+	if err == nil {
+		t.Fatal("fixWithEngineWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrFixRequiresFailingStatus) {
+		t.Fatalf("errors.Is(err, ErrFixRequiresFailingStatus) = false, err=%v", err)
+	}
+}
+
+func TestFixWithEngineWithDeps_RejectsNilEngine(t *testing.T) {
+	t.Parallel()
+
+	_, err := fixWithEngineWithDeps(context.Background(), failingStatusResult(), FixOptions{}, fixDeps{})
+	if err == nil {
+		t.Fatal("fixWithEngineWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrFixRequiresEngine) {
+		t.Fatalf("errors.Is(err, ErrFixRequiresEngine) = false, err=%v", err)
+	}
+}
+
+func TestFixWithEngineWithDeps_RequiresCleanWorkingTreeByDefault(t *testing.T) {
+	t.Parallel()
+
+	streamCalled := false
+
+	_, err := fixWithEngineWithDeps(context.Background(), failingStatusResult(), FixOptions{
+		Engine: stubFixEngine{},
+	}, fixDeps{
+		workingTreeChanges: func(context.Context) ([]string, error) {
+			return []string{"new_untracked_file.go"}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-fix", nil
+		},
+		streamPrompt: func(context.Context, engine.Engine, string, *engine.Display) (string, error) {
+			streamCalled = true
+			return "", nil
+		},
+	})
+	if err == nil {
+		t.Fatal("fixWithEngineWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrFixDirtyWorkingTree) {
+		t.Fatalf("errors.Is(err, ErrFixDirtyWorkingTree) = false, err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "new_untracked_file.go") {
+		t.Fatalf("error %q should list changed file", err)
+	}
+	if streamCalled {
+		t.Fatal("streamPrompt should not be called when tree is dirty")
+	}
+}
+
+func TestFixWithEngineWithDeps_RejectsNoChangesAfterEngine(t *testing.T) {
+	t.Parallel()
+
+	streamCalled := false
+	addCalled := false
+	commitCalled := false
+	pushCalled := false
+	changesCalls := 0
+
+	_, err := fixWithEngineWithDeps(context.Background(), failingStatusResult(), FixOptions{
+		Engine: stubFixEngine{},
+	}, fixDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-fix", nil
+		},
+		workingTreeChanges: func(context.Context) ([]string, error) {
+			changesCalls++
+			return nil, nil
+		},
+		streamPrompt: func(_ context.Context, _ engine.Engine, prompt string, _ *engine.Display) (string, error) {
+			streamCalled = true
+			if !strings.Contains(prompt, "build") {
+				t.Fatalf("prompt should include failing check name, got %q", prompt)
+			}
+			return "", nil
+		},
+		addAll: func(context.Context) error {
+			addCalled = true
+			return nil
+		},
+		commit: func(context.Context, string) error {
+			commitCalled = true
+			return nil
+		},
+		currentHeadSHA: func(context.Context) (string, error) {
+			return "deadbeef", nil
+		},
+		pushBranch: func(context.Context, string) error {
+			pushCalled = true
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("fixWithEngineWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrFixNoChanges) {
+		t.Fatalf("errors.Is(err, ErrFixNoChanges) = false, err=%v", err)
+	}
+	if !streamCalled {
+		t.Fatal("streamPrompt should be called")
+	}
+	if changesCalls != 2 {
+		t.Fatalf("workingTreeChanges calls = %d, want 2", changesCalls)
+	}
+	if addCalled {
+		t.Fatal("addAll should not be called when no files changed")
+	}
+	if commitCalled {
+		t.Fatal("commit should not be called when no files changed")
+	}
+	if pushCalled {
+		t.Fatal("pushBranch should not be called when no files changed")
+	}
+}
+
+func TestFixWithEngineWithDeps_SuccessCommitsAndPushes(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/ci-fix"
+
+	changesCalls := 0
+	addCalls := 0
+	commitCalls := 0
+	pushCalls := 0
+	streamCalls := 0
+	commitMessage := ""
+
+	result, err := fixWithEngineWithDeps(context.Background(), failingStatusResult(), FixOptions{
+		Engine:      stubFixEngine{},
+		Attempt:     2,
+		MaxAttempts: 4,
+	}, fixDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return branch, nil
+		},
+		workingTreeChanges: func(context.Context) ([]string, error) {
+			changesCalls++
+			if changesCalls == 1 {
+				return nil, nil
+			}
+			return []string{"z.go", "a.go", "a.go", "b.go"}, nil
+		},
+		streamPrompt: func(_ context.Context, _ engine.Engine, prompt string, _ *engine.Display) (string, error) {
+			streamCalls++
+			for _, want := range []string{"build", "lint"} {
+				if !strings.Contains(prompt, want) {
+					t.Fatalf("prompt %q should contain %q", prompt, want)
+				}
+			}
+			return "done", nil
+		},
+		addAll: func(context.Context) error {
+			addCalls++
+			return nil
+		},
+		commit: func(_ context.Context, msg string) error {
+			commitCalls++
+			commitMessage = msg
+			return nil
+		},
+		currentHeadSHA: func(context.Context) (string, error) {
+			return "deadbeef", nil
+		},
+		pushBranch: func(_ context.Context, gotBranch string) error {
+			pushCalls++
+			if gotBranch != branch {
+				t.Fatalf("push branch = %q, want %q", gotBranch, branch)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("fixWithEngineWithDeps() error = %v", err)
+	}
+
+	if streamCalls != 1 {
+		t.Fatalf("streamPrompt calls = %d, want 1", streamCalls)
+	}
+	if changesCalls != 2 {
+		t.Fatalf("workingTreeChanges calls = %d, want 2", changesCalls)
+	}
+	if addCalls != 1 {
+		t.Fatalf("addAll calls = %d, want 1", addCalls)
+	}
+	if commitCalls != 1 {
+		t.Fatalf("commit calls = %d, want 1", commitCalls)
+	}
+	if pushCalls != 1 {
+		t.Fatalf("pushBranch calls = %d, want 1", pushCalls)
+	}
+
+	if !strings.Contains(commitMessage, "attempt 2") {
+		t.Fatalf("commit message = %q, want to include attempt metadata", commitMessage)
+	}
+
+	if result.ContractVersion != FixContractVersion {
+		t.Fatalf("result.ContractVersion = %q, want %q", result.ContractVersion, FixContractVersion)
+	}
+	if result.Attempt != 2 {
+		t.Fatalf("result.Attempt = %d, want 2", result.Attempt)
+	}
+	if result.MaxAttempts != 4 {
+		t.Fatalf("result.MaxAttempts = %d, want 4", result.MaxAttempts)
+	}
+	if !result.Applied {
+		t.Fatal("result.Applied = false, want true")
+	}
+	if result.Branch != branch {
+		t.Fatalf("result.Branch = %q, want %q", result.Branch, branch)
+	}
+	if result.CommitSHA != "deadbeef" {
+		t.Fatalf("result.CommitSHA = %q, want %q", result.CommitSHA, "deadbeef")
+	}
+	if !result.Pushed {
+		t.Fatal("result.Pushed = false, want true")
+	}
+	if got, want := result.FilesChanged, []string{"a.go", "b.go", "z.go"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("result.FilesChanged = %v, want %v", got, want)
+	}
+	if !strings.Contains(result.Summary, branch) {
+		t.Fatalf("result.Summary = %q, want branch %q", result.Summary, branch)
+	}
+}
+
+func TestParsePorcelainPath_HandlesUntrackedAndRename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		line string
+		want string
+	}{
+		{line: "?? new_file.go", want: "new_file.go"},
+		{line: " M internal/ci/fix.go", want: "internal/ci/fix.go"},
+		{line: "R  old_name.go -> new_name.go", want: "new_name.go"},
+		{line: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parsePorcelainPath(tt.line); got != tt.want {
+				t.Fatalf("parsePorcelainPath(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func failingStatusResult() StatusResult {
+	return StatusResult{
+		Status: StatusFailing,
+		Checks: []StatusCheck{
+			{
+				Key:    "check:build",
+				Source: CheckSourceCheckRun,
+				Name:   "build",
+				Status: StatusFailing,
+			},
+			{
+				Key:    "status:lint",
+				Source: CheckSourceStatus,
+				Name:   "lint",
+				Status: StatusFailing,
+			},
+		},
+		Summary: "status=failing (passing=0, failing=2, pending=0)",
+	}
+}

--- a/internal/ci/fix_test.go
+++ b/internal/ci/fix_test.go
@@ -3,6 +3,9 @@ package ci
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -269,6 +272,8 @@ func TestParsePorcelainPath_HandlesUntrackedAndRename(t *testing.T) {
 		{line: "?? new_file.go", want: "new_file.go"},
 		{line: " M internal/ci/fix.go", want: "internal/ci/fix.go"},
 		{line: "R  old_name.go -> new_name.go", want: "new_name.go"},
+		{line: " C source.txt -> copy.txt", want: "copy.txt"},
+		{line: "?? docs/plan -> draft.md", want: "docs/plan -> draft.md"},
 		{line: "", want: ""},
 	}
 
@@ -280,6 +285,43 @@ func TestParsePorcelainPath_HandlesUntrackedAndRename(t *testing.T) {
 				t.Fatalf("parsePorcelainPath(%q) = %q, want %q", tt.line, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGitWorkingTreeChanges_PreservesLeadingPorcelainStatusColumns(t *testing.T) {
+	repo := t.TempDir()
+	runGitCommand(t, repo, "init")
+	runGitCommand(t, repo, "config", "user.name", "Hal Test")
+	runGitCommand(t, repo, "config", "user.email", "hal-test@example.com")
+
+	trackedFile := filepath.Join(repo, "tracked.txt")
+	if err := os.WriteFile(trackedFile, []byte("original\n"), 0o644); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+	runGitCommand(t, repo, "add", "tracked.txt")
+	runGitCommand(t, repo, "commit", "-m", "initial")
+
+	if err := os.WriteFile(trackedFile, []byte("changed\n"), 0o644); err != nil {
+		t.Fatalf("modify tracked file: %v", err)
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir to repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(wd)
+	})
+
+	changed, err := gitWorkingTreeChanges(context.Background())
+	if err != nil {
+		t.Fatalf("gitWorkingTreeChanges() error = %v", err)
+	}
+	if got, want := changed, []string{"tracked.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("gitWorkingTreeChanges() = %v, want %v", got, want)
 	}
 }
 
@@ -301,5 +343,16 @@ func failingStatusResult() StatusResult {
 			},
 		},
 		Summary: "status=failing (passing=0, failing=2, pending=0)",
+	}
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 	}
 }

--- a/internal/ci/merge.go
+++ b/internal/ci/merge.go
@@ -1,0 +1,258 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+const defaultMergeStrategy = "squash"
+
+var (
+	// ErrMergeInvalidStrategy is returned when merge strategy is unsupported.
+	ErrMergeInvalidStrategy = errors.New("ci merge strategy must be one of squash, merge, rebase")
+
+	// ErrMergeRequiresPassingStatus is returned when merge runs against non-passing checks.
+	ErrMergeRequiresPassingStatus = errors.New("ci merge requires passing status")
+
+	// ErrMergeNoChecksDisallowed is returned when no checks were discovered and override is disabled.
+	ErrMergeNoChecksDisallowed = errors.New("ci merge blocked: no checks discovered")
+
+	// ErrMergePRNotFound is returned when there is no open pull request for the current branch.
+	ErrMergePRNotFound = errors.New("ci merge requires an open pull request for the current branch")
+
+	// ErrMergeHeadDrift is returned when the expected PR head SHA differs from current PR head SHA.
+	ErrMergeHeadDrift = errors.New("ci merge aborted: pull request head changed")
+
+	// ErrRemoteBranchNotFound is returned when deleting a remote branch returns HTTP 404.
+	ErrRemoteBranchNotFound = errors.New("remote branch not found")
+)
+
+// MergeOptions configures safe pull request merge behavior.
+type MergeOptions struct {
+	Strategy      string
+	DeleteBranch  bool
+	AllowNoChecks bool
+}
+
+type mergeDeps struct {
+	currentBranch      func(context.Context) (string, error)
+	resolveRepo        func(context.Context) (GitHubRepository, error)
+	getStatus          func(context.Context) (StatusResult, error)
+	findOpenPR         func(context.Context, GitHubRepository, string) (*PullRequest, error)
+	mergePullRequest   func(context.Context, GitHubRepository, int, string) (string, error)
+	deleteRemoteBranch func(context.Context, GitHubRepository, string) error
+}
+
+// MergePR merges the open pull request for the current branch with CI safety guards.
+func MergePR(ctx context.Context, opts MergeOptions) (MergeResult, error) {
+	return mergePRWithDeps(ctx, opts, mergeDeps{})
+}
+
+func mergePRWithDeps(ctx context.Context, opts MergeOptions, deps mergeDeps) (MergeResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	strategy, err := normalizeMergeStrategy(opts.Strategy)
+	if err != nil {
+		return MergeResult{}, err
+	}
+
+	if deps.currentBranch == nil {
+		deps.currentBranch = gitCurrentBranch
+	}
+	if deps.resolveRepo == nil {
+		deps.resolveRepo = ResolveGitHubRepository
+	}
+	if deps.getStatus == nil {
+		deps.getStatus = GetStatus
+	}
+	if deps.findOpenPR == nil {
+		deps.findOpenPR = findOpenPullRequest
+	}
+	if deps.mergePullRequest == nil {
+		deps.mergePullRequest = mergePullRequest
+	}
+	if deps.deleteRemoteBranch == nil {
+		deps.deleteRemoteBranch = deleteRemoteBranch
+	}
+
+	branch, err := deps.currentBranch(ctx)
+	if err != nil {
+		return MergeResult{}, err
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return MergeResult{}, fmt.Errorf("get current branch: empty branch name")
+	}
+
+	repo, err := deps.resolveRepo(ctx)
+	if err != nil {
+		return MergeResult{}, err
+	}
+
+	status, err := deps.getStatus(ctx)
+	if err != nil {
+		return MergeResult{}, err
+	}
+	if !status.ChecksDiscovered {
+		if !opts.AllowNoChecks {
+			return MergeResult{}, fmt.Errorf("%w; rerun with --allow-no-checks to override", ErrMergeNoChecksDisallowed)
+		}
+	} else if status.Status != StatusPassing {
+		return MergeResult{}, fmt.Errorf("%w: got %q; run 'hal ci status' and 'hal ci fix' before retrying", ErrMergeRequiresPassingStatus, status.Status)
+	}
+
+	pr, err := deps.findOpenPR(ctx, repo, branch)
+	if err != nil {
+		return MergeResult{}, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
+	}
+	if pr == nil {
+		return MergeResult{}, fmt.Errorf("%w: branch %q", ErrMergePRNotFound, branch)
+	}
+
+	expectedHeadSHA := strings.TrimSpace(status.SHA)
+	currentHeadSHA := strings.TrimSpace(pr.HeadSHA)
+	if expectedHeadSHA != "" && currentHeadSHA != "" && expectedHeadSHA != currentHeadSHA {
+		return MergeResult{}, fmt.Errorf("%w: expected %s but found %s; rerun 'hal ci status' and retry merge", ErrMergeHeadDrift, expectedHeadSHA, currentHeadSHA)
+	}
+
+	mergeCommitSHA, err := deps.mergePullRequest(ctx, repo, pr.Number, strategy)
+	if err != nil {
+		return MergeResult{}, err
+	}
+
+	result := MergeResult{
+		ContractVersion: MergeContractVersion,
+		PRNumber:        pr.Number,
+		Strategy:        strategy,
+		Merged:          true,
+		MergeCommitSHA:  strings.TrimSpace(mergeCommitSHA),
+	}
+
+	if opts.DeleteBranch {
+		branchToDelete := strings.TrimSpace(pr.HeadRef)
+		if branchToDelete == "" {
+			branchToDelete = branch
+		}
+		if err := deps.deleteRemoteBranch(ctx, repo, branchToDelete); err != nil {
+			switch {
+			case errors.Is(err, ErrRemoteBranchNotFound):
+				// Ignore; branch is already gone.
+			default:
+				result.DeleteWarning = fmt.Sprintf("delete remote branch %q: %v", branchToDelete, err)
+			}
+		} else {
+			result.BranchDeleted = true
+		}
+	}
+
+	result.Summary = mergeSummary(result, opts.DeleteBranch)
+	return result, nil
+}
+
+func normalizeMergeStrategy(strategy string) (string, error) {
+	strategy = strings.ToLower(strings.TrimSpace(strategy))
+	if strategy == "" {
+		strategy = defaultMergeStrategy
+	}
+
+	switch strategy {
+	case "squash", "merge", "rebase":
+		return strategy, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrMergeInvalidStrategy, strategy)
+	}
+}
+
+func mergeSummary(result MergeResult, deleteBranchRequested bool) string {
+	summary := fmt.Sprintf("merged pull request #%d using %s strategy", result.PRNumber, result.Strategy)
+	if !deleteBranchRequested {
+		return summary
+	}
+
+	if result.BranchDeleted {
+		return summary + " and deleted the remote branch"
+	}
+	if result.DeleteWarning != "" {
+		return summary + "; warning: " + result.DeleteWarning
+	}
+	return summary + "; remote branch already absent"
+}
+
+type ghMergeResponse struct {
+	SHA string `json:"sha"`
+}
+
+func mergePullRequest(ctx context.Context, repo GitHubRepository, prNumber int, strategy string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	endpoint := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", repo.Owner, repo.Name, prNumber)
+	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "PUT", "-H", "Accept: application/vnd.github+json", endpoint, "-f", "merge_method="+strategy)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return "", fmt.Errorf("merge pull request #%d failed: %s: %w", prNumber, stderrText, err)
+		}
+		return "", fmt.Errorf("merge pull request #%d failed: %w", prNumber, err)
+	}
+
+	var response ghMergeResponse
+	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
+		return "", fmt.Errorf("decode merge response for pull request #%d: %w", prNumber, err)
+	}
+
+	sha := strings.TrimSpace(response.SHA)
+	if sha == "" {
+		return "", fmt.Errorf("merge pull request #%d failed: empty merge commit sha", prNumber)
+	}
+	return sha, nil
+}
+
+func deleteRemoteBranch(ctx context.Context, repo GitHubRepository, branch string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return fmt.Errorf("delete remote branch: empty branch name")
+	}
+
+	endpoint := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", repo.Owner, repo.Name, url.PathEscape(branch))
+	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "DELETE", "-H", "Accept: application/vnd.github+json", endpoint)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if isHTTP404Error(stderrText) {
+			return fmt.Errorf("%w: %s", ErrRemoteBranchNotFound, branch)
+		}
+		if stderrText != "" {
+			return fmt.Errorf("delete remote branch %q failed: %s: %w", branch, stderrText, err)
+		}
+		return fmt.Errorf("delete remote branch %q failed: %w", branch, err)
+	}
+
+	return nil
+}
+
+func isHTTP404Error(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return strings.Contains(lower, "http 404") || strings.Contains(lower, "404 not found")
+}

--- a/internal/ci/merge.go
+++ b/internal/ci/merge.go
@@ -1,13 +1,11 @@
 package ci
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
-	"os/exec"
 	"strings"
 )
 
@@ -45,7 +43,7 @@ type mergeDeps struct {
 	resolveRepo        func(context.Context) (GitHubRepository, error)
 	getStatus          func(context.Context) (StatusResult, error)
 	findOpenPR         func(context.Context, GitHubRepository, string) (*PullRequest, error)
-	mergePullRequest   func(context.Context, GitHubRepository, int, string) (string, error)
+	mergePullRequest   func(context.Context, GitHubRepository, int, string, string) (string, error)
 	deleteRemoteBranch func(context.Context, GitHubRepository, string) error
 }
 
@@ -59,7 +57,7 @@ func mergePRWithDeps(ctx context.Context, opts MergeOptions, deps mergeDeps) (Me
 		ctx = context.Background()
 	}
 
-	strategy, err := normalizeMergeStrategy(opts.Strategy)
+	strategy, err := NormalizeMergeStrategy(opts.Strategy)
 	if err != nil {
 		return MergeResult{}, err
 	}
@@ -97,6 +95,14 @@ func mergePRWithDeps(ctx context.Context, opts MergeOptions, deps mergeDeps) (Me
 		return MergeResult{}, err
 	}
 
+	pr, err := deps.findOpenPR(ctx, repo, branch)
+	if err != nil {
+		return MergeResult{}, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
+	}
+	if pr == nil {
+		return MergeResult{}, fmt.Errorf("%w: branch %q", ErrMergePRNotFound, branch)
+	}
+
 	status, err := deps.getStatus(ctx)
 	if err != nil {
 		return MergeResult{}, err
@@ -109,22 +115,17 @@ func mergePRWithDeps(ctx context.Context, opts MergeOptions, deps mergeDeps) (Me
 		return MergeResult{}, fmt.Errorf("%w: got %q; run 'hal ci status' and 'hal ci fix' before retrying", ErrMergeRequiresPassingStatus, status.Status)
 	}
 
-	pr, err := deps.findOpenPR(ctx, repo, branch)
-	if err != nil {
-		return MergeResult{}, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
-	}
-	if pr == nil {
-		return MergeResult{}, fmt.Errorf("%w: branch %q", ErrMergePRNotFound, branch)
-	}
-
 	expectedHeadSHA := strings.TrimSpace(status.SHA)
 	currentHeadSHA := strings.TrimSpace(pr.HeadSHA)
 	if expectedHeadSHA != "" && currentHeadSHA != "" && expectedHeadSHA != currentHeadSHA {
 		return MergeResult{}, fmt.Errorf("%w: expected %s but found %s; rerun 'hal ci status' and retry merge", ErrMergeHeadDrift, expectedHeadSHA, currentHeadSHA)
 	}
 
-	mergeCommitSHA, err := deps.mergePullRequest(ctx, repo, pr.Number, strategy)
+	mergeCommitSHA, err := deps.mergePullRequest(ctx, repo, pr.Number, strategy, expectedHeadSHA)
 	if err != nil {
+		if expectedHeadSHA != "" && (isGitHubAPIHTTPStatus(err, http.StatusConflict) || isGitHubAPIHTTPStatus(err, http.StatusUnprocessableEntity)) {
+			return MergeResult{}, fmt.Errorf("%w: expected %s; rerun 'hal ci status' and retry merge", ErrMergeHeadDrift, expectedHeadSHA)
+		}
 		return MergeResult{}, err
 	}
 
@@ -157,7 +158,8 @@ func mergePRWithDeps(ctx context.Context, opts MergeOptions, deps mergeDeps) (Me
 	return result, nil
 }
 
-func normalizeMergeStrategy(strategy string) (string, error) {
+// NormalizeMergeStrategy returns a canonical merge strategy or an error when unsupported.
+func NormalizeMergeStrategy(strategy string) (string, error) {
 	strategy = strings.ToLower(strings.TrimSpace(strategy))
 	if strategy == "" {
 		strategy = defaultMergeStrategy
@@ -190,29 +192,32 @@ type ghMergeResponse struct {
 	SHA string `json:"sha"`
 }
 
-func mergePullRequest(ctx context.Context, repo GitHubRepository, prNumber int, strategy string) (string, error) {
+func mergePullRequest(ctx context.Context, repo GitHubRepository, prNumber int, strategy string, expectedHeadSHA string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	endpoint := fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", repo.Owner, repo.Name, prNumber)
-	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "PUT", "-H", "Accept: application/vnd.github+json", endpoint, "-f", "merge_method="+strategy)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		stderrText := strings.TrimSpace(stderr.String())
-		if stderrText != "" {
-			return "", fmt.Errorf("merge pull request #%d failed: %s: %w", prNumber, stderrText, err)
-		}
-		return "", fmt.Errorf("merge pull request #%d failed: %w", prNumber, err)
+	mergeRequest := map[string]string{
+		"merge_method": strategy,
+	}
+	expectedHeadSHA = strings.TrimSpace(expectedHeadSHA)
+	if expectedHeadSHA != "" {
+		mergeRequest["sha"] = expectedHeadSHA
 	}
 
 	var response ghMergeResponse
-	if err := json.Unmarshal(stdout.Bytes(), &response); err != nil {
-		return "", fmt.Errorf("decode merge response for pull request #%d: %w", prNumber, err)
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{
+		Method:   http.MethodPut,
+		Endpoint: endpoint,
+		Body:     mergeRequest,
+	}, &response); err != nil {
+		return "", fmt.Errorf("merge pull request #%d failed: %w", prNumber, err)
 	}
 
 	sha := strings.TrimSpace(response.SHA)
@@ -232,27 +237,21 @@ func deleteRemoteBranch(ctx context.Context, repo GitHubRepository, branch strin
 		return fmt.Errorf("delete remote branch: empty branch name")
 	}
 
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return err
+	}
+
 	endpoint := fmt.Sprintf("/repos/%s/%s/git/refs/heads/%s", repo.Owner, repo.Name, url.PathEscape(branch))
-	cmd := exec.CommandContext(ctx, "gh", "api", "-X", "DELETE", "-H", "Accept: application/vnd.github+json", endpoint)
-
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		stderrText := strings.TrimSpace(stderr.String())
-		if isHTTP404Error(stderrText) {
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{
+		Method:   http.MethodDelete,
+		Endpoint: endpoint,
+	}, nil); err != nil {
+		if isGitHubAPIHTTPStatus(err, http.StatusNotFound) {
 			return fmt.Errorf("%w: %s", ErrRemoteBranchNotFound, branch)
-		}
-		if stderrText != "" {
-			return fmt.Errorf("delete remote branch %q failed: %s: %w", branch, stderrText, err)
 		}
 		return fmt.Errorf("delete remote branch %q failed: %w", branch, err)
 	}
 
 	return nil
-}
-
-func isHTTP404Error(text string) bool {
-	lower := strings.ToLower(strings.TrimSpace(text))
-	return strings.Contains(lower, "http 404") || strings.Contains(lower, "404 not found")
 }

--- a/internal/ci/merge_test.go
+++ b/internal/ci/merge_test.go
@@ -1,0 +1,325 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMergePRWithDeps_RejectsInvalidStrategy(t *testing.T) {
+	t.Parallel()
+
+	depsCalled := false
+	_, err := mergePRWithDeps(context.Background(), MergeOptions{Strategy: "fast-forward"}, mergeDeps{
+		currentBranch: func(context.Context) (string, error) {
+			depsCalled = true
+			return "hal/ci-merge", nil
+		},
+	})
+	if err == nil {
+		t.Fatal("mergePRWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrMergeInvalidStrategy) {
+		t.Fatalf("errors.Is(err, ErrMergeInvalidStrategy) = false, err=%v", err)
+	}
+	if depsCalled {
+		t.Fatal("strategy should be validated before evaluating dependencies")
+	}
+}
+
+func TestMergePRWithDeps_BlocksNonPassingStatuses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status StatusResult
+	}{
+		{
+			name: "failing",
+			status: StatusResult{
+				Status:           StatusFailing,
+				ChecksDiscovered: true,
+				SHA:              "head-sha",
+			},
+		},
+		{
+			name: "pending",
+			status: StatusResult{
+				Status:           StatusPending,
+				ChecksDiscovered: true,
+				SHA:              "head-sha",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			findCalled := false
+			mergeCalled := false
+
+			_, err := mergePRWithDeps(context.Background(), MergeOptions{}, mergeDeps{
+				currentBranch: func(context.Context) (string, error) {
+					return "hal/ci-merge", nil
+				},
+				resolveRepo: func(context.Context) (GitHubRepository, error) {
+					return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+				},
+				getStatus: func(context.Context) (StatusResult, error) {
+					return tt.status, nil
+				},
+				findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+					findCalled = true
+					return &PullRequest{Number: 7, HeadSHA: "head-sha"}, nil
+				},
+				mergePullRequest: func(context.Context, GitHubRepository, int, string) (string, error) {
+					mergeCalled = true
+					return "merge-sha", nil
+				},
+			})
+			if err == nil {
+				t.Fatal("mergePRWithDeps() error = nil, want non-nil")
+			}
+			if !errors.Is(err, ErrMergeRequiresPassingStatus) {
+				t.Fatalf("errors.Is(err, ErrMergeRequiresPassingStatus) = false, err=%v", err)
+			}
+			if findCalled {
+				t.Fatal("findOpenPR should not be called when status is not passing")
+			}
+			if mergeCalled {
+				t.Fatal("mergePullRequest should not be called when status is not passing")
+			}
+		})
+	}
+}
+
+func TestMergePRWithDeps_AllowNoChecksBehavior(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/no-checks"
+	const sha = "head-sha"
+
+	t.Run("blocks when override disabled", func(t *testing.T) {
+		t.Parallel()
+
+		findCalled := false
+		_, err := mergePRWithDeps(context.Background(), MergeOptions{}, mergeDeps{
+			currentBranch: func(context.Context) (string, error) {
+				return branch, nil
+			},
+			resolveRepo: func(context.Context) (GitHubRepository, error) {
+				return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+			},
+			getStatus: func(context.Context) (StatusResult, error) {
+				return StatusResult{Status: StatusPending, ChecksDiscovered: false, SHA: sha}, nil
+			},
+			findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+				findCalled = true
+				return &PullRequest{Number: 9, HeadSHA: sha}, nil
+			},
+		})
+		if err == nil {
+			t.Fatal("mergePRWithDeps() error = nil, want non-nil")
+		}
+		if !errors.Is(err, ErrMergeNoChecksDisallowed) {
+			t.Fatalf("errors.Is(err, ErrMergeNoChecksDisallowed) = false, err=%v", err)
+		}
+		if findCalled {
+			t.Fatal("findOpenPR should not be called when no-check override is disabled")
+		}
+	})
+
+	t.Run("allows merge when override enabled", func(t *testing.T) {
+		t.Parallel()
+
+		mergeCalled := false
+		deleteCalled := false
+
+		result, err := mergePRWithDeps(context.Background(), MergeOptions{AllowNoChecks: true}, mergeDeps{
+			currentBranch: func(context.Context) (string, error) {
+				return branch, nil
+			},
+			resolveRepo: func(context.Context) (GitHubRepository, error) {
+				return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+			},
+			getStatus: func(context.Context) (StatusResult, error) {
+				return StatusResult{Status: StatusPending, ChecksDiscovered: false, SHA: sha}, nil
+			},
+			findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+				return &PullRequest{Number: 9, HeadSHA: sha, HeadRef: branch}, nil
+			},
+			mergePullRequest: func(_ context.Context, _ GitHubRepository, prNumber int, strategy string) (string, error) {
+				mergeCalled = true
+				if prNumber != 9 {
+					t.Fatalf("prNumber = %d, want 9", prNumber)
+				}
+				if strategy != "squash" {
+					t.Fatalf("strategy = %q, want default \"squash\"", strategy)
+				}
+				return "merged-sha", nil
+			},
+			deleteRemoteBranch: func(context.Context, GitHubRepository, string) error {
+				deleteCalled = true
+				return nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("mergePRWithDeps() error = %v", err)
+		}
+		if !mergeCalled {
+			t.Fatal("mergePullRequest was not called")
+		}
+		if deleteCalled {
+			t.Fatal("deleteRemoteBranch should not be called when DeleteBranch is false")
+		}
+		if result.ContractVersion != MergeContractVersion {
+			t.Fatalf("result.ContractVersion = %q, want %q", result.ContractVersion, MergeContractVersion)
+		}
+		if !result.Merged {
+			t.Fatal("result.Merged = false, want true")
+		}
+		if result.Strategy != "squash" {
+			t.Fatalf("result.Strategy = %q, want %q", result.Strategy, "squash")
+		}
+		if result.PRNumber != 9 {
+			t.Fatalf("result.PRNumber = %d, want 9", result.PRNumber)
+		}
+		if result.MergeCommitSHA != "merged-sha" {
+			t.Fatalf("result.MergeCommitSHA = %q, want %q", result.MergeCommitSHA, "merged-sha")
+		}
+	})
+}
+
+func TestMergePRWithDeps_BlocksHeadDrift(t *testing.T) {
+	t.Parallel()
+
+	mergeCalled := false
+	_, err := mergePRWithDeps(context.Background(), MergeOptions{}, mergeDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-merge", nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		getStatus: func(context.Context) (StatusResult, error) {
+			return StatusResult{Status: StatusPassing, ChecksDiscovered: true, SHA: "old-sha"}, nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+			return &PullRequest{Number: 22, HeadSHA: "new-sha"}, nil
+		},
+		mergePullRequest: func(context.Context, GitHubRepository, int, string) (string, error) {
+			mergeCalled = true
+			return "", nil
+		},
+	})
+	if err == nil {
+		t.Fatal("mergePRWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrMergeHeadDrift) {
+		t.Fatalf("errors.Is(err, ErrMergeHeadDrift) = false, err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "old-sha") || !strings.Contains(err.Error(), "new-sha") {
+		t.Fatalf("drift error should include both shas, got %q", err)
+	}
+	if mergeCalled {
+		t.Fatal("mergePullRequest should not be called when head drift is detected")
+	}
+}
+
+func TestMergePRWithDeps_DeleteBranchWarnings(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/ci-merge"
+
+	tests := []struct {
+		name              string
+		deleteErr         error
+		wantBranchDeleted bool
+		wantWarning       string
+	}{
+		{
+			name:              "delete success",
+			deleteErr:         nil,
+			wantBranchDeleted: true,
+			wantWarning:       "",
+		},
+		{
+			name:              "ignore 404",
+			deleteErr:         fmt.Errorf("%w: already deleted", ErrRemoteBranchNotFound),
+			wantBranchDeleted: false,
+			wantWarning:       "",
+		},
+		{
+			name:              "non-404 warning",
+			deleteErr:         errors.New("permission denied"),
+			wantBranchDeleted: false,
+			wantWarning:       "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deleteCalls := 0
+
+			result, err := mergePRWithDeps(context.Background(), MergeOptions{Strategy: "merge", DeleteBranch: true}, mergeDeps{
+				currentBranch: func(context.Context) (string, error) {
+					return branch, nil
+				},
+				resolveRepo: func(context.Context) (GitHubRepository, error) {
+					return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+				},
+				getStatus: func(context.Context) (StatusResult, error) {
+					return StatusResult{Status: StatusPassing, ChecksDiscovered: true, SHA: "head-sha"}, nil
+				},
+				findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+					return &PullRequest{Number: 42, HeadSHA: "head-sha", HeadRef: branch}, nil
+				},
+				mergePullRequest: func(_ context.Context, _ GitHubRepository, prNumber int, strategy string) (string, error) {
+					if prNumber != 42 {
+						t.Fatalf("prNumber = %d, want 42", prNumber)
+					}
+					if strategy != "merge" {
+						t.Fatalf("strategy = %q, want %q", strategy, "merge")
+					}
+					return "merge-commit-sha", nil
+				},
+				deleteRemoteBranch: func(_ context.Context, _ GitHubRepository, gotBranch string) error {
+					deleteCalls++
+					if gotBranch != branch {
+						t.Fatalf("delete branch = %q, want %q", gotBranch, branch)
+					}
+					return tt.deleteErr
+				},
+			})
+			if err != nil {
+				t.Fatalf("mergePRWithDeps() error = %v", err)
+			}
+			if deleteCalls != 1 {
+				t.Fatalf("deleteRemoteBranch calls = %d, want 1", deleteCalls)
+			}
+			if !result.Merged {
+				t.Fatal("result.Merged = false, want true")
+			}
+			if result.Strategy != "merge" {
+				t.Fatalf("result.Strategy = %q, want %q", result.Strategy, "merge")
+			}
+			if result.BranchDeleted != tt.wantBranchDeleted {
+				t.Fatalf("result.BranchDeleted = %t, want %t", result.BranchDeleted, tt.wantBranchDeleted)
+			}
+			if tt.wantWarning == "" {
+				if result.DeleteWarning != "" {
+					t.Fatalf("result.DeleteWarning = %q, want empty", result.DeleteWarning)
+				}
+			} else if !strings.Contains(result.DeleteWarning, tt.wantWarning) {
+				t.Fatalf("result.DeleteWarning = %q, want to contain %q", result.DeleteWarning, tt.wantWarning)
+			}
+		})
+	}
+}

--- a/internal/ci/merge_test.go
+++ b/internal/ci/merge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -76,7 +77,7 @@ func TestMergePRWithDeps_BlocksNonPassingStatuses(t *testing.T) {
 					findCalled = true
 					return &PullRequest{Number: 7, HeadSHA: "head-sha"}, nil
 				},
-				mergePullRequest: func(context.Context, GitHubRepository, int, string) (string, error) {
+				mergePullRequest: func(context.Context, GitHubRepository, int, string, string) (string, error) {
 					mergeCalled = true
 					return "merge-sha", nil
 				},
@@ -87,8 +88,8 @@ func TestMergePRWithDeps_BlocksNonPassingStatuses(t *testing.T) {
 			if !errors.Is(err, ErrMergeRequiresPassingStatus) {
 				t.Fatalf("errors.Is(err, ErrMergeRequiresPassingStatus) = false, err=%v", err)
 			}
-			if findCalled {
-				t.Fatal("findOpenPR should not be called when status is not passing")
+			if !findCalled {
+				t.Fatal("findOpenPR should be called before status guards to confirm an open PR exists")
 			}
 			if mergeCalled {
 				t.Fatal("mergePullRequest should not be called when status is not passing")
@@ -128,8 +129,8 @@ func TestMergePRWithDeps_AllowNoChecksBehavior(t *testing.T) {
 		if !errors.Is(err, ErrMergeNoChecksDisallowed) {
 			t.Fatalf("errors.Is(err, ErrMergeNoChecksDisallowed) = false, err=%v", err)
 		}
-		if findCalled {
-			t.Fatal("findOpenPR should not be called when no-check override is disabled")
+		if !findCalled {
+			t.Fatal("findOpenPR should be called before no-check gating")
 		}
 	})
 
@@ -152,13 +153,16 @@ func TestMergePRWithDeps_AllowNoChecksBehavior(t *testing.T) {
 			findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
 				return &PullRequest{Number: 9, HeadSHA: sha, HeadRef: branch}, nil
 			},
-			mergePullRequest: func(_ context.Context, _ GitHubRepository, prNumber int, strategy string) (string, error) {
+			mergePullRequest: func(_ context.Context, _ GitHubRepository, prNumber int, strategy string, expectedHeadSHA string) (string, error) {
 				mergeCalled = true
 				if prNumber != 9 {
 					t.Fatalf("prNumber = %d, want 9", prNumber)
 				}
 				if strategy != "squash" {
 					t.Fatalf("strategy = %q, want default \"squash\"", strategy)
+				}
+				if expectedHeadSHA != sha {
+					t.Fatalf("expectedHeadSHA = %q, want %q", expectedHeadSHA, sha)
 				}
 				return "merged-sha", nil
 			},
@@ -194,6 +198,36 @@ func TestMergePRWithDeps_AllowNoChecksBehavior(t *testing.T) {
 	})
 }
 
+func TestMergePRWithDeps_ReturnsPRNotFoundBeforeStatus(t *testing.T) {
+	t.Parallel()
+
+	statusCalled := false
+	_, err := mergePRWithDeps(context.Background(), MergeOptions{}, mergeDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-merge", nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		getStatus: func(context.Context) (StatusResult, error) {
+			statusCalled = true
+			return StatusResult{Status: StatusPassing, ChecksDiscovered: true, SHA: "head-sha"}, nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+			return nil, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("mergePRWithDeps() error = nil, want non-nil")
+	}
+	if !errors.Is(err, ErrMergePRNotFound) {
+		t.Fatalf("errors.Is(err, ErrMergePRNotFound) = false, err=%v", err)
+	}
+	if statusCalled {
+		t.Fatal("getStatus should not be called when no open pull request exists")
+	}
+}
+
 func TestMergePRWithDeps_BlocksHeadDrift(t *testing.T) {
 	t.Parallel()
 
@@ -211,7 +245,7 @@ func TestMergePRWithDeps_BlocksHeadDrift(t *testing.T) {
 		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
 			return &PullRequest{Number: 22, HeadSHA: "new-sha"}, nil
 		},
-		mergePullRequest: func(context.Context, GitHubRepository, int, string) (string, error) {
+		mergePullRequest: func(context.Context, GitHubRepository, int, string, string) (string, error) {
 			mergeCalled = true
 			return "", nil
 		},
@@ -227,6 +261,61 @@ func TestMergePRWithDeps_BlocksHeadDrift(t *testing.T) {
 	}
 	if mergeCalled {
 		t.Fatal("mergePullRequest should not be called when head drift is detected")
+	}
+}
+
+func TestMergePRWithDeps_MapsMergeHeadMismatchStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{
+			name:       "conflict",
+			statusCode: http.StatusConflict,
+		},
+		{
+			name:       "unprocessable entity",
+			statusCode: http.StatusUnprocessableEntity,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := mergePRWithDeps(context.Background(), MergeOptions{}, mergeDeps{
+				currentBranch: func(context.Context) (string, error) {
+					return "hal/ci-merge", nil
+				},
+				resolveRepo: func(context.Context) (GitHubRepository, error) {
+					return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+				},
+				getStatus: func(context.Context) (StatusResult, error) {
+					return StatusResult{Status: StatusPassing, ChecksDiscovered: true, SHA: "head-sha"}, nil
+				},
+				findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+					return &PullRequest{Number: 22, HeadSHA: "head-sha"}, nil
+				},
+				mergePullRequest: func(_ context.Context, _ GitHubRepository, _ int, _ string, expectedHeadSHA string) (string, error) {
+					if expectedHeadSHA != "head-sha" {
+						t.Fatalf("expectedHeadSHA = %q, want %q", expectedHeadSHA, "head-sha")
+					}
+					return "", &githubAPIHTTPError{StatusCode: tt.statusCode}
+				},
+			})
+			if err == nil {
+				t.Fatal("mergePRWithDeps() error = nil, want non-nil")
+			}
+			if !errors.Is(err, ErrMergeHeadDrift) {
+				t.Fatalf("errors.Is(err, ErrMergeHeadDrift) = false, err=%v", err)
+			}
+			if !strings.Contains(err.Error(), "head-sha") {
+				t.Fatalf("drift error should include expected sha, got %q", err)
+			}
+		})
 	}
 }
 
@@ -281,12 +370,15 @@ func TestMergePRWithDeps_DeleteBranchWarnings(t *testing.T) {
 				findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
 					return &PullRequest{Number: 42, HeadSHA: "head-sha", HeadRef: branch}, nil
 				},
-				mergePullRequest: func(_ context.Context, _ GitHubRepository, prNumber int, strategy string) (string, error) {
+				mergePullRequest: func(_ context.Context, _ GitHubRepository, prNumber int, strategy string, expectedHeadSHA string) (string, error) {
 					if prNumber != 42 {
 						t.Fatalf("prNumber = %d, want 42", prNumber)
 					}
 					if strategy != "merge" {
 						t.Fatalf("strategy = %q, want %q", strategy, "merge")
+					}
+					if expectedHeadSHA != "head-sha" {
+						t.Fatalf("expectedHeadSHA = %q, want %q", expectedHeadSHA, "head-sha")
 					}
 					return "merge-commit-sha", nil
 				},

--- a/internal/ci/push.go
+++ b/internal/ci/push.go
@@ -1,0 +1,268 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+const defaultPushTitlePrefix = "hal ci: "
+
+// PushOptions configures push and pull-request creation behavior.
+type PushOptions struct {
+	BaseRef string
+	Title   string
+	Body    string
+	Draft   *bool
+}
+
+type createPullRequestOptions struct {
+	BaseRef string
+	HeadRef string
+	Title   string
+	Body    string
+	Draft   bool
+}
+
+type pushDeps struct {
+	currentBranch func(context.Context) (string, error)
+	pushBranch    func(context.Context, string) error
+	resolveRepo   func(context.Context) (GitHubRepository, error)
+	findOpenPR    func(context.Context, GitHubRepository, string) (*PullRequest, error)
+	createPR      func(context.Context, createPullRequestOptions) (string, error)
+}
+
+// PushAndCreatePR pushes the current branch and creates or reuses an open pull request.
+func PushAndCreatePR(ctx context.Context, opts PushOptions) (PushResult, error) {
+	return pushAndCreatePRWithDeps(ctx, opts, pushDeps{})
+}
+
+func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDeps) (PushResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if deps.currentBranch == nil {
+		deps.currentBranch = gitCurrentBranch
+	}
+	if deps.pushBranch == nil {
+		deps.pushBranch = gitPushBranch
+	}
+	if deps.resolveRepo == nil {
+		deps.resolveRepo = ResolveGitHubRepository
+	}
+	if deps.findOpenPR == nil {
+		deps.findOpenPR = findOpenPullRequest
+	}
+	if deps.createPR == nil {
+		deps.createPR = createPullRequest
+	}
+
+	branch, err := deps.currentBranch(ctx)
+	if err != nil {
+		return PushResult{}, err
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return PushResult{}, fmt.Errorf("get current branch: empty branch name")
+	}
+
+	if err := deps.pushBranch(ctx, branch); err != nil {
+		return PushResult{}, err
+	}
+
+	repo, err := deps.resolveRepo(ctx)
+	if err != nil {
+		return PushResult{}, err
+	}
+
+	existingPR, err := deps.findOpenPR(ctx, repo, branch)
+	if err != nil {
+		return PushResult{}, err
+	}
+	if existingPR != nil {
+		existing := *existingPR
+		existing.Existing = true
+		if strings.TrimSpace(existing.HeadRef) == "" {
+			existing.HeadRef = branch
+		}
+		return buildPushResult(branch, existing), nil
+	}
+
+	createOpts := defaultCreatePullRequestOptions(branch, opts)
+	prURL, err := deps.createPR(ctx, createOpts)
+	if err != nil {
+		return PushResult{}, err
+	}
+
+	createdPR, err := deps.findOpenPR(ctx, repo, branch)
+	if err != nil {
+		return PushResult{}, err
+	}
+	if createdPR == nil {
+		createdPR = &PullRequest{
+			URL:     strings.TrimSpace(prURL),
+			Title:   createOpts.Title,
+			HeadRef: branch,
+			BaseRef: createOpts.BaseRef,
+			Draft:   createOpts.Draft,
+		}
+	}
+
+	created := *createdPR
+	created.Existing = false
+	if strings.TrimSpace(created.URL) == "" {
+		created.URL = strings.TrimSpace(prURL)
+	}
+	if strings.TrimSpace(created.Title) == "" {
+		created.Title = createOpts.Title
+	}
+	if strings.TrimSpace(created.HeadRef) == "" {
+		created.HeadRef = branch
+	}
+
+	return buildPushResult(branch, created), nil
+}
+
+func buildPushResult(branch string, pr PullRequest) PushResult {
+	summary := fmt.Sprintf("pushed branch %s and created pull request", branch)
+	if pr.Existing {
+		summary = fmt.Sprintf("pushed branch %s and reused existing pull request", branch)
+	}
+	return PushResult{
+		ContractVersion: PushContractVersion,
+		Branch:          branch,
+		Pushed:          true,
+		DryRun:          false,
+		PullRequest:     pr,
+		Summary:         summary,
+	}
+}
+
+func defaultCreatePullRequestOptions(branch string, opts PushOptions) createPullRequestOptions {
+	draft := true
+	if opts.Draft != nil {
+		draft = *opts.Draft
+	}
+
+	title := strings.TrimSpace(opts.Title)
+	if title == "" {
+		title = defaultPushPRTitle(branch)
+	}
+
+	body := opts.Body
+	if strings.TrimSpace(body) == "" {
+		body = defaultPushPRBody(branch)
+	}
+
+	return createPullRequestOptions{
+		BaseRef: strings.TrimSpace(opts.BaseRef),
+		HeadRef: branch,
+		Title:   title,
+		Body:    body,
+		Draft:   draft,
+	}
+}
+
+func defaultPushPRTitle(branch string) string {
+	return defaultPushTitlePrefix + branch
+}
+
+func defaultPushPRBody(branch string) string {
+	return fmt.Sprintf("Automated pull request created by `hal ci push` for branch `%s`.", branch)
+}
+
+func gitPushBranch(ctx context.Context, branch string) error {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return fmt.Errorf("push branch: empty branch name")
+	}
+
+	if _, err := runGit(ctx, "push", "-u", "origin", branch); err != nil {
+		return fmt.Errorf("push branch %q: %w", branch, err)
+	}
+	return nil
+}
+
+type ghOpenPullRequest struct {
+	Number  int    `json:"number"`
+	HTMLURL string `json:"html_url"`
+	Title   string `json:"title"`
+	Draft   bool   `json:"draft"`
+	Head    struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+func findOpenPullRequest(ctx context.Context, repo GitHubRepository, branch string) (*PullRequest, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return nil, nil
+	}
+
+	query := url.Values{}
+	query.Set("state", "open")
+	query.Set("head", repo.Owner+":"+branch)
+	query.Set("per_page", "1")
+	query.Set("page", "1")
+
+	endpoint := fmt.Sprintf("/repos/%s/%s/pulls?%s", repo.Owner, repo.Name, query.Encode())
+	var pulls []ghOpenPullRequest
+	if err := ghAPI(ctx, endpoint, &pulls); err != nil {
+		return nil, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
+	}
+	if len(pulls) == 0 {
+		return nil, nil
+	}
+
+	pr := PullRequest{
+		Number:   pulls[0].Number,
+		URL:      strings.TrimSpace(pulls[0].HTMLURL),
+		Title:    strings.TrimSpace(pulls[0].Title),
+		HeadRef:  strings.TrimSpace(pulls[0].Head.Ref),
+		HeadSHA:  strings.TrimSpace(pulls[0].Head.SHA),
+		BaseRef:  strings.TrimSpace(pulls[0].Base.Ref),
+		Draft:    pulls[0].Draft,
+		Existing: true,
+	}
+	return &pr, nil
+}
+
+func createPullRequest(ctx context.Context, opts createPullRequestOptions) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	args := []string{"pr", "create", "--head", opts.HeadRef, "--title", opts.Title, "--body", opts.Body}
+	if opts.BaseRef != "" {
+		args = append(args, "--base", opts.BaseRef)
+	}
+	if opts.Draft {
+		args = append(args, "--draft")
+	}
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return "", fmt.Errorf("create pull request failed: %s: %w", stderrText, err)
+		}
+		return "", fmt.Errorf("create pull request failed: %w", err)
+	}
+
+	prURL := strings.TrimSpace(stdout.String())
+	if prURL == "" {
+		return "", fmt.Errorf("create pull request failed: empty pull request URL")
+	}
+	return prURL, nil
+}

--- a/internal/ci/push.go
+++ b/internal/ci/push.go
@@ -17,6 +17,30 @@ var (
 	ErrAmbiguousOpenPullRequest = errors.New("ci ambiguous open pull request selection")
 )
 
+// FindOpenPullRequestForBranch resolves the open pull request for the given branch.
+// Returns (nil, nil) when no open pull request exists.
+func FindOpenPullRequestForBranch(ctx context.Context, branch string) (*PullRequest, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return nil, fmt.Errorf("find open pull request: empty branch name")
+	}
+
+	repo, err := ResolveGitHubRepository(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pr, err := findOpenPullRequest(ctx, repo, branch)
+	if err != nil {
+		return nil, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
+	}
+	return pr, nil
+}
+
 // PushOptions configures push and pull-request creation behavior.
 type PushOptions struct {
 	BaseRef string

--- a/internal/ci/push.go
+++ b/internal/ci/push.go
@@ -1,15 +1,21 @@
 package ci
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
-	"os/exec"
+	"strconv"
 	"strings"
 )
 
 const defaultPushTitlePrefix = "hal ci: "
+
+var (
+	// ErrAmbiguousOpenPullRequest is returned when a branch maps to multiple open pull requests.
+	ErrAmbiguousOpenPullRequest = errors.New("ci ambiguous open pull request selection")
+)
 
 // PushOptions configures push and pull-request creation behavior.
 type PushOptions struct {
@@ -20,6 +26,7 @@ type PushOptions struct {
 }
 
 type createPullRequestOptions struct {
+	Repo    GitHubRepository
 	BaseRef string
 	HeadRef string
 	Title   string
@@ -31,13 +38,35 @@ type pushDeps struct {
 	currentBranch func(context.Context) (string, error)
 	pushBranch    func(context.Context, string) error
 	resolveRepo   func(context.Context) (GitHubRepository, error)
-	findOpenPR    func(context.Context, GitHubRepository, string) (*PullRequest, error)
+	resolveBaseRef func(context.Context, GitHubRepository, string) (string, error)
+	findOpenPR    func(context.Context, GitHubRepository, string, string) (*PullRequest, error)
 	createPR      func(context.Context, createPullRequestOptions) (string, error)
 }
 
 // PushAndCreatePR pushes the current branch and creates or reuses an open pull request.
 func PushAndCreatePR(ctx context.Context, opts PushOptions) (PushResult, error) {
 	return pushAndCreatePRWithDeps(ctx, opts, pushDeps{})
+}
+
+// PushAndCreatePRInDir pushes the current branch and creates or reuses an open pull request
+// within the provided repository directory.
+func PushAndCreatePRInDir(ctx context.Context, dir string, opts PushOptions) (PushResult, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return PushAndCreatePR(ctx, opts)
+	}
+
+	return pushAndCreatePRWithDeps(ctx, opts, pushDeps{
+		currentBranch: func(ctx context.Context) (string, error) {
+			return gitCurrentBranchInDir(ctx, dir)
+		},
+		pushBranch: func(ctx context.Context, branch string) error {
+			return gitPushBranchInDir(ctx, dir, branch)
+		},
+		resolveRepo: func(ctx context.Context) (GitHubRepository, error) {
+			return ResolveGitHubRepositoryInDir(ctx, dir)
+		},
+	})
 }
 
 func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDeps) (PushResult, error) {
@@ -53,8 +82,11 @@ func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDep
 	if deps.resolveRepo == nil {
 		deps.resolveRepo = ResolveGitHubRepository
 	}
+	if deps.resolveBaseRef == nil {
+		deps.resolveBaseRef = resolvePullRequestBaseRef
+	}
 	if deps.findOpenPR == nil {
-		deps.findOpenPR = findOpenPullRequest
+		deps.findOpenPR = findOpenPullRequestForBase
 	}
 	if deps.createPR == nil {
 		deps.createPR = createPullRequest
@@ -69,16 +101,21 @@ func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDep
 		return PushResult{}, fmt.Errorf("get current branch: empty branch name")
 	}
 
-	if err := deps.pushBranch(ctx, branch); err != nil {
-		return PushResult{}, err
-	}
-
 	repo, err := deps.resolveRepo(ctx)
 	if err != nil {
 		return PushResult{}, err
 	}
 
-	existingPR, err := deps.findOpenPR(ctx, repo, branch)
+	if err := deps.pushBranch(ctx, branch); err != nil {
+		return PushResult{}, err
+	}
+
+	baseRef, err := deps.resolveBaseRef(ctx, repo, opts.BaseRef)
+	if err != nil {
+		return PushResult{}, err
+	}
+
+	existingPR, err := deps.findOpenPR(ctx, repo, branch, baseRef)
 	if err != nil {
 		return PushResult{}, err
 	}
@@ -92,16 +129,15 @@ func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDep
 	}
 
 	createOpts := defaultCreatePullRequestOptions(branch, opts)
+	createOpts.Repo = repo
+	createOpts.BaseRef = baseRef
 	prURL, err := deps.createPR(ctx, createOpts)
 	if err != nil {
 		return PushResult{}, err
 	}
 
-	createdPR, err := deps.findOpenPR(ctx, repo, branch)
-	if err != nil {
-		return PushResult{}, err
-	}
-	if createdPR == nil {
+	createdPR, err := deps.findOpenPR(ctx, repo, branch, baseRef)
+	if err != nil || createdPR == nil {
 		createdPR = &PullRequest{
 			URL:     strings.TrimSpace(prURL),
 			Title:   createOpts.Title,
@@ -174,13 +210,42 @@ func defaultPushPRBody(branch string) string {
 	return fmt.Sprintf("Automated pull request created by `hal ci push` for branch `%s`.", branch)
 }
 
+func resolvePullRequestBaseRef(ctx context.Context, repo GitHubRepository, baseRef string) (string, error) {
+	baseRef = strings.TrimSpace(baseRef)
+	if baseRef != "" {
+		return baseRef, nil
+	}
+
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return defaultBranch(ctx, client, repo)
+}
+
 func gitPushBranch(ctx context.Context, branch string) error {
+	return gitPushBranchInDir(ctx, "", branch)
+}
+
+func gitCurrentBranchInDir(ctx context.Context, dir string) (string, error) {
+	branch, err := runGitInDir(ctx, dir, "branch", "--show-current")
+	if err != nil {
+		return "", fmt.Errorf("get current branch: %w", err)
+	}
+	if branch == "" {
+		return "", fmt.Errorf("get current branch: empty branch name")
+	}
+	return branch, nil
+}
+
+func gitPushBranchInDir(ctx context.Context, dir string, branch string) error {
 	branch = strings.TrimSpace(branch)
 	if branch == "" {
 		return fmt.Errorf("push branch: empty branch name")
 	}
 
-	if _, err := runGit(ctx, "push", "-u", "origin", branch); err != nil {
+	if _, err := runGitInDir(ctx, dir, "push", "-u", "origin", branch); err != nil {
 		return fmt.Errorf("push branch %q: %w", branch, err)
 	}
 	return nil
@@ -201,6 +266,18 @@ type ghOpenPullRequest struct {
 }
 
 func findOpenPullRequest(ctx context.Context, repo GitHubRepository, branch string) (*PullRequest, error) {
+	return findOpenPullRequestForBase(ctx, repo, branch, "")
+}
+
+func findOpenPullRequestForBase(ctx context.Context, repo GitHubRepository, branch, baseRef string) (*PullRequest, error) {
+	pulls, err := listOpenPullRequestsForBranch(ctx, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	return selectOpenPullRequest(branch, baseRef, pulls)
+}
+
+func listOpenPullRequestsForBranch(ctx context.Context, repo GitHubRepository, branch string) ([]ghOpenPullRequest, error) {
 	branch = strings.TrimSpace(branch)
 	if branch == "" {
 		return nil, nil
@@ -209,26 +286,68 @@ func findOpenPullRequest(ctx context.Context, repo GitHubRepository, branch stri
 	query := url.Values{}
 	query.Set("state", "open")
 	query.Set("head", repo.Owner+":"+branch)
-	query.Set("per_page", "1")
-	query.Set("page", "1")
+	query.Set("per_page", "100")
 
-	endpoint := fmt.Sprintf("/repos/%s/%s/pulls?%s", repo.Owner, repo.Name, query.Encode())
 	var pulls []ghOpenPullRequest
-	if err := ghAPI(ctx, endpoint, &pulls); err != nil {
-		return nil, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
+	for page := 1; ; page++ {
+		query.Set("page", strconv.Itoa(page))
+		endpoint := fmt.Sprintf("/repos/%s/%s/pulls?%s", repo.Owner, repo.Name, query.Encode())
+		var pagePulls []ghOpenPullRequest
+		if err := ghAPI(ctx, endpoint, &pagePulls); err != nil {
+			return nil, fmt.Errorf("find open pull request for branch %q: %w", branch, err)
+		}
+		pulls = append(pulls, pagePulls...)
+		if len(pagePulls) < 100 {
+			break
+		}
 	}
-	if len(pulls) == 0 {
+	return pulls, nil
+}
+
+func selectOpenPullRequest(branch, baseRef string, pulls []ghOpenPullRequest) (*PullRequest, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" || len(pulls) == 0 {
 		return nil, nil
 	}
 
+	baseRef = strings.TrimSpace(baseRef)
+	candidates := pulls
+	if baseRef != "" {
+		filtered := make([]ghOpenPullRequest, 0, len(pulls))
+		for _, pull := range pulls {
+			if strings.TrimSpace(pull.Base.Ref) == baseRef {
+				filtered = append(filtered, pull)
+			}
+		}
+		// GitHub limits open PRs per head branch to one in normal operation.
+		// If the requested base differs from that one existing PR, reuse it
+		// rather than attempting duplicate PR creation.
+		if len(filtered) == 0 && len(pulls) == 1 {
+			candidates = pulls
+		} else {
+			candidates = filtered
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	if len(candidates) > 1 {
+		if baseRef == "" {
+			return nil, fmt.Errorf("%w: branch %q has %d open pull requests", ErrAmbiguousOpenPullRequest, branch, len(candidates))
+		}
+		return nil, fmt.Errorf("%w: branch %q with base %q has %d open pull requests", ErrAmbiguousOpenPullRequest, branch, baseRef, len(candidates))
+	}
+
+	pull := candidates[0]
 	pr := PullRequest{
-		Number:   pulls[0].Number,
-		URL:      strings.TrimSpace(pulls[0].HTMLURL),
-		Title:    strings.TrimSpace(pulls[0].Title),
-		HeadRef:  strings.TrimSpace(pulls[0].Head.Ref),
-		HeadSHA:  strings.TrimSpace(pulls[0].Head.SHA),
-		BaseRef:  strings.TrimSpace(pulls[0].Base.Ref),
-		Draft:    pulls[0].Draft,
+		Number:   pull.Number,
+		URL:      strings.TrimSpace(pull.HTMLURL),
+		Title:    strings.TrimSpace(pull.Title),
+		HeadRef:  strings.TrimSpace(pull.Head.Ref),
+		HeadSHA:  strings.TrimSpace(pull.Head.SHA),
+		BaseRef:  strings.TrimSpace(pull.Base.Ref),
+		Draft:    pull.Draft,
 		Existing: true,
 	}
 	return &pr, nil
@@ -239,30 +358,61 @@ func createPullRequest(ctx context.Context, opts createPullRequestOptions) (stri
 		ctx = context.Background()
 	}
 
-	args := []string{"pr", "create", "--head", opts.HeadRef, "--title", opts.Title, "--body", opts.Body}
-	if opts.BaseRef != "" {
-		args = append(args, "--base", opts.BaseRef)
-	}
-	if opts.Draft {
-		args = append(args, "--draft")
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return "", err
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		stderrText := strings.TrimSpace(stderr.String())
-		if stderrText != "" {
-			return "", fmt.Errorf("create pull request failed: %s: %w", stderrText, err)
+	baseRef := strings.TrimSpace(opts.BaseRef)
+	if baseRef == "" {
+		baseRef, err = defaultBranch(ctx, client, opts.Repo)
+		if err != nil {
+			return "", err
 		}
+	}
+
+	endpoint := fmt.Sprintf("/repos/%s/%s/pulls", opts.Repo.Owner, opts.Repo.Name)
+	request := map[string]any{
+		"title": opts.Title,
+		"head":  opts.HeadRef,
+		"base":  baseRef,
+		"body":  opts.Body,
+		"draft": opts.Draft,
+	}
+
+	var response struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{
+		Method:   http.MethodPost,
+		Endpoint: endpoint,
+		Body:     request,
+	}, &response); err != nil {
 		return "", fmt.Errorf("create pull request failed: %w", err)
 	}
 
-	prURL := strings.TrimSpace(stdout.String())
+	prURL := strings.TrimSpace(response.HTMLURL)
 	if prURL == "" {
 		return "", fmt.Errorf("create pull request failed: empty pull request URL")
 	}
 	return prURL, nil
+}
+
+func defaultBranch(ctx context.Context, client ClientSelection, repo GitHubRepository) (string, error) {
+	endpoint := fmt.Sprintf("/repos/%s/%s", repo.Owner, repo.Name)
+	var response struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{
+		Method:   http.MethodGet,
+		Endpoint: endpoint,
+	}, &response); err != nil {
+		return "", fmt.Errorf("resolve default branch for pull request: %w", err)
+	}
+
+	baseRef := strings.TrimSpace(response.DefaultBranch)
+	if baseRef == "" {
+		return "", fmt.Errorf("resolve default branch for pull request: empty default branch")
+	}
+	return baseRef, nil
 }

--- a/internal/ci/push.go
+++ b/internal/ci/push.go
@@ -15,6 +15,8 @@ const defaultPushTitlePrefix = "hal ci: "
 var (
 	// ErrAmbiguousOpenPullRequest is returned when a branch maps to multiple open pull requests.
 	ErrAmbiguousOpenPullRequest = errors.New("ci ambiguous open pull request selection")
+	// ErrOpenPullRequestBaseMismatch is returned when an explicit base does not match existing open pull requests for a branch.
+	ErrOpenPullRequestBaseMismatch = errors.New("ci open pull request base mismatch")
 )
 
 // FindOpenPullRequestForBranch resolves the open pull request for the given branch.
@@ -134,12 +136,9 @@ func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDep
 		return PushResult{}, err
 	}
 
-	baseRef, err := deps.resolveBaseRef(ctx, repo, opts.BaseRef)
-	if err != nil {
-		return PushResult{}, err
-	}
-
-	existingPR, err := deps.findOpenPR(ctx, repo, branch, baseRef)
+	requestedBaseRef := strings.TrimSpace(opts.BaseRef)
+	existingLookupBaseRef := requestedBaseRef
+	existingPR, err := deps.findOpenPR(ctx, repo, branch, existingLookupBaseRef)
 	if err != nil {
 		return PushResult{}, err
 	}
@@ -150,6 +149,14 @@ func pushAndCreatePRWithDeps(ctx context.Context, opts PushOptions, deps pushDep
 			existing.HeadRef = branch
 		}
 		return buildPushResult(branch, existing), nil
+	}
+
+	baseRef := requestedBaseRef
+	if baseRef == "" {
+		baseRef, err = deps.resolveBaseRef(ctx, repo, "")
+		if err != nil {
+			return PushResult{}, err
+		}
 	}
 
 	createOpts := defaultCreatePullRequestOptions(branch, opts)
@@ -343,14 +350,14 @@ func selectOpenPullRequest(branch, baseRef string, pulls []ghOpenPullRequest) (*
 				filtered = append(filtered, pull)
 			}
 		}
-		// GitHub limits open PRs per head branch to one in normal operation.
-		// If the requested base differs from that one existing PR, reuse it
-		// rather than attempting duplicate PR creation.
-		if len(filtered) == 0 && len(pulls) == 1 {
-			candidates = pulls
-		} else {
-			candidates = filtered
+		if len(filtered) == 0 && len(pulls) > 0 {
+			if len(pulls) == 1 {
+				existingBase := strings.TrimSpace(pulls[0].Base.Ref)
+				return nil, fmt.Errorf("%w: branch %q has open pull request with base %q; requested %q", ErrOpenPullRequestBaseMismatch, branch, existingBase, baseRef)
+			}
+			return nil, fmt.Errorf("%w: branch %q has %d open pull requests but none target base %q", ErrOpenPullRequestBaseMismatch, branch, len(pulls), baseRef)
 		}
+		candidates = filtered
 	}
 
 	if len(candidates) == 0 {

--- a/internal/ci/push_test.go
+++ b/internal/ci/push_test.go
@@ -1,0 +1,227 @@
+package ci
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/ci-push"
+	const prURL = "https://github.com/acme/repo/pull/42"
+
+	pushedBranch := ""
+	createCalls := 0
+	findCalls := 0
+
+	result, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{}, pushDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return branch, nil
+		},
+		pushBranch: func(_ context.Context, gotBranch string) error {
+			pushedBranch = gotBranch
+			return nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		findOpenPR: func(_ context.Context, repo GitHubRepository, gotBranch string) (*PullRequest, error) {
+			findCalls++
+			if repo.FullName() != "acme/repo" {
+				t.Fatalf("repo = %q, want %q", repo.FullName(), "acme/repo")
+			}
+			if gotBranch != branch {
+				t.Fatalf("branch = %q, want %q", gotBranch, branch)
+			}
+			return &PullRequest{
+				Number:   42,
+				URL:      prURL,
+				Title:    "existing pr",
+				HeadRef:  branch,
+				HeadSHA:  "abc123",
+				BaseRef:  "main",
+				Draft:    true,
+				Existing: true,
+			}, nil
+		},
+		createPR: func(context.Context, createPullRequestOptions) (string, error) {
+			createCalls++
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("pushAndCreatePRWithDeps() error = %v", err)
+	}
+
+	if pushedBranch != branch {
+		t.Fatalf("pushed branch = %q, want %q", pushedBranch, branch)
+	}
+	if findCalls != 1 {
+		t.Fatalf("findOpenPR calls = %d, want 1", findCalls)
+	}
+	if createCalls != 0 {
+		t.Fatalf("createPR calls = %d, want 0", createCalls)
+	}
+	if !result.Pushed {
+		t.Fatal("result.Pushed = false, want true")
+	}
+	if result.Branch != branch {
+		t.Fatalf("result.Branch = %q, want %q", result.Branch, branch)
+	}
+	if result.PullRequest.Number != 42 {
+		t.Fatalf("result.PullRequest.Number = %d, want 42", result.PullRequest.Number)
+	}
+	if result.PullRequest.URL != prURL {
+		t.Fatalf("result.PullRequest.URL = %q, want %q", result.PullRequest.URL, prURL)
+	}
+	if !result.PullRequest.Existing {
+		t.Fatal("result.PullRequest.Existing = false, want true")
+	}
+}
+
+func TestPushAndCreatePRWithDeps_DefaultsDraftTitleBodyDeterministically(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/new-feature"
+	const createdURL = "https://github.com/acme/repo/pull/7"
+
+	createCalls := 0
+	findCalls := 0
+	capturedCreate := createPullRequestOptions{}
+
+	result, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{}, pushDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return branch, nil
+		},
+		pushBranch: func(_ context.Context, gotBranch string) error {
+			if gotBranch != branch {
+				t.Fatalf("pushed branch = %q, want %q", gotBranch, branch)
+			}
+			return nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+			findCalls++
+			switch findCalls {
+			case 1:
+				return nil, nil
+			case 2:
+				return &PullRequest{
+					Number:   7,
+					URL:      createdURL,
+					Title:    capturedCreate.Title,
+					HeadRef:  branch,
+					HeadSHA:  "def456",
+					BaseRef:  "main",
+					Draft:    capturedCreate.Draft,
+					Existing: false,
+				}, nil
+			default:
+				return nil, fmt.Errorf("unexpected findOpenPR call %d", findCalls)
+			}
+		},
+		createPR: func(_ context.Context, createOpts createPullRequestOptions) (string, error) {
+			createCalls++
+			capturedCreate = createOpts
+			return createdURL, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("pushAndCreatePRWithDeps() error = %v", err)
+	}
+
+	if createCalls != 1 {
+		t.Fatalf("createPR calls = %d, want 1", createCalls)
+	}
+	if findCalls != 2 {
+		t.Fatalf("findOpenPR calls = %d, want 2", findCalls)
+	}
+
+	if !capturedCreate.Draft {
+		t.Fatal("createPR draft = false, want true by default")
+	}
+	if capturedCreate.Title != "hal ci: hal/new-feature" {
+		t.Fatalf("createPR title = %q, want %q", capturedCreate.Title, "hal ci: hal/new-feature")
+	}
+	if capturedCreate.Body != "Automated pull request created by `hal ci push` for branch `hal/new-feature`." {
+		t.Fatalf("createPR body = %q, want deterministic default", capturedCreate.Body)
+	}
+	if capturedCreate.HeadRef != branch {
+		t.Fatalf("createPR headRef = %q, want %q", capturedCreate.HeadRef, branch)
+	}
+
+	if result.PullRequest.Number != 7 {
+		t.Fatalf("result.PullRequest.Number = %d, want 7", result.PullRequest.Number)
+	}
+	if result.PullRequest.Existing {
+		t.Fatal("result.PullRequest.Existing = true, want false")
+	}
+	if !result.PullRequest.Draft {
+		t.Fatal("result.PullRequest.Draft = false, want true")
+	}
+}
+
+func TestPushAndCreatePRWithDeps_ExplicitDraftFalseOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/non-draft"
+	draft := false
+
+	createCalls := 0
+	findCalls := 0
+	capturedCreate := createPullRequestOptions{}
+
+	_, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{Draft: &draft}, pushDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return branch, nil
+		},
+		pushBranch: func(context.Context, string) error {
+			return nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+			findCalls++
+			switch findCalls {
+			case 1:
+				return nil, nil
+			case 2:
+				return &PullRequest{Number: 11, URL: "https://github.com/acme/repo/pull/11", HeadRef: branch, Draft: false}, nil
+			default:
+				return nil, fmt.Errorf("unexpected findOpenPR call %d", findCalls)
+			}
+		},
+		createPR: func(_ context.Context, createOpts createPullRequestOptions) (string, error) {
+			createCalls++
+			capturedCreate = createOpts
+			return "https://github.com/acme/repo/pull/11", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("pushAndCreatePRWithDeps() error = %v", err)
+	}
+
+	if createCalls != 1 {
+		t.Fatalf("createPR calls = %d, want 1", createCalls)
+	}
+	if capturedCreate.Draft {
+		t.Fatal("createPR draft = true, want false when explicitly requested")
+	}
+}
+
+func TestDefaultPushPRTitleAndBody_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	branch := "hal/ci-gap-free"
+	if got, want := defaultPushPRTitle(branch), "hal ci: hal/ci-gap-free"; got != want {
+		t.Fatalf("defaultPushPRTitle(%q) = %q, want %q", branch, got, want)
+	}
+	if got, want := defaultPushPRBody(branch), "Automated pull request created by `hal ci push` for branch `hal/ci-gap-free`."; got != want {
+		t.Fatalf("defaultPushPRBody(%q) = %q, want %q", branch, got, want)
+	}
+}

--- a/internal/ci/push_test.go
+++ b/internal/ci/push_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testing.T) {
+func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPRWithoutImplicitBaseFilter(t *testing.T) {
 	t.Parallel()
 
 	const branch = "hal/ci-push"
@@ -16,6 +16,7 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 	pushedBranch := ""
 	createCalls := 0
 	findCalls := 0
+	resolveBaseRefCalled := false
 
 	result, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{}, pushDeps{
 		currentBranch: func(context.Context) (string, error) {
@@ -29,6 +30,7 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
 		},
 		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			resolveBaseRefCalled = true
 			return "main", nil
 		},
 		findOpenPR: func(_ context.Context, repo GitHubRepository, gotBranch, gotBaseRef string) (*PullRequest, error) {
@@ -39,8 +41,8 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 			if gotBranch != branch {
 				t.Fatalf("branch = %q, want %q", gotBranch, branch)
 			}
-			if gotBaseRef != "main" {
-				t.Fatalf("baseRef = %q, want %q", gotBaseRef, "main")
+			if gotBaseRef != "" {
+				t.Fatalf("baseRef = %q, want empty for implicit-base lookup", gotBaseRef)
 			}
 			return &PullRequest{
 				Number:   42,
@@ -48,7 +50,7 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 				Title:    "existing pr",
 				HeadRef:  branch,
 				HeadSHA:  "abc123",
-				BaseRef:  "main",
+				BaseRef:  "release/1.2",
 				Draft:    true,
 				Existing: true,
 			}, nil
@@ -71,6 +73,9 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 	if createCalls != 0 {
 		t.Fatalf("createPR calls = %d, want 0", createCalls)
 	}
+	if resolveBaseRefCalled {
+		t.Fatal("resolveBaseRef called = true, want false when existing PR is found without explicit base")
+	}
 	if !result.Pushed {
 		t.Fatal("result.Pushed = false, want true")
 	}
@@ -85,6 +90,9 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 	}
 	if !result.PullRequest.Existing {
 		t.Fatal("result.PullRequest.Existing = false, want true")
+	}
+	if result.PullRequest.BaseRef != "release/1.2" {
+		t.Fatalf("result.PullRequest.BaseRef = %q, want %q", result.PullRequest.BaseRef, "release/1.2")
 	}
 }
 
@@ -119,13 +127,16 @@ func TestPushAndCreatePRWithDeps_DefaultsDraftTitleBodyDeterministically(t *test
 			if gotBranch != branch {
 				t.Fatalf("branch = %q, want %q", gotBranch, branch)
 			}
-			if gotBaseRef != "main" {
-				t.Fatalf("baseRef = %q, want %q", gotBaseRef, "main")
-			}
 			switch findCalls {
 			case 1:
+				if gotBaseRef != "" {
+					t.Fatalf("first lookup baseRef = %q, want empty", gotBaseRef)
+				}
 				return nil, nil
 			case 2:
+				if gotBaseRef != "main" {
+					t.Fatalf("second lookup baseRef = %q, want %q", gotBaseRef, "main")
+				}
 				return &PullRequest{
 					Number:   7,
 					URL:      createdURL,
@@ -214,6 +225,67 @@ func TestPushAndCreatePRWithDeps_ExplicitDraftFalseOverridesDefault(t *testing.T
 				return nil, nil
 			case 2:
 				return &PullRequest{Number: 11, URL: "https://github.com/acme/repo/pull/11", HeadRef: branch, BaseRef: "main", Draft: false}, nil
+			default:
+				return nil, fmt.Errorf("unexpected findOpenPR call %d", findCalls)
+			}
+		},
+		createPR: func(_ context.Context, createOpts createPullRequestOptions) (string, error) {
+			createCalls++
+			capturedCreate = createOpts
+			return "https://github.com/acme/repo/pull/11", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("pushAndCreatePRWithDeps() error = %v", err)
+	}
+
+	if createCalls != 1 {
+		t.Fatalf("createPR calls = %d, want 1", createCalls)
+	}
+	if capturedCreate.Draft {
+		t.Fatal("createPR draft = true, want false when explicitly requested")
+	}
+}
+
+func TestPushAndCreatePRWithDeps_ImplicitBaseLookupThenResolvedBaseLookupAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/non-draft"
+	draft := false
+
+	createCalls := 0
+	findCalls := 0
+	capturedCreate := createPullRequestOptions{}
+
+	_, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{Draft: &draft}, pushDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return branch, nil
+		},
+		pushBranch: func(context.Context, string) error {
+			return nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			return "main", nil
+		},
+		findOpenPR: func(_ context.Context, _ GitHubRepository, gotBranch, gotBaseRef string) (*PullRequest, error) {
+			findCalls++
+			if gotBranch != branch {
+				t.Fatalf("branch = %q, want %q", gotBranch, branch)
+			}
+			switch findCalls {
+			case 1:
+				if gotBaseRef != "" {
+					t.Fatalf("first lookup baseRef = %q, want empty", gotBaseRef)
+				}
+				return nil, nil
+			case 2:
+				if gotBaseRef != "main" {
+					t.Fatalf("second lookup baseRef = %q, want %q", gotBaseRef, "main")
+				}
+				return nil, nil
 			default:
 				return nil, fmt.Errorf("unexpected findOpenPR call %d", findCalls)
 			}
@@ -387,7 +459,7 @@ func TestSelectOpenPullRequest_AmbiguousWithoutBase(t *testing.T) {
 	}
 }
 
-func TestSelectOpenPullRequest_ReusesSingleHeadMatchWhenBaseDiffers(t *testing.T) {
+func TestSelectOpenPullRequest_ReturnsBaseMismatchForSingleHeadMatch(t *testing.T) {
 	t.Parallel()
 
 	prDevelop := ghOpenPullRequest{Number: 12, HTMLURL: "https://github.com/acme/repo/pull/12", Title: "develop target"}
@@ -396,17 +468,11 @@ func TestSelectOpenPullRequest_ReusesSingleHeadMatchWhenBaseDiffers(t *testing.T
 	prDevelop.Base.Ref = "develop"
 
 	pr, err := selectOpenPullRequest("hal/ci-push", "main", []ghOpenPullRequest{prDevelop})
-	if err != nil {
-		t.Fatalf("selectOpenPullRequest() error = %v", err)
+	if !errors.Is(err, ErrOpenPullRequestBaseMismatch) {
+		t.Fatalf("errors.Is(err, ErrOpenPullRequestBaseMismatch) = false, err=%v", err)
 	}
-	if pr == nil {
-		t.Fatal("selectOpenPullRequest() returned nil PR")
-	}
-	if pr.Number != 12 {
-		t.Fatalf("pr.Number = %d, want 12", pr.Number)
-	}
-	if pr.BaseRef != "develop" {
-		t.Fatalf("pr.BaseRef = %q, want %q", pr.BaseRef, "develop")
+	if pr != nil {
+		t.Fatalf("selectOpenPullRequest() = %+v, want nil", pr)
 	}
 }
 

--- a/internal/ci/push_test.go
+++ b/internal/ci/push_test.go
@@ -2,6 +2,7 @@ package ci
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -27,13 +28,19 @@ func TestPushAndCreatePRWithDeps_PushesCurrentBranchAndReusesExistingPR(t *testi
 		resolveRepo: func(context.Context) (GitHubRepository, error) {
 			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
 		},
-		findOpenPR: func(_ context.Context, repo GitHubRepository, gotBranch string) (*PullRequest, error) {
+		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			return "main", nil
+		},
+		findOpenPR: func(_ context.Context, repo GitHubRepository, gotBranch, gotBaseRef string) (*PullRequest, error) {
 			findCalls++
 			if repo.FullName() != "acme/repo" {
 				t.Fatalf("repo = %q, want %q", repo.FullName(), "acme/repo")
 			}
 			if gotBranch != branch {
 				t.Fatalf("branch = %q, want %q", gotBranch, branch)
+			}
+			if gotBaseRef != "main" {
+				t.Fatalf("baseRef = %q, want %q", gotBaseRef, "main")
 			}
 			return &PullRequest{
 				Number:   42,
@@ -104,8 +111,17 @@ func TestPushAndCreatePRWithDeps_DefaultsDraftTitleBodyDeterministically(t *test
 		resolveRepo: func(context.Context) (GitHubRepository, error) {
 			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
 		},
-		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			return "main", nil
+		},
+		findOpenPR: func(_ context.Context, _ GitHubRepository, gotBranch, gotBaseRef string) (*PullRequest, error) {
 			findCalls++
+			if gotBranch != branch {
+				t.Fatalf("branch = %q, want %q", gotBranch, branch)
+			}
+			if gotBaseRef != "main" {
+				t.Fatalf("baseRef = %q, want %q", gotBaseRef, "main")
+			}
 			switch findCalls {
 			case 1:
 				return nil, nil
@@ -153,6 +169,9 @@ func TestPushAndCreatePRWithDeps_DefaultsDraftTitleBodyDeterministically(t *test
 	if capturedCreate.HeadRef != branch {
 		t.Fatalf("createPR headRef = %q, want %q", capturedCreate.HeadRef, branch)
 	}
+	if capturedCreate.BaseRef != "main" {
+		t.Fatalf("createPR baseRef = %q, want %q", capturedCreate.BaseRef, "main")
+	}
 
 	if result.PullRequest.Number != 7 {
 		t.Fatalf("result.PullRequest.Number = %d, want 7", result.PullRequest.Number)
@@ -185,13 +204,16 @@ func TestPushAndCreatePRWithDeps_ExplicitDraftFalseOverridesDefault(t *testing.T
 		resolveRepo: func(context.Context) (GitHubRepository, error) {
 			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
 		},
-		findOpenPR: func(context.Context, GitHubRepository, string) (*PullRequest, error) {
+		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			return "main", nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string, string) (*PullRequest, error) {
 			findCalls++
 			switch findCalls {
 			case 1:
 				return nil, nil
 			case 2:
-				return &PullRequest{Number: 11, URL: "https://github.com/acme/repo/pull/11", HeadRef: branch, Draft: false}, nil
+				return &PullRequest{Number: 11, URL: "https://github.com/acme/repo/pull/11", HeadRef: branch, BaseRef: "main", Draft: false}, nil
 			default:
 				return nil, fmt.Errorf("unexpected findOpenPR call %d", findCalls)
 			}
@@ -211,6 +233,180 @@ func TestPushAndCreatePRWithDeps_ExplicitDraftFalseOverridesDefault(t *testing.T
 	}
 	if capturedCreate.Draft {
 		t.Fatal("createPR draft = true, want false when explicitly requested")
+	}
+}
+
+func TestPushAndCreatePRWithDeps_CreateSuccessLookupFailureFallsBackToCreateResult(t *testing.T) {
+	t.Parallel()
+
+	const branch = "hal/fallback-on-read-error"
+	const createdURL = "https://github.com/acme/repo/pull/99"
+
+	createCalls := 0
+	findCalls := 0
+	capturedCreate := createPullRequestOptions{}
+
+	result, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{}, pushDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return branch, nil
+		},
+		pushBranch: func(context.Context, string) error {
+			return nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			return "develop", nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string, string) (*PullRequest, error) {
+			findCalls++
+			switch findCalls {
+			case 1:
+				return nil, nil
+			case 2:
+				return nil, errors.New("transient list failure")
+			default:
+				return nil, fmt.Errorf("unexpected findOpenPR call %d", findCalls)
+			}
+		},
+		createPR: func(_ context.Context, createOpts createPullRequestOptions) (string, error) {
+			createCalls++
+			capturedCreate = createOpts
+			return createdURL, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("pushAndCreatePRWithDeps() error = %v", err)
+	}
+
+	if createCalls != 1 {
+		t.Fatalf("createPR calls = %d, want 1", createCalls)
+	}
+	if findCalls != 2 {
+		t.Fatalf("findOpenPR calls = %d, want 2", findCalls)
+	}
+
+	if result.PullRequest.Existing {
+		t.Fatal("result.PullRequest.Existing = true, want false")
+	}
+	if result.PullRequest.URL != createdURL {
+		t.Fatalf("result.PullRequest.URL = %q, want %q", result.PullRequest.URL, createdURL)
+	}
+	if result.PullRequest.Title != capturedCreate.Title {
+		t.Fatalf("result.PullRequest.Title = %q, want %q", result.PullRequest.Title, capturedCreate.Title)
+	}
+	if result.PullRequest.HeadRef != branch {
+		t.Fatalf("result.PullRequest.HeadRef = %q, want %q", result.PullRequest.HeadRef, branch)
+	}
+	if result.PullRequest.BaseRef != "develop" {
+		t.Fatalf("result.PullRequest.BaseRef = %q, want %q", result.PullRequest.BaseRef, "develop")
+	}
+	if result.PullRequest.Draft != capturedCreate.Draft {
+		t.Fatalf("result.PullRequest.Draft = %t, want %t", result.PullRequest.Draft, capturedCreate.Draft)
+	}
+}
+
+func TestPushAndCreatePRWithDeps_ResolveRepoFailureDoesNotPush(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("resolve repo failed")
+	pushCalled := false
+
+	_, err := pushAndCreatePRWithDeps(context.Background(), PushOptions{}, pushDeps{
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-push", nil
+		},
+		pushBranch: func(context.Context, string) error {
+			pushCalled = true
+			return nil
+		},
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{}, expectedErr
+		},
+		resolveBaseRef: func(context.Context, GitHubRepository, string) (string, error) {
+			t.Fatal("resolveBaseRef should not be called when resolveRepo fails")
+			return "", nil
+		},
+		findOpenPR: func(context.Context, GitHubRepository, string, string) (*PullRequest, error) {
+			t.Fatal("findOpenPR should not be called when resolveRepo fails")
+			return nil, nil
+		},
+		createPR: func(context.Context, createPullRequestOptions) (string, error) {
+			t.Fatal("createPR should not be called when resolveRepo fails")
+			return "", nil
+		},
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("pushAndCreatePRWithDeps() error = %v, want %v", err, expectedErr)
+	}
+	if pushCalled {
+		t.Fatal("pushBranch should not be called when resolveRepo fails")
+	}
+}
+
+func TestSelectOpenPullRequest_FiltersByBase(t *testing.T) {
+	t.Parallel()
+
+	prMain := ghOpenPullRequest{Number: 11, HTMLURL: "https://github.com/acme/repo/pull/11", Title: "main target"}
+	prMain.Head.Ref = "hal/ci-push"
+	prMain.Head.SHA = "aaa111"
+	prMain.Base.Ref = "main"
+
+	prDevelop := ghOpenPullRequest{Number: 12, HTMLURL: "https://github.com/acme/repo/pull/12", Title: "develop target"}
+	prDevelop.Head.Ref = "hal/ci-push"
+	prDevelop.Head.SHA = "bbb222"
+	prDevelop.Base.Ref = "develop"
+
+	pr, err := selectOpenPullRequest("hal/ci-push", "develop", []ghOpenPullRequest{prMain, prDevelop})
+	if err != nil {
+		t.Fatalf("selectOpenPullRequest() error = %v", err)
+	}
+	if pr == nil {
+		t.Fatal("selectOpenPullRequest() returned nil PR")
+	}
+	if pr.Number != 12 {
+		t.Fatalf("pr.Number = %d, want 12", pr.Number)
+	}
+	if pr.BaseRef != "develop" {
+		t.Fatalf("pr.BaseRef = %q, want %q", pr.BaseRef, "develop")
+	}
+}
+
+func TestSelectOpenPullRequest_AmbiguousWithoutBase(t *testing.T) {
+	t.Parallel()
+
+	prMain := ghOpenPullRequest{Number: 11}
+	prMain.Base.Ref = "main"
+	prDevelop := ghOpenPullRequest{Number: 12}
+	prDevelop.Base.Ref = "develop"
+
+	_, err := selectOpenPullRequest("hal/ci-push", "", []ghOpenPullRequest{prMain, prDevelop})
+	if !errors.Is(err, ErrAmbiguousOpenPullRequest) {
+		t.Fatalf("errors.Is(err, ErrAmbiguousOpenPullRequest) = false, err=%v", err)
+	}
+}
+
+func TestSelectOpenPullRequest_ReusesSingleHeadMatchWhenBaseDiffers(t *testing.T) {
+	t.Parallel()
+
+	prDevelop := ghOpenPullRequest{Number: 12, HTMLURL: "https://github.com/acme/repo/pull/12", Title: "develop target"}
+	prDevelop.Head.Ref = "hal/ci-push"
+	prDevelop.Head.SHA = "bbb222"
+	prDevelop.Base.Ref = "develop"
+
+	pr, err := selectOpenPullRequest("hal/ci-push", "main", []ghOpenPullRequest{prDevelop})
+	if err != nil {
+		t.Fatalf("selectOpenPullRequest() error = %v", err)
+	}
+	if pr == nil {
+		t.Fatal("selectOpenPullRequest() returned nil PR")
+	}
+	if pr.Number != 12 {
+		t.Fatalf("pr.Number = %d, want 12", pr.Number)
+	}
+	if pr.BaseRef != "develop" {
+		t.Fatalf("pr.BaseRef = %q, want %q", pr.BaseRef, "develop")
 	}
 }
 

--- a/internal/ci/remote.go
+++ b/internal/ci/remote.go
@@ -1,0 +1,160 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+var (
+	// ErrMissingOriginRemote is returned when git remote origin is not configured.
+	ErrMissingOriginRemote = errors.New("git remote \"origin\" is not configured")
+
+	// ErrNonGitHubOriginRemote is returned when origin does not point to github.com.
+	ErrNonGitHubOriginRemote = errors.New("origin remote is not a GitHub repository")
+
+	// ErrInvalidGitHubOriginRemote is returned when a github.com remote cannot be parsed as owner/repo.
+	ErrInvalidGitHubOriginRemote = errors.New("origin remote must include owner and repository name")
+)
+
+const githubOriginGuidance = "set origin to git@github.com:<owner>/<repo>.git or https://github.com/<owner>/<repo>.git"
+
+// GitHubRepository identifies a GitHub repository by owner and name.
+type GitHubRepository struct {
+	Owner string
+	Name  string
+}
+
+// FullName returns the owner/name repository identifier.
+func (r GitHubRepository) FullName() string {
+	if r.Owner == "" || r.Name == "" {
+		return ""
+	}
+	return r.Owner + "/" + r.Name
+}
+
+type githubRepoResolverDeps struct {
+	originRemoteURL func(context.Context) (string, error)
+}
+
+// ResolveGitHubRepository reads the git origin remote and requires it to be a GitHub repository.
+func ResolveGitHubRepository(ctx context.Context) (GitHubRepository, error) {
+	return resolveGitHubRepositoryWithDeps(ctx, githubRepoResolverDeps{
+		originRemoteURL: gitOriginRemoteURL,
+	})
+}
+
+func resolveGitHubRepositoryWithDeps(ctx context.Context, deps githubRepoResolverDeps) (GitHubRepository, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if deps.originRemoteURL == nil {
+		deps.originRemoteURL = gitOriginRemoteURL
+	}
+
+	remoteURL, err := deps.originRemoteURL(ctx)
+	if err != nil {
+		if errors.Is(err, ErrMissingOriginRemote) {
+			return GitHubRepository{}, missingOriginRemoteError()
+		}
+		return GitHubRepository{}, err
+	}
+
+	repo, err := ParseGitHubRepository(remoteURL)
+	if err != nil {
+		return GitHubRepository{}, err
+	}
+	return repo, nil
+}
+
+// ParseGitHubRepository parses common GitHub SSH/HTTPS remote URLs.
+func ParseGitHubRepository(remoteURL string) (GitHubRepository, error) {
+	remoteURL = strings.TrimSpace(remoteURL)
+	if remoteURL == "" {
+		return GitHubRepository{}, missingOriginRemoteError()
+	}
+
+	if strings.Contains(remoteURL, "://") {
+		parsed, err := url.Parse(remoteURL)
+		if err != nil {
+			return GitHubRepository{}, nonGitHubOriginRemoteError(remoteURL)
+		}
+		if !strings.EqualFold(parsed.Hostname(), "github.com") {
+			return GitHubRepository{}, nonGitHubOriginRemoteError(remoteURL)
+		}
+		return parseGitHubRepoPath(parsed.Path, remoteURL)
+	}
+
+	hostAndPath := strings.SplitN(remoteURL, ":", 2)
+	if len(hostAndPath) == 2 {
+		host := hostAndPath[0]
+		if at := strings.LastIndex(host, "@"); at >= 0 {
+			host = host[at+1:]
+		}
+		if !strings.EqualFold(host, "github.com") {
+			return GitHubRepository{}, nonGitHubOriginRemoteError(remoteURL)
+		}
+		return parseGitHubRepoPath(hostAndPath[1], remoteURL)
+	}
+
+	return GitHubRepository{}, nonGitHubOriginRemoteError(remoteURL)
+}
+
+func parseGitHubRepoPath(path string, remoteURL string) (GitHubRepository, error) {
+	path = strings.TrimSpace(path)
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+
+	segments := strings.Split(path, "/")
+	if len(segments) != 2 || segments[0] == "" || segments[1] == "" {
+		return GitHubRepository{}, invalidGitHubOriginRemoteError(remoteURL)
+	}
+
+	return GitHubRepository{Owner: segments[0], Name: segments[1]}, nil
+}
+
+func gitOriginRemoteURL(ctx context.Context) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if isMissingOriginRemote(strings.TrimSpace(stderr.String())) {
+			return "", ErrMissingOriginRemote
+		}
+		return "", fmt.Errorf("failed to read git origin remote: %w", err)
+	}
+
+	remoteURL := strings.TrimSpace(stdout.String())
+	if remoteURL == "" {
+		return "", ErrMissingOriginRemote
+	}
+	return remoteURL, nil
+}
+
+func isMissingOriginRemote(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "no such remote") && strings.Contains(lower, "origin")
+}
+
+func missingOriginRemoteError() error {
+	return fmt.Errorf("%w; %s", ErrMissingOriginRemote, githubOriginGuidance)
+}
+
+func nonGitHubOriginRemoteError(remoteURL string) error {
+	return fmt.Errorf("%w: %q; %s", ErrNonGitHubOriginRemote, remoteURL, githubOriginGuidance)
+}
+
+func invalidGitHubOriginRemoteError(remoteURL string) error {
+	return fmt.Errorf("%w: %q; %s", ErrInvalidGitHubOriginRemote, remoteURL, githubOriginGuidance)
+}

--- a/internal/ci/remote.go
+++ b/internal/ci/remote.go
@@ -48,6 +48,16 @@ func ResolveGitHubRepository(ctx context.Context) (GitHubRepository, error) {
 	})
 }
 
+// ResolveGitHubRepositoryInDir reads the git origin remote in the given directory
+// and requires it to be a GitHub repository.
+func ResolveGitHubRepositoryInDir(ctx context.Context, dir string) (GitHubRepository, error) {
+	return resolveGitHubRepositoryWithDeps(ctx, githubRepoResolverDeps{
+		originRemoteURL: func(ctx context.Context) (string, error) {
+			return gitOriginRemoteURLInDir(ctx, dir)
+		},
+	})
+}
+
 func resolveGitHubRepositoryWithDeps(ctx context.Context, deps githubRepoResolverDeps) (GitHubRepository, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -119,11 +129,18 @@ func parseGitHubRepoPath(path string, remoteURL string) (GitHubRepository, error
 }
 
 func gitOriginRemoteURL(ctx context.Context) (string, error) {
+	return gitOriginRemoteURLInDir(ctx, "")
+}
+
+func gitOriginRemoteURLInDir(ctx context.Context, dir string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/ci/remote_test.go
+++ b/internal/ci/remote_test.go
@@ -1,0 +1,116 @@
+package ci
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseGitHubRepository_CommonFormats(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+		wantOwner string
+		wantName  string
+	}{
+		{
+			name:      "ssh scp style",
+			remoteURL: "git@github.com:acme/hal.git",
+			wantOwner: "acme",
+			wantName:  "hal",
+		},
+		{
+			name:      "ssh url style",
+			remoteURL: "ssh://git@github.com/acme/hal.git",
+			wantOwner: "acme",
+			wantName:  "hal",
+		},
+		{
+			name:      "https style",
+			remoteURL: "https://github.com/acme/hal.git",
+			wantOwner: "acme",
+			wantName:  "hal",
+		},
+		{
+			name:      "https without dot git",
+			remoteURL: "https://github.com/acme/hal",
+			wantOwner: "acme",
+			wantName:  "hal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, err := ParseGitHubRepository(tt.remoteURL)
+			if err != nil {
+				t.Fatalf("ParseGitHubRepository(%q) error = %v", tt.remoteURL, err)
+			}
+
+			if repo.Owner != tt.wantOwner {
+				t.Fatalf("repo.Owner = %q, want %q", repo.Owner, tt.wantOwner)
+			}
+			if repo.Name != tt.wantName {
+				t.Fatalf("repo.Name = %q, want %q", repo.Name, tt.wantName)
+			}
+			if repo.FullName() != tt.wantOwner+"/"+tt.wantName {
+				t.Fatalf("repo.FullName() = %q, want %q", repo.FullName(), tt.wantOwner+"/"+tt.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveGitHubRepositoryWithDeps_MissingOriginRemote(t *testing.T) {
+	_, err := resolveGitHubRepositoryWithDeps(context.Background(), githubRepoResolverDeps{
+		originRemoteURL: func(context.Context) (string, error) {
+			return "", ErrMissingOriginRemote
+		},
+	})
+	if !errors.Is(err, ErrMissingOriginRemote) {
+		t.Fatalf("error = %v, want %v", err, ErrMissingOriginRemote)
+	}
+	if !strings.Contains(err.Error(), "set origin to git@github.com") {
+		t.Fatalf("error text = %q, want actionable guidance", err.Error())
+	}
+}
+
+func TestResolveGitHubRepositoryWithDeps_NonGitHubRemote(t *testing.T) {
+	_, err := resolveGitHubRepositoryWithDeps(context.Background(), githubRepoResolverDeps{
+		originRemoteURL: func(context.Context) (string, error) {
+			return "git@gitlab.com:acme/hal.git", nil
+		},
+	})
+	if !errors.Is(err, ErrNonGitHubOriginRemote) {
+		t.Fatalf("error = %v, want %v", err, ErrNonGitHubOriginRemote)
+	}
+	if !strings.Contains(err.Error(), "git@gitlab.com:acme/hal.git") {
+		t.Fatalf("error text = %q, want remote URL included", err.Error())
+	}
+	if !strings.Contains(err.Error(), "https://github.com/<owner>/<repo>.git") {
+		t.Fatalf("error text = %q, want actionable guidance", err.Error())
+	}
+}
+
+func TestResolveGitHubRepositoryWithDeps_GitHubRemote(t *testing.T) {
+	repo, err := resolveGitHubRepositoryWithDeps(context.Background(), githubRepoResolverDeps{
+		originRemoteURL: func(context.Context) (string, error) {
+			return "git@github.com:acme/hal.git", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveGitHubRepositoryWithDeps() error = %v", err)
+	}
+	if repo.Owner != "acme" {
+		t.Fatalf("repo.Owner = %q, want %q", repo.Owner, "acme")
+	}
+	if repo.Name != "hal" {
+		t.Fatalf("repo.Name = %q, want %q", repo.Name, "hal")
+	}
+}
+
+func TestParseGitHubRepository_InvalidGitHubPath(t *testing.T) {
+	_, err := ParseGitHubRepository("https://github.com/acme")
+	if !errors.Is(err, ErrInvalidGitHubOriginRemote) {
+		t.Fatalf("error = %v, want %v", err, ErrInvalidGitHubOriginRemote)
+	}
+}

--- a/internal/ci/status.go
+++ b/internal/ci/status.go
@@ -9,9 +9,50 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 )
 
-const statusPageSize = 100
+const (
+	statusPageSize = 100
+
+	defaultWaitPollInterval = 30 * time.Second
+	defaultWaitTimeout      = 30 * time.Minute
+	defaultNoChecksGrace    = 90 * time.Second
+)
+
+// WaitOptions configures WaitForChecks polling behavior.
+type WaitOptions struct {
+	PollInterval  time.Duration
+	Timeout       time.Duration
+	NoChecksGrace time.Duration
+}
+
+type waitForChecksDeps struct {
+	getStatus func(context.Context) (StatusResult, error)
+	newTicker func(time.Duration) waitTicker
+	after     func(time.Duration) <-chan time.Time
+}
+
+type waitTicker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realWaitTicker struct {
+	ticker *time.Ticker
+}
+
+func newRealWaitTicker(d time.Duration) waitTicker {
+	return realWaitTicker{ticker: time.NewTicker(d)}
+}
+
+func (t realWaitTicker) Chan() <-chan time.Time {
+	return t.ticker.C
+}
+
+func (t realWaitTicker) Stop() {
+	t.ticker.Stop()
+}
 
 type statusDeps struct {
 	resolveRepo            func(context.Context) (GitHubRepository, error)
@@ -38,6 +79,89 @@ type commitStatusData struct {
 // GetStatus aggregates CI state from both GitHub check-runs and commit statuses.
 func GetStatus(ctx context.Context) (StatusResult, error) {
 	return getStatusWithDeps(ctx, statusDeps{})
+}
+
+// WaitForChecks polls status until checks complete, timeout, or no checks are detected.
+func WaitForChecks(ctx context.Context, opts WaitOptions) (StatusResult, error) {
+	return waitForChecksWithDeps(ctx, opts, waitForChecksDeps{})
+}
+
+func waitForChecksWithDeps(ctx context.Context, opts WaitOptions, deps waitForChecksDeps) (StatusResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts = waitOptionsWithDefaults(opts)
+
+	if deps.getStatus == nil {
+		deps.getStatus = GetStatus
+	}
+	if deps.newTicker == nil {
+		deps.newTicker = newRealWaitTicker
+	}
+	if deps.after == nil {
+		deps.after = time.After
+	}
+
+	ticker := deps.newTicker(opts.PollInterval)
+	defer ticker.Stop()
+
+	timeoutCh := deps.after(opts.Timeout)
+	noChecksCh := deps.after(opts.NoChecksGrace)
+
+	for {
+		result, err := deps.getStatus(ctx)
+		if err != nil {
+			return StatusResult{}, err
+		}
+		result.Wait = true
+
+		if result.Status != StatusPending {
+			result.WaitTerminalReason = WaitTerminalReasonCompleted
+			return result, nil
+		}
+
+		if result.ChecksDiscovered {
+			noChecksCh = nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return StatusResult{}, ctx.Err()
+		case <-timeoutCh:
+			result.WaitTerminalReason = WaitTerminalReasonTimeout
+			return result, nil
+		case <-noChecksCh:
+			confirm, err := deps.getStatus(ctx)
+			if err != nil {
+				return StatusResult{}, err
+			}
+			confirm.Wait = true
+			if confirm.Status != StatusPending {
+				confirm.WaitTerminalReason = WaitTerminalReasonCompleted
+				return confirm, nil
+			}
+			if confirm.ChecksDiscovered {
+				noChecksCh = nil
+				continue
+			}
+			confirm.WaitTerminalReason = WaitTerminalReasonNoChecksDetected
+			return confirm, nil
+		case <-ticker.Chan():
+		}
+	}
+}
+
+func waitOptionsWithDefaults(opts WaitOptions) WaitOptions {
+	if opts.PollInterval <= 0 {
+		opts.PollInterval = defaultWaitPollInterval
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = defaultWaitTimeout
+	}
+	if opts.NoChecksGrace <= 0 {
+		opts.NoChecksGrace = defaultNoChecksGrace
+	}
+	return opts
 }
 
 func getStatusWithDeps(ctx context.Context, deps statusDeps) (StatusResult, error) {

--- a/internal/ci/status.go
+++ b/internal/ci/status.go
@@ -1,0 +1,430 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+const statusPageSize = 100
+
+type statusDeps struct {
+	resolveRepo            func(context.Context) (GitHubRepository, error)
+	currentBranch          func(context.Context) (string, error)
+	currentHeadSHA         func(context.Context) (string, error)
+	findPRHeadSHA          func(context.Context, GitHubRepository, string) (string, error)
+	listCheckRunsPage      func(context.Context, GitHubRepository, string, int, int) ([]checkRunData, error)
+	listCommitStatusesPage func(context.Context, GitHubRepository, string, int, int) ([]commitStatusData, error)
+}
+
+type checkRunData struct {
+	Name       string
+	Status     string
+	Conclusion string
+	URL        string
+}
+
+type commitStatusData struct {
+	Context string
+	State   string
+	URL     string
+}
+
+// GetStatus aggregates CI state from both GitHub check-runs and commit statuses.
+func GetStatus(ctx context.Context) (StatusResult, error) {
+	return getStatusWithDeps(ctx, statusDeps{})
+}
+
+func getStatusWithDeps(ctx context.Context, deps statusDeps) (StatusResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if deps.resolveRepo == nil {
+		deps.resolveRepo = ResolveGitHubRepository
+	}
+	if deps.currentBranch == nil {
+		deps.currentBranch = gitCurrentBranch
+	}
+	if deps.currentHeadSHA == nil {
+		deps.currentHeadSHA = gitCurrentHEADSHA
+	}
+	if deps.findPRHeadSHA == nil {
+		deps.findPRHeadSHA = findPRHeadSHA
+	}
+	if deps.listCheckRunsPage == nil {
+		deps.listCheckRunsPage = listCheckRunsPage
+	}
+	if deps.listCommitStatusesPage == nil {
+		deps.listCommitStatusesPage = listCommitStatusesPage
+	}
+
+	repo, err := deps.resolveRepo(ctx)
+	if err != nil {
+		return StatusResult{}, err
+	}
+
+	branch, err := deps.currentBranch(ctx)
+	if err != nil {
+		return StatusResult{}, err
+	}
+
+	sha, err := resolveStatusSHA(ctx, deps, repo, branch)
+	if err != nil {
+		return StatusResult{}, err
+	}
+
+	checks, err := aggregateStatusChecks(ctx, deps, repo, sha)
+	if err != nil {
+		return StatusResult{}, err
+	}
+
+	totals, status := summarizeAggregatedChecks(checks)
+	checksDiscovered := len(checks) > 0
+	if !checksDiscovered {
+		status = StatusPending
+	}
+
+	return StatusResult{
+		ContractVersion:  StatusContractVersion,
+		Branch:           branch,
+		SHA:              sha,
+		Status:           status,
+		ChecksDiscovered: checksDiscovered,
+		Wait:             false,
+		Checks:           checks,
+		Totals:           totals,
+		Summary:          statusSummary(status, totals, checksDiscovered),
+	}, nil
+}
+
+func resolveStatusSHA(ctx context.Context, deps statusDeps, repo GitHubRepository, branch string) (string, error) {
+	prHeadSHA, err := deps.findPRHeadSHA(ctx, repo, branch)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(prHeadSHA) != "" {
+		return strings.TrimSpace(prHeadSHA), nil
+	}
+
+	sha, err := deps.currentHeadSHA(ctx)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(sha), nil
+}
+
+func aggregateStatusChecks(ctx context.Context, deps statusDeps, repo GitHubRepository, sha string) ([]StatusCheck, error) {
+	checkRuns, err := listAllCheckRuns(ctx, deps, repo, sha)
+	if err != nil {
+		return nil, err
+	}
+	commitStatuses, err := listAllCommitStatuses(ctx, deps, repo, sha)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{})
+	checks := make([]StatusCheck, 0, len(checkRuns)+len(commitStatuses))
+
+	for _, run := range checkRuns {
+		key := checkContextKey(run.Name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		checks = append(checks, StatusCheck{
+			Key:    key,
+			Source: CheckSourceCheckRun,
+			Name:   run.Name,
+			Status: mapCheckRunStatus(run.Status, run.Conclusion),
+			URL:    strings.TrimSpace(run.URL),
+		})
+	}
+
+	for _, status := range commitStatuses {
+		key := statusContextKey(status.Context)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		checks = append(checks, StatusCheck{
+			Key:    key,
+			Source: CheckSourceStatus,
+			Name:   status.Context,
+			Status: mapCommitStatusState(status.State),
+			URL:    strings.TrimSpace(status.URL),
+		})
+	}
+
+	sort.Slice(checks, func(i, j int) bool {
+		return checks[i].Key < checks[j].Key
+	})
+
+	return checks, nil
+}
+
+func listAllCheckRuns(ctx context.Context, deps statusDeps, repo GitHubRepository, sha string) ([]checkRunData, error) {
+	all := make([]checkRunData, 0)
+	for page := 1; ; page++ {
+		pageRuns, err := deps.listCheckRunsPage(ctx, repo, sha, page, statusPageSize)
+		if err != nil {
+			return nil, fmt.Errorf("list check-runs page %d: %w", page, err)
+		}
+		all = append(all, pageRuns...)
+		if len(pageRuns) < statusPageSize {
+			break
+		}
+	}
+	return all, nil
+}
+
+func listAllCommitStatuses(ctx context.Context, deps statusDeps, repo GitHubRepository, sha string) ([]commitStatusData, error) {
+	all := make([]commitStatusData, 0)
+	for page := 1; ; page++ {
+		pageStatuses, err := deps.listCommitStatusesPage(ctx, repo, sha, page, statusPageSize)
+		if err != nil {
+			return nil, fmt.Errorf("list commit statuses page %d: %w", page, err)
+		}
+		all = append(all, pageStatuses...)
+		if len(pageStatuses) < statusPageSize {
+			break
+		}
+	}
+	return all, nil
+}
+
+func summarizeAggregatedChecks(checks []StatusCheck) (StatusTotals, string) {
+	totals := StatusTotals{}
+	for _, check := range checks {
+		switch check.Status {
+		case StatusPassing:
+			totals.Passing++
+		case StatusFailing:
+			totals.Failing++
+		case StatusPending:
+			totals.Pending++
+		default:
+			// Treat unknown check states as pending for safety.
+			totals.Pending++
+		}
+	}
+
+	if totals.Pending > 0 {
+		return totals, StatusPending
+	}
+	if totals.Failing > 0 {
+		return totals, StatusFailing
+	}
+	if totals.Passing > 0 {
+		return totals, StatusPassing
+	}
+	return totals, StatusPending
+}
+
+func statusSummary(status string, totals StatusTotals, checksDiscovered bool) string {
+	if !checksDiscovered {
+		return "no CI contexts discovered; status pending"
+	}
+	return fmt.Sprintf("status=%s (passing=%d, failing=%d, pending=%d)", status, totals.Passing, totals.Failing, totals.Pending)
+}
+
+func checkContextKey(name string) string {
+	return "check:" + strings.TrimSpace(name)
+}
+
+func statusContextKey(contextName string) string {
+	return "status:" + strings.TrimSpace(contextName)
+}
+
+func mapCheckRunStatus(runStatus string, conclusion string) string {
+	runStatus = strings.ToLower(strings.TrimSpace(runStatus))
+	conclusion = strings.ToLower(strings.TrimSpace(conclusion))
+
+	switch runStatus {
+	case "queued", "in_progress":
+		return StatusPending
+	case "completed":
+		switch conclusion {
+		case "failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale":
+			return StatusFailing
+		case "success", "neutral", "skipped":
+			return StatusPassing
+		default:
+			return StatusPending
+		}
+	default:
+		return StatusPending
+	}
+}
+
+func mapCommitStatusState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "success":
+		return StatusPassing
+	case "failure", "error":
+		return StatusFailing
+	case "pending":
+		return StatusPending
+	default:
+		return StatusPending
+	}
+}
+
+func gitCurrentBranch(ctx context.Context) (string, error) {
+	branch, err := runGit(ctx, "branch", "--show-current")
+	if err != nil {
+		return "", fmt.Errorf("get current branch: %w", err)
+	}
+	if branch == "" {
+		return "", fmt.Errorf("get current branch: empty branch name")
+	}
+	return branch, nil
+}
+
+func gitCurrentHEADSHA(ctx context.Context) (string, error) {
+	sha, err := runGit(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("get HEAD sha: %w", err)
+	}
+	if sha == "" {
+		return "", fmt.Errorf("get HEAD sha: empty sha")
+	}
+	return sha, nil
+}
+
+func runGit(ctx context.Context, args ...string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return "", fmt.Errorf("git %s failed: %s: %w", strings.Join(args, " "), stderrText, err)
+		}
+		return "", fmt.Errorf("git %s failed: %w", strings.Join(args, " "), err)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+type ghPullRequest struct {
+	Head struct {
+		SHA string `json:"sha"`
+	} `json:"head"`
+}
+
+func findPRHeadSHA(ctx context.Context, repo GitHubRepository, branch string) (string, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return "", nil
+	}
+
+	query := url.Values{}
+	query.Set("state", "open")
+	query.Set("head", repo.Owner+":"+branch)
+	query.Set("per_page", "1")
+	query.Set("page", "1")
+
+	endpoint := fmt.Sprintf("/repos/%s/%s/pulls?%s", repo.Owner, repo.Name, query.Encode())
+	var pulls []ghPullRequest
+	if err := ghAPI(ctx, endpoint, &pulls); err != nil {
+		return "", fmt.Errorf("find pull request for branch %q: %w", branch, err)
+	}
+	if len(pulls) == 0 {
+		return "", nil
+	}
+	return strings.TrimSpace(pulls[0].Head.SHA), nil
+}
+
+type ghCheckRunsResponse struct {
+	CheckRuns []ghCheckRun `json:"check_runs"`
+}
+
+type ghCheckRun struct {
+	Name       string  `json:"name"`
+	Status     string  `json:"status"`
+	Conclusion *string `json:"conclusion"`
+	HTMLURL    string  `json:"html_url"`
+}
+
+func listCheckRunsPage(ctx context.Context, repo GitHubRepository, sha string, page int, perPage int) ([]checkRunData, error) {
+	endpoint := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs?per_page=%d&page=%d", repo.Owner, repo.Name, sha, perPage, page)
+	response := ghCheckRunsResponse{}
+	if err := ghAPI(ctx, endpoint, &response); err != nil {
+		return nil, err
+	}
+
+	runs := make([]checkRunData, 0, len(response.CheckRuns))
+	for _, run := range response.CheckRuns {
+		conclusion := ""
+		if run.Conclusion != nil {
+			conclusion = *run.Conclusion
+		}
+		runs = append(runs, checkRunData{
+			Name:       strings.TrimSpace(run.Name),
+			Status:     strings.TrimSpace(run.Status),
+			Conclusion: strings.TrimSpace(conclusion),
+			URL:        strings.TrimSpace(run.HTMLURL),
+		})
+	}
+	return runs, nil
+}
+
+type ghCommitStatus struct {
+	Context   string `json:"context"`
+	State     string `json:"state"`
+	TargetURL string `json:"target_url"`
+}
+
+func listCommitStatusesPage(ctx context.Context, repo GitHubRepository, sha string, page int, perPage int) ([]commitStatusData, error) {
+	endpoint := fmt.Sprintf("/repos/%s/%s/commits/%s/statuses?per_page=%d&page=%d", repo.Owner, repo.Name, sha, perPage, page)
+	response := make([]ghCommitStatus, 0)
+	if err := ghAPI(ctx, endpoint, &response); err != nil {
+		return nil, err
+	}
+
+	statuses := make([]commitStatusData, 0, len(response))
+	for _, status := range response {
+		statuses = append(statuses, commitStatusData{
+			Context: strings.TrimSpace(status.Context),
+			State:   strings.TrimSpace(status.State),
+			URL:     strings.TrimSpace(status.TargetURL),
+		})
+	}
+	return statuses, nil
+}
+
+func ghAPI(ctx context.Context, endpoint string, out any) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cmd := exec.CommandContext(ctx, "gh", "api", "-H", "Accept: application/vnd.github+json", endpoint)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrText := strings.TrimSpace(stderr.String())
+		if stderrText != "" {
+			return fmt.Errorf("gh api %s failed: %s: %w", endpoint, stderrText, err)
+		}
+		return fmt.Errorf("gh api %s failed: %w", endpoint, err)
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), out); err != nil {
+		return fmt.Errorf("decode gh api response for %s: %w", endpoint, err)
+	}
+	return nil
+}

--- a/internal/ci/status.go
+++ b/internal/ci/status.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os/exec"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -19,6 +24,12 @@ const (
 	defaultWaitTimeout      = 30 * time.Minute
 	defaultNoChecksGrace    = 90 * time.Second
 )
+
+var ghHTTPStatusCodePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\(http\s+(\d{3})\)`),
+	regexp.MustCompile(`(?i)\bhttp(?:\s+status)?(?:\s+code)?\s*[:=]?\s*(\d{3})\b`),
+	regexp.MustCompile(`(?i)\bstatus\s+code\s*[:=]?\s*(\d{3})\b`),
+}
 
 // WaitOptions configures WaitForChecks polling behavior.
 type WaitOptions struct {
@@ -78,12 +89,34 @@ type commitStatusData struct {
 
 // GetStatus aggregates CI state from both GitHub check-runs and commit statuses.
 func GetStatus(ctx context.Context) (StatusResult, error) {
-	return getStatusWithDeps(ctx, statusDeps{})
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return StatusResult{}, err
+	}
+	return getStatusWithClient(ctx, client)
 }
 
 // WaitForChecks polls status until checks complete, timeout, or no checks are detected.
 func WaitForChecks(ctx context.Context, opts WaitOptions) (StatusResult, error) {
 	return waitForChecksWithDeps(ctx, opts, waitForChecksDeps{})
+}
+
+func getStatusWithClient(ctx context.Context, client ClientSelection) (StatusResult, error) {
+	return getStatusWithDeps(ctx, statusDeps{
+		findPRHeadSHA: func(callCtx context.Context, repo GitHubRepository, branch string) (string, error) {
+			return findPRHeadSHAWithClient(callCtx, client, repo, branch)
+		},
+		listCheckRunsPage: func(callCtx context.Context, repo GitHubRepository, sha string, page int, perPage int) ([]checkRunData, error) {
+			return listCheckRunsPageWithClient(callCtx, client, repo, sha, page, perPage)
+		},
+		listCommitStatusesPage: func(callCtx context.Context, repo GitHubRepository, sha string, page int, perPage int) ([]commitStatusData, error) {
+			return listCommitStatusesPageWithClient(callCtx, client, repo, sha, page, perPage)
+		},
+	})
 }
 
 func waitForChecksWithDeps(ctx context.Context, opts WaitOptions, deps waitForChecksDeps) (StatusResult, error) {
@@ -93,7 +126,13 @@ func waitForChecksWithDeps(ctx context.Context, opts WaitOptions, deps waitForCh
 	opts = waitOptionsWithDefaults(opts)
 
 	if deps.getStatus == nil {
-		deps.getStatus = GetStatus
+		client, err := SelectGitHubClient(ctx)
+		if err != nil {
+			return StatusResult{}, err
+		}
+		deps.getStatus = func(callCtx context.Context) (StatusResult, error) {
+			return getStatusWithClient(callCtx, client)
+		}
 	}
 	if deps.newTicker == nil {
 		deps.newTicker = newRealWaitTicker
@@ -423,10 +462,29 @@ func gitCurrentHEADSHA(ctx context.Context) (string, error) {
 }
 
 func runGit(ctx context.Context, args ...string) (string, error) {
+	return runGitInDir(ctx, "", args...)
+}
+
+func runGitInDir(ctx context.Context, dir string, args ...string) (string, error) {
+	out, err := runGitRawInDir(ctx, dir, args...)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func runGitRaw(ctx context.Context, args ...string) (string, error) {
+	return runGitRawInDir(ctx, "", args...)
+}
+
+func runGitRawInDir(ctx context.Context, dir string, args ...string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	cmd := exec.CommandContext(ctx, "git", args...)
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -439,7 +497,7 @@ func runGit(ctx context.Context, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s failed: %w", strings.Join(args, " "), err)
 	}
 
-	return strings.TrimSpace(stdout.String()), nil
+	return strings.TrimRight(stdout.String(), "\r\n"), nil
 }
 
 type ghPullRequest struct {
@@ -449,6 +507,14 @@ type ghPullRequest struct {
 }
 
 func findPRHeadSHA(ctx context.Context, repo GitHubRepository, branch string) (string, error) {
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return "", err
+	}
+	return findPRHeadSHAWithClient(ctx, client, repo, branch)
+}
+
+func findPRHeadSHAWithClient(ctx context.Context, client ClientSelection, repo GitHubRepository, branch string) (string, error) {
 	branch = strings.TrimSpace(branch)
 	if branch == "" {
 		return "", nil
@@ -462,7 +528,7 @@ func findPRHeadSHA(ctx context.Context, repo GitHubRepository, branch string) (s
 
 	endpoint := fmt.Sprintf("/repos/%s/%s/pulls?%s", repo.Owner, repo.Name, query.Encode())
 	var pulls []ghPullRequest
-	if err := ghAPI(ctx, endpoint, &pulls); err != nil {
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{Method: http.MethodGet, Endpoint: endpoint}, &pulls); err != nil {
 		return "", fmt.Errorf("find pull request for branch %q: %w", branch, err)
 	}
 	if len(pulls) == 0 {
@@ -483,9 +549,17 @@ type ghCheckRun struct {
 }
 
 func listCheckRunsPage(ctx context.Context, repo GitHubRepository, sha string, page int, perPage int) ([]checkRunData, error) {
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return listCheckRunsPageWithClient(ctx, client, repo, sha, page, perPage)
+}
+
+func listCheckRunsPageWithClient(ctx context.Context, client ClientSelection, repo GitHubRepository, sha string, page int, perPage int) ([]checkRunData, error) {
 	endpoint := fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs?per_page=%d&page=%d", repo.Owner, repo.Name, sha, perPage, page)
 	response := ghCheckRunsResponse{}
-	if err := ghAPI(ctx, endpoint, &response); err != nil {
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{Method: http.MethodGet, Endpoint: endpoint}, &response); err != nil {
 		return nil, err
 	}
 
@@ -512,9 +586,17 @@ type ghCommitStatus struct {
 }
 
 func listCommitStatusesPage(ctx context.Context, repo GitHubRepository, sha string, page int, perPage int) ([]commitStatusData, error) {
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return listCommitStatusesPageWithClient(ctx, client, repo, sha, page, perPage)
+}
+
+func listCommitStatusesPageWithClient(ctx context.Context, client ClientSelection, repo GitHubRepository, sha string, page int, perPage int) ([]commitStatusData, error) {
 	endpoint := fmt.Sprintf("/repos/%s/%s/commits/%s/statuses?per_page=%d&page=%d", repo.Owner, repo.Name, sha, perPage, page)
 	response := make([]ghCommitStatus, 0)
-	if err := ghAPI(ctx, endpoint, &response); err != nil {
+	if err := ghAPIWithClient(ctx, client, githubAPIRequest{Method: http.MethodGet, Endpoint: endpoint}, &response); err != nil {
 		return nil, err
 	}
 
@@ -530,25 +612,206 @@ func listCommitStatusesPage(ctx context.Context, repo GitHubRepository, sha stri
 }
 
 func ghAPI(ctx context.Context, endpoint string, out any) error {
+	client, err := SelectGitHubClient(ctx)
+	if err != nil {
+		return err
+	}
+	return ghAPIWithClient(ctx, client, githubAPIRequest{Method: http.MethodGet, Endpoint: endpoint}, out)
+}
+
+type githubAPIRequest struct {
+	Method   string
+	Endpoint string
+	Body     any
+}
+
+type githubAPIHTTPError struct {
+	Method     string
+	Endpoint   string
+	StatusCode int
+	Body       string
+}
+
+func (e *githubAPIHTTPError) Error() string {
+	if e == nil {
+		return "github api request failed"
+	}
+	if e.Body != "" {
+		return fmt.Sprintf("github api %s %s failed: HTTP %d: %s", e.Method, e.Endpoint, e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("github api %s %s failed: HTTP %d", e.Method, e.Endpoint, e.StatusCode)
+}
+
+func isGitHubAPIHTTPStatus(err error, statusCode int) bool {
+	var apiErr *githubAPIHTTPError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == statusCode
+}
+
+func ghAPIWithClient(ctx context.Context, client ClientSelection, req githubAPIRequest, out any) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	cmd := exec.CommandContext(ctx, "gh", "api", "-H", "Accept: application/vnd.github+json", endpoint)
+	method := strings.ToUpper(strings.TrimSpace(req.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+	endpoint := strings.TrimSpace(req.Endpoint)
+	if endpoint == "" {
+		return fmt.Errorf("github api endpoint must not be empty")
+	}
+	if !strings.HasPrefix(endpoint, "/") {
+		endpoint = "/" + endpoint
+	}
+	req.Method = method
+	req.Endpoint = endpoint
+
+	switch client.Kind {
+	case ClientKindAPI:
+		token := strings.TrimSpace(client.Token)
+		if token == "" {
+			return ErrInvalidEnvToken
+		}
+		return ghAPIWithToken(ctx, req, token, out)
+	case ClientKindGH:
+		return ghAPIWithGH(ctx, req, out)
+	default:
+		return fmt.Errorf("unsupported GitHub client kind %q", client.Kind)
+	}
+}
+
+func ghAPIWithToken(ctx context.Context, req githubAPIRequest, token string, out any) error {
+	var reqBody io.Reader
+	if req.Body != nil {
+		payload, err := json.Marshal(req.Body)
+		if err != nil {
+			return fmt.Errorf("encode github api request body for %s %s: %w", req.Method, req.Endpoint, err)
+		}
+		reqBody = bytes.NewReader(payload)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, "https://api.github.com"+req.Endpoint, reqBody)
+	if err != nil {
+		return fmt.Errorf("build github api request %s %s: %w", req.Method, req.Endpoint, err)
+	}
+	httpReq.Header.Set("Accept", "application/vnd.github+json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if req.Body != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("github api %s %s failed: %w", req.Method, req.Endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read github api response for %s %s: %w", req.Method, req.Endpoint, err)
+	}
+	body = bytes.TrimSpace(body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &githubAPIHTTPError{
+			Method:     req.Method,
+			Endpoint:   req.Endpoint,
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(body)),
+		}
+	}
+
+	if out == nil || len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode github api response for %s %s: %w", req.Method, req.Endpoint, err)
+	}
+	return nil
+}
+
+func ghAPIWithGH(ctx context.Context, req githubAPIRequest, out any) error {
+	args := []string{"api", "-H", "Accept: application/vnd.github+json"}
+	if req.Method != http.MethodGet {
+		args = append(args, "-X", req.Method)
+	}
+
+	var stdin *bytes.Reader
+	if req.Body != nil {
+		payload, err := json.Marshal(req.Body)
+		if err != nil {
+			return fmt.Errorf("encode gh api request body for %s %s: %w", req.Method, req.Endpoint, err)
+		}
+		stdin = bytes.NewReader(payload)
+		args = append(args, "-H", "Content-Type: application/json", "--input", "-")
+	}
+	args = append(args, req.Endpoint)
+
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
 		stderrText := strings.TrimSpace(stderr.String())
-		if stderrText != "" {
-			return fmt.Errorf("gh api %s failed: %s: %w", endpoint, stderrText, err)
+		if apiErr := ghAPIHTTPErrorFromStderr(req, stderrText); apiErr != nil {
+			return apiErr
 		}
-		return fmt.Errorf("gh api %s failed: %w", endpoint, err)
+		if stderrText != "" {
+			return fmt.Errorf("gh api %s %s failed: %s: %w", req.Method, req.Endpoint, stderrText, err)
+		}
+		return fmt.Errorf("gh api %s %s failed: %w", req.Method, req.Endpoint, err)
 	}
 
-	if err := json.Unmarshal(stdout.Bytes(), out); err != nil {
-		return fmt.Errorf("decode gh api response for %s: %w", endpoint, err)
+	if out == nil {
+		return nil
+	}
+	body := bytes.TrimSpace(stdout.Bytes())
+	if len(body) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode gh api response for %s %s: %w", req.Method, req.Endpoint, err)
 	}
 	return nil
+}
+
+func ghAPIHTTPErrorFromStderr(req githubAPIRequest, stderrText string) *githubAPIHTTPError {
+	statusCode, ok := parseHTTPStatusCode(stderrText)
+	if !ok {
+		return nil
+	}
+	return &githubAPIHTTPError{
+		Method:     req.Method,
+		Endpoint:   req.Endpoint,
+		StatusCode: statusCode,
+		Body:       strings.TrimSpace(stderrText),
+	}
+}
+
+func parseHTTPStatusCode(text string) (int, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return 0, false
+	}
+
+	for _, pattern := range ghHTTPStatusCodePatterns {
+		matches := pattern.FindStringSubmatch(trimmed)
+		if len(matches) != 2 {
+			continue
+		}
+		code, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		if code >= 100 && code <= 599 {
+			return code, true
+		}
+	}
+
+	return 0, false
 }

--- a/internal/ci/status.go
+++ b/internal/ci/status.go
@@ -23,12 +23,17 @@ const (
 	defaultWaitPollInterval = 30 * time.Second
 	defaultWaitTimeout      = 30 * time.Minute
 	defaultNoChecksGrace    = 90 * time.Second
+	defaultGitHubAPITimeout = 30 * time.Second
 )
 
 var ghHTTPStatusCodePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\(http\s+(\d{3})\)`),
 	regexp.MustCompile(`(?i)\bhttp(?:\s+status)?(?:\s+code)?\s*[:=]?\s*(\d{3})\b`),
 	regexp.MustCompile(`(?i)\bstatus\s+code\s*[:=]?\s*(\d{3})\b`),
+}
+
+var githubAPITokenHTTPClient = &http.Client{
+	Timeout: defaultGitHubAPITimeout,
 }
 
 // WaitOptions configures WaitForChecks polling behavior.
@@ -701,7 +706,7 @@ func ghAPIWithToken(ctx context.Context, req githubAPIRequest, token string, out
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := githubAPITokenHTTPClient.Do(httpReq)
 	if err != nil {
 		return fmt.Errorf("github api %s %s failed: %w", req.Method, req.Endpoint, err)
 	}

--- a/internal/ci/status_test.go
+++ b/internal/ci/status_test.go
@@ -1,0 +1,398 @@
+package ci
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestGetStatusWithDeps_MixedContexts_UsesPRHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	headCalled := false
+	checkSHA := ""
+	statusSHA := ""
+
+	result, err := getStatusWithDeps(context.Background(), statusDeps{
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/ci-gap-free", nil
+		},
+		currentHeadSHA: func(context.Context) (string, error) {
+			headCalled = true
+			return "local-head-sha", nil
+		},
+		findPRHeadSHA: func(context.Context, GitHubRepository, string) (string, error) {
+			return "pr-head-sha", nil
+		},
+		listCheckRunsPage: func(_ context.Context, _ GitHubRepository, sha string, page int, perPage int) ([]checkRunData, error) {
+			checkSHA = sha
+			if page != 1 {
+				t.Fatalf("check-runs page = %d, want 1", page)
+			}
+			if perPage != statusPageSize {
+				t.Fatalf("check-runs perPage = %d, want %d", perPage, statusPageSize)
+			}
+			return []checkRunData{
+				{Name: "build", Status: "completed", Conclusion: "success", URL: "https://example/check/build"},
+				{Name: "integration", Status: "queued", URL: "https://example/check/integration"},
+			}, nil
+		},
+		listCommitStatusesPage: func(_ context.Context, _ GitHubRepository, sha string, page int, perPage int) ([]commitStatusData, error) {
+			statusSHA = sha
+			if page != 1 {
+				t.Fatalf("statuses page = %d, want 1", page)
+			}
+			if perPage != statusPageSize {
+				t.Fatalf("statuses perPage = %d, want %d", perPage, statusPageSize)
+			}
+			return []commitStatusData{
+				{Context: "lint", State: "success", URL: "https://example/status/lint"},
+				{Context: "security", State: "failure", URL: "https://example/status/security"},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("getStatusWithDeps() error = %v", err)
+	}
+
+	if headCalled {
+		t.Fatal("currentHeadSHA should not be called when PR head sha is available")
+	}
+	if result.SHA != "pr-head-sha" {
+		t.Fatalf("result.SHA = %q, want %q", result.SHA, "pr-head-sha")
+	}
+	if checkSHA != "pr-head-sha" {
+		t.Fatalf("check-runs sha = %q, want %q", checkSHA, "pr-head-sha")
+	}
+	if statusSHA != "pr-head-sha" {
+		t.Fatalf("statuses sha = %q, want %q", statusSHA, "pr-head-sha")
+	}
+
+	if result.Status != StatusPending {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusPending)
+	}
+	if !result.ChecksDiscovered {
+		t.Fatal("result.ChecksDiscovered = false, want true")
+	}
+	if result.Totals.Pending != 1 || result.Totals.Failing != 1 || result.Totals.Passing != 2 {
+		t.Fatalf("totals = %#v, want pending=1 failing=1 passing=2", result.Totals)
+	}
+
+	checks := checksByKey(result.Checks)
+	assertCheck(t, checks, "check:build", CheckSourceCheckRun, "build", StatusPassing)
+	assertCheck(t, checks, "check:integration", CheckSourceCheckRun, "integration", StatusPending)
+	assertCheck(t, checks, "status:lint", CheckSourceStatus, "lint", StatusPassing)
+	assertCheck(t, checks, "status:security", CheckSourceStatus, "security", StatusFailing)
+}
+
+func TestGetStatusWithDeps_UsesLocalHeadSHAWhenNoPR(t *testing.T) {
+	t.Parallel()
+
+	headCalls := 0
+	checkSHA := ""
+	statusSHA := ""
+
+	result, err := getStatusWithDeps(context.Background(), statusDeps{
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/no-pr", nil
+		},
+		currentHeadSHA: func(context.Context) (string, error) {
+			headCalls++
+			return "local-head-sha", nil
+		},
+		findPRHeadSHA: func(context.Context, GitHubRepository, string) (string, error) {
+			return "", nil
+		},
+		listCheckRunsPage: func(_ context.Context, _ GitHubRepository, sha string, page int, _ int) ([]checkRunData, error) {
+			checkSHA = sha
+			if page != 1 {
+				t.Fatalf("check-runs page = %d, want 1", page)
+			}
+			return nil, nil
+		},
+		listCommitStatusesPage: func(_ context.Context, _ GitHubRepository, sha string, page int, _ int) ([]commitStatusData, error) {
+			statusSHA = sha
+			if page != 1 {
+				t.Fatalf("statuses page = %d, want 1", page)
+			}
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("getStatusWithDeps() error = %v", err)
+	}
+
+	if headCalls != 1 {
+		t.Fatalf("currentHeadSHA calls = %d, want 1", headCalls)
+	}
+	if result.SHA != "local-head-sha" {
+		t.Fatalf("result.SHA = %q, want %q", result.SHA, "local-head-sha")
+	}
+	if checkSHA != "local-head-sha" {
+		t.Fatalf("check-runs sha = %q, want %q", checkSHA, "local-head-sha")
+	}
+	if statusSHA != "local-head-sha" {
+		t.Fatalf("statuses sha = %q, want %q", statusSHA, "local-head-sha")
+	}
+
+	if result.Status != StatusPending {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusPending)
+	}
+	if result.ChecksDiscovered {
+		t.Fatal("result.ChecksDiscovered = true, want false")
+	}
+	if len(result.Checks) != 0 {
+		t.Fatalf("len(result.Checks) = %d, want 0", len(result.Checks))
+	}
+	if result.Totals != (StatusTotals{}) {
+		t.Fatalf("totals = %#v, want empty", result.Totals)
+	}
+}
+
+func TestGetStatusWithDeps_DedupesByLockedKeys(t *testing.T) {
+	t.Parallel()
+
+	result, err := getStatusWithDeps(context.Background(), statusDeps{
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/dedupe", nil
+		},
+		currentHeadSHA: func(context.Context) (string, error) {
+			return "head-sha", nil
+		},
+		findPRHeadSHA: func(context.Context, GitHubRepository, string) (string, error) {
+			return "", nil
+		},
+		listCheckRunsPage: func(_ context.Context, _ GitHubRepository, _ string, page int, _ int) ([]checkRunData, error) {
+			if page != 1 {
+				t.Fatalf("check-runs page = %d, want 1", page)
+			}
+			return []checkRunData{
+				{Name: "build", Status: "completed", Conclusion: "success"},
+				{Name: "build", Status: "completed", Conclusion: "failure"},
+			}, nil
+		},
+		listCommitStatusesPage: func(_ context.Context, _ GitHubRepository, _ string, page int, _ int) ([]commitStatusData, error) {
+			if page != 1 {
+				t.Fatalf("statuses page = %d, want 1", page)
+			}
+			return []commitStatusData{
+				{Context: "lint", State: "failure"},
+				{Context: "lint", State: "success"},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("getStatusWithDeps() error = %v", err)
+	}
+
+	if len(result.Checks) != 2 {
+		t.Fatalf("len(result.Checks) = %d, want 2", len(result.Checks))
+	}
+
+	checks := checksByKey(result.Checks)
+	assertCheck(t, checks, "check:build", CheckSourceCheckRun, "build", StatusPassing)
+	assertCheck(t, checks, "status:lint", CheckSourceStatus, "lint", StatusFailing)
+
+	if result.Status != StatusFailing {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusFailing)
+	}
+	if result.Totals.Passing != 1 || result.Totals.Failing != 1 || result.Totals.Pending != 0 {
+		t.Fatalf("totals = %#v, want passing=1 failing=1 pending=0", result.Totals)
+	}
+}
+
+func TestGetStatusWithDeps_PaginatesCheckRunsAndStatuses(t *testing.T) {
+	t.Parallel()
+
+	checkPages := []int{}
+	statusPages := []int{}
+
+	result, err := getStatusWithDeps(context.Background(), statusDeps{
+		resolveRepo: func(context.Context) (GitHubRepository, error) {
+			return GitHubRepository{Owner: "acme", Name: "repo"}, nil
+		},
+		currentBranch: func(context.Context) (string, error) {
+			return "hal/pagination", nil
+		},
+		currentHeadSHA: func(context.Context) (string, error) {
+			return "head-sha", nil
+		},
+		findPRHeadSHA: func(context.Context, GitHubRepository, string) (string, error) {
+			return "", nil
+		},
+		listCheckRunsPage: func(_ context.Context, _ GitHubRepository, _ string, page int, perPage int) ([]checkRunData, error) {
+			if perPage != statusPageSize {
+				t.Fatalf("check-runs perPage = %d, want %d", perPage, statusPageSize)
+			}
+			checkPages = append(checkPages, page)
+			switch page {
+			case 1:
+				return makeCheckRuns(statusPageSize, "check-a"), nil
+			case 2:
+				return makeCheckRuns(1, "check-b"), nil
+			default:
+				return nil, fmt.Errorf("unexpected check-runs page %d", page)
+			}
+		},
+		listCommitStatusesPage: func(_ context.Context, _ GitHubRepository, _ string, page int, perPage int) ([]commitStatusData, error) {
+			if perPage != statusPageSize {
+				t.Fatalf("statuses perPage = %d, want %d", perPage, statusPageSize)
+			}
+			statusPages = append(statusPages, page)
+			switch page {
+			case 1:
+				return makeCommitStatuses(statusPageSize, "status-a"), nil
+			case 2:
+				return makeCommitStatuses(1, "status-b"), nil
+			default:
+				return nil, fmt.Errorf("unexpected statuses page %d", page)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("getStatusWithDeps() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(checkPages, []int{1, 2}) {
+		t.Fatalf("check-runs pages = %v, want [1 2]", checkPages)
+	}
+	if !reflect.DeepEqual(statusPages, []int{1, 2}) {
+		t.Fatalf("statuses pages = %v, want [1 2]", statusPages)
+	}
+
+	wantChecks := (statusPageSize + 1) + (statusPageSize + 1)
+	if len(result.Checks) != wantChecks {
+		t.Fatalf("len(result.Checks) = %d, want %d", len(result.Checks), wantChecks)
+	}
+	if !result.ChecksDiscovered {
+		t.Fatal("result.ChecksDiscovered = false, want true")
+	}
+	if result.Status != StatusPassing {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusPassing)
+	}
+	if result.Totals.Passing != wantChecks || result.Totals.Failing != 0 || result.Totals.Pending != 0 {
+		t.Fatalf("totals = %#v, want passing=%d failing=0 pending=0", result.Totals, wantChecks)
+	}
+}
+
+func TestMapCheckRunStatus_LockedMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		runStatus  string
+		conclusion string
+		want       string
+	}{
+		{name: "queued", runStatus: "queued", want: StatusPending},
+		{name: "in progress", runStatus: "in_progress", want: StatusPending},
+		{name: "completed success", runStatus: "completed", conclusion: "success", want: StatusPassing},
+		{name: "completed neutral", runStatus: "completed", conclusion: "neutral", want: StatusPassing},
+		{name: "completed skipped", runStatus: "completed", conclusion: "skipped", want: StatusPassing},
+		{name: "completed failure", runStatus: "completed", conclusion: "failure", want: StatusFailing},
+		{name: "completed timed out", runStatus: "completed", conclusion: "timed_out", want: StatusFailing},
+		{name: "completed cancelled", runStatus: "completed", conclusion: "cancelled", want: StatusFailing},
+		{name: "completed action required", runStatus: "completed", conclusion: "action_required", want: StatusFailing},
+		{name: "completed startup failure", runStatus: "completed", conclusion: "startup_failure", want: StatusFailing},
+		{name: "completed stale", runStatus: "completed", conclusion: "stale", want: StatusFailing},
+		{name: "completed unknown", runStatus: "completed", conclusion: "unknown", want: StatusPending},
+		{name: "unknown run status", runStatus: "requested", conclusion: "success", want: StatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapCheckRunStatus(tt.runStatus, tt.conclusion)
+			if got != tt.want {
+				t.Fatalf("mapCheckRunStatus(%q, %q) = %q, want %q", tt.runStatus, tt.conclusion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapCommitStatusState_LockedMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state string
+		want  string
+	}{
+		{state: "success", want: StatusPassing},
+		{state: "failure", want: StatusFailing},
+		{state: "error", want: StatusFailing},
+		{state: "pending", want: StatusPending},
+		{state: "", want: StatusPending},
+		{state: "unknown", want: StatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapCommitStatusState(tt.state)
+			if got != tt.want {
+				t.Fatalf("mapCommitStatusState(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func makeCheckRuns(count int, prefix string) []checkRunData {
+	runs := make([]checkRunData, 0, count)
+	for i := 0; i < count; i++ {
+		runs = append(runs, checkRunData{
+			Name:       fmt.Sprintf("%s-%03d", prefix, i),
+			Status:     "completed",
+			Conclusion: "success",
+		})
+	}
+	return runs
+}
+
+func makeCommitStatuses(count int, prefix string) []commitStatusData {
+	statuses := make([]commitStatusData, 0, count)
+	for i := 0; i < count; i++ {
+		statuses = append(statuses, commitStatusData{
+			Context: fmt.Sprintf("%s-%03d", prefix, i),
+			State:   "success",
+		})
+	}
+	return statuses
+}
+
+func checksByKey(checks []StatusCheck) map[string]StatusCheck {
+	m := make(map[string]StatusCheck, len(checks))
+	for _, check := range checks {
+		m[check.Key] = check
+	}
+	return m
+}
+
+func assertCheck(t *testing.T, checks map[string]StatusCheck, key, source, name, status string) {
+	t.Helper()
+
+	check, ok := checks[key]
+	if !ok {
+		t.Fatalf("missing check %q", key)
+	}
+	if check.Source != source {
+		t.Fatalf("check %q source = %q, want %q", key, check.Source, source)
+	}
+	if check.Name != name {
+		t.Fatalf("check %q name = %q, want %q", key, check.Name, name)
+	}
+	if check.Status != status {
+		t.Fatalf("check %q status = %q, want %q", key, check.Status, status)
+	}
+}

--- a/internal/ci/status_test.go
+++ b/internal/ci/status_test.go
@@ -348,6 +348,82 @@ func TestMapCommitStatusState_LockedMappings(t *testing.T) {
 	}
 }
 
+func TestGHAPIHTTPErrorFromStderr_ParsesHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	req := githubAPIRequest{
+		Method:   "DELETE",
+		Endpoint: "/repos/acme/repo/git/refs/heads/hal%2Ffeature",
+	}
+
+	apiErr := ghAPIHTTPErrorFromStderr(req, "gh: Not Found (HTTP 404)")
+	if apiErr == nil {
+		t.Fatal("ghAPIHTTPErrorFromStderr() = nil, want non-nil")
+	}
+	if apiErr.Method != req.Method {
+		t.Fatalf("Method = %q, want %q", apiErr.Method, req.Method)
+	}
+	if apiErr.Endpoint != req.Endpoint {
+		t.Fatalf("Endpoint = %q, want %q", apiErr.Endpoint, req.Endpoint)
+	}
+	if apiErr.StatusCode != 404 {
+		t.Fatalf("StatusCode = %d, want 404", apiErr.StatusCode)
+	}
+	if !isGitHubAPIHTTPStatus(apiErr, 404) {
+		t.Fatal("isGitHubAPIHTTPStatus(apiErr, 404) = false, want true")
+	}
+}
+
+func TestParseHTTPStatusCode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		want int
+		ok   bool
+	}{
+		{
+			name: "parenthesized http status",
+			text: "gh: Not Found (HTTP 404)",
+			want: 404,
+			ok:   true,
+		},
+		{
+			name: "http status code label",
+			text: "request failed; HTTP status code: 422",
+			want: 422,
+			ok:   true,
+		},
+		{
+			name: "missing status code",
+			text: "gh: authentication failed",
+			want: 0,
+			ok:   false,
+		},
+		{
+			name: "invalid status code",
+			text: "gh: weird response (HTTP 999)",
+			want: 0,
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseHTTPStatusCode(tt.text)
+			if ok != tt.ok {
+				t.Fatalf("parseHTTPStatusCode(%q) ok = %v, want %v", tt.text, ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("parseHTTPStatusCode(%q) code = %d, want %d", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
 func makeCheckRuns(count int, prefix string) []checkRunData {
 	runs := make([]checkRunData, 0, count)
 	for i := 0; i < count; i++ {

--- a/internal/ci/status_test.go
+++ b/internal/ci/status_test.go
@@ -424,6 +424,17 @@ func TestParseHTTPStatusCode(t *testing.T) {
 	}
 }
 
+func TestGitHubAPITokenHTTPClient_UsesBoundedTimeout(t *testing.T) {
+	t.Parallel()
+
+	if githubAPITokenHTTPClient == nil {
+		t.Fatal("githubAPITokenHTTPClient = nil, want non-nil")
+	}
+	if githubAPITokenHTTPClient.Timeout != defaultGitHubAPITimeout {
+		t.Fatalf("githubAPITokenHTTPClient.Timeout = %s, want %s", githubAPITokenHTTPClient.Timeout, defaultGitHubAPITimeout)
+	}
+}
+
 func makeCheckRuns(count int, prefix string) []checkRunData {
 	runs := make([]checkRunData, 0, count)
 	for i := 0; i < count; i++ {

--- a/internal/ci/status_wait_test.go
+++ b/internal/ci/status_wait_test.go
@@ -1,0 +1,271 @@
+package ci
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestWaitForChecksWithDeps_DefaultOptions(t *testing.T) {
+	t.Parallel()
+
+	pollInterval := time.Duration(0)
+	afterDurations := make([]time.Duration, 0, 2)
+	ticker := &fakeWaitTicker{ch: make(chan time.Time, 1)}
+
+	result, err := waitForChecksWithDeps(context.Background(), WaitOptions{}, waitForChecksDeps{
+		getStatus: func(context.Context) (StatusResult, error) {
+			return StatusResult{Status: StatusPassing, ChecksDiscovered: true}, nil
+		},
+		newTicker: func(d time.Duration) waitTicker {
+			pollInterval = d
+			return ticker
+		},
+		after: func(d time.Duration) <-chan time.Time {
+			afterDurations = append(afterDurations, d)
+			return make(chan time.Time)
+		},
+	})
+	if err != nil {
+		t.Fatalf("waitForChecksWithDeps() error = %v", err)
+	}
+
+	if pollInterval != defaultWaitPollInterval {
+		t.Fatalf("poll interval = %s, want %s", pollInterval, defaultWaitPollInterval)
+	}
+	if !reflect.DeepEqual(afterDurations, []time.Duration{defaultWaitTimeout, defaultNoChecksGrace}) {
+		t.Fatalf("after durations = %v, want [%s %s]", afterDurations, defaultWaitTimeout, defaultNoChecksGrace)
+	}
+	if !result.Wait {
+		t.Fatal("result.Wait = false, want true")
+	}
+	if result.WaitTerminalReason != WaitTerminalReasonCompleted {
+		t.Fatalf("result.WaitTerminalReason = %q, want %q", result.WaitTerminalReason, WaitTerminalReasonCompleted)
+	}
+	if !ticker.stopped {
+		t.Fatal("ticker.Stop() was not called")
+	}
+}
+
+func TestWaitForChecksWithDeps_Completed(t *testing.T) {
+	t.Parallel()
+
+	opts := WaitOptions{
+		PollInterval:  time.Second,
+		Timeout:       time.Minute,
+		NoChecksGrace: 5 * time.Second,
+	}
+	calls := 0
+	afterCalls := 0
+	timeoutCh := make(chan time.Time, 1)
+	noChecksCh := make(chan time.Time, 1)
+	ticker := &fakeWaitTicker{ch: make(chan time.Time, 1)}
+	ticker.ch <- time.Now()
+
+	result, err := waitForChecksWithDeps(context.Background(), opts, waitForChecksDeps{
+		getStatus: func(context.Context) (StatusResult, error) {
+			calls++
+			switch calls {
+			case 1:
+				return StatusResult{Status: StatusPending, ChecksDiscovered: true}, nil
+			case 2:
+				return StatusResult{Status: StatusPassing, ChecksDiscovered: true}, nil
+			default:
+				t.Fatalf("unexpected extra status poll #%d", calls)
+				return StatusResult{}, nil
+			}
+		},
+		newTicker: func(d time.Duration) waitTicker {
+			if d != opts.PollInterval {
+				t.Fatalf("poll interval = %s, want %s", d, opts.PollInterval)
+			}
+			return ticker
+		},
+		after: func(d time.Duration) <-chan time.Time {
+			afterCalls++
+			switch afterCalls {
+			case 1:
+				if d != opts.Timeout {
+					t.Fatalf("timeout duration = %s, want %s", d, opts.Timeout)
+				}
+				return timeoutCh
+			case 2:
+				if d != opts.NoChecksGrace {
+					t.Fatalf("no-checks grace = %s, want %s", d, opts.NoChecksGrace)
+				}
+				return noChecksCh
+			default:
+				t.Fatalf("unexpected after() call #%d", afterCalls)
+				return make(chan time.Time)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("waitForChecksWithDeps() error = %v", err)
+	}
+
+	if result.Status != StatusPassing {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusPassing)
+	}
+	if result.WaitTerminalReason != WaitTerminalReasonCompleted {
+		t.Fatalf("result.WaitTerminalReason = %q, want %q", result.WaitTerminalReason, WaitTerminalReasonCompleted)
+	}
+	if !result.Wait {
+		t.Fatal("result.Wait = false, want true")
+	}
+	if calls != 2 {
+		t.Fatalf("status polls = %d, want 2", calls)
+	}
+	if !ticker.stopped {
+		t.Fatal("ticker.Stop() was not called")
+	}
+}
+
+func TestWaitForChecksWithDeps_Timeout(t *testing.T) {
+	t.Parallel()
+
+	opts := WaitOptions{
+		PollInterval:  time.Second,
+		Timeout:       2 * time.Minute,
+		NoChecksGrace: 5 * time.Second,
+	}
+	calls := 0
+	afterCalls := 0
+	timeoutCh := make(chan time.Time, 1)
+	timeoutCh <- time.Now()
+	noChecksCh := make(chan time.Time, 1)
+	ticker := &fakeWaitTicker{ch: make(chan time.Time, 1)}
+
+	result, err := waitForChecksWithDeps(context.Background(), opts, waitForChecksDeps{
+		getStatus: func(context.Context) (StatusResult, error) {
+			calls++
+			return StatusResult{Status: StatusPending, ChecksDiscovered: true}, nil
+		},
+		newTicker: func(d time.Duration) waitTicker {
+			if d != opts.PollInterval {
+				t.Fatalf("poll interval = %s, want %s", d, opts.PollInterval)
+			}
+			return ticker
+		},
+		after: func(d time.Duration) <-chan time.Time {
+			afterCalls++
+			switch afterCalls {
+			case 1:
+				if d != opts.Timeout {
+					t.Fatalf("timeout duration = %s, want %s", d, opts.Timeout)
+				}
+				return timeoutCh
+			case 2:
+				if d != opts.NoChecksGrace {
+					t.Fatalf("no-checks grace = %s, want %s", d, opts.NoChecksGrace)
+				}
+				return noChecksCh
+			default:
+				t.Fatalf("unexpected after() call #%d", afterCalls)
+				return make(chan time.Time)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("waitForChecksWithDeps() error = %v", err)
+	}
+
+	if result.WaitTerminalReason != WaitTerminalReasonTimeout {
+		t.Fatalf("result.WaitTerminalReason = %q, want %q", result.WaitTerminalReason, WaitTerminalReasonTimeout)
+	}
+	if result.Status != StatusPending {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusPending)
+	}
+	if !result.Wait {
+		t.Fatal("result.Wait = false, want true")
+	}
+	if calls != 1 {
+		t.Fatalf("status polls = %d, want 1", calls)
+	}
+	if !ticker.stopped {
+		t.Fatal("ticker.Stop() was not called")
+	}
+}
+
+func TestWaitForChecksWithDeps_NoChecksDetected(t *testing.T) {
+	t.Parallel()
+
+	opts := WaitOptions{
+		PollInterval:  time.Second,
+		Timeout:       2 * time.Minute,
+		NoChecksGrace: 5 * time.Second,
+	}
+	calls := 0
+	afterCalls := 0
+	timeoutCh := make(chan time.Time, 1)
+	noChecksCh := make(chan time.Time, 1)
+	noChecksCh <- time.Now()
+	ticker := &fakeWaitTicker{ch: make(chan time.Time, 1)}
+
+	result, err := waitForChecksWithDeps(context.Background(), opts, waitForChecksDeps{
+		getStatus: func(context.Context) (StatusResult, error) {
+			calls++
+			return StatusResult{Status: StatusPending, ChecksDiscovered: false}, nil
+		},
+		newTicker: func(d time.Duration) waitTicker {
+			if d != opts.PollInterval {
+				t.Fatalf("poll interval = %s, want %s", d, opts.PollInterval)
+			}
+			return ticker
+		},
+		after: func(d time.Duration) <-chan time.Time {
+			afterCalls++
+			switch afterCalls {
+			case 1:
+				if d != opts.Timeout {
+					t.Fatalf("timeout duration = %s, want %s", d, opts.Timeout)
+				}
+				return timeoutCh
+			case 2:
+				if d != opts.NoChecksGrace {
+					t.Fatalf("no-checks grace = %s, want %s", d, opts.NoChecksGrace)
+				}
+				return noChecksCh
+			default:
+				t.Fatalf("unexpected after() call #%d", afterCalls)
+				return make(chan time.Time)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("waitForChecksWithDeps() error = %v", err)
+	}
+
+	if result.WaitTerminalReason != WaitTerminalReasonNoChecksDetected {
+		t.Fatalf("result.WaitTerminalReason = %q, want %q", result.WaitTerminalReason, WaitTerminalReasonNoChecksDetected)
+	}
+	if result.Status != StatusPending {
+		t.Fatalf("result.Status = %q, want %q", result.Status, StatusPending)
+	}
+	if result.ChecksDiscovered {
+		t.Fatal("result.ChecksDiscovered = true, want false")
+	}
+	if !result.Wait {
+		t.Fatal("result.Wait = false, want true")
+	}
+	if calls != 2 {
+		t.Fatalf("status polls = %d, want 2 (initial + no-check confirmation)", calls)
+	}
+	if !ticker.stopped {
+		t.Fatal("ticker.Stop() was not called")
+	}
+}
+
+type fakeWaitTicker struct {
+	ch      chan time.Time
+	stopped bool
+}
+
+func (t *fakeWaitTicker) Chan() <-chan time.Time {
+	return t.ch
+}
+
+func (t *fakeWaitTicker) Stop() {
+	t.stopped = true
+}

--- a/internal/ci/types.go
+++ b/internal/ci/types.go
@@ -1,0 +1,107 @@
+package ci
+
+// Stable machine-contract identifiers for CI command output.
+const (
+	PushContractVersion   = "ci-push-v1"
+	StatusContractVersion = "ci-status-v1"
+	FixContractVersion    = "ci-fix-v1"
+	MergeContractVersion  = "ci-merge-v1"
+)
+
+// Aggregated status values.
+const (
+	StatusPending = "pending"
+	StatusFailing = "failing"
+	StatusPassing = "passing"
+)
+
+// Wait terminal reason values.
+const (
+	WaitTerminalReasonCompleted        = "completed"
+	WaitTerminalReasonTimeout          = "timeout"
+	WaitTerminalReasonNoChecksDetected = "no_checks_detected"
+)
+
+// Check context source values.
+const (
+	CheckSourceCheckRun = "check"
+	CheckSourceStatus   = "status"
+)
+
+// PushResult is the shared machine-readable output for push flows.
+type PushResult struct {
+	ContractVersion string      `json:"contractVersion"`
+	Branch          string      `json:"branch"`
+	Pushed          bool        `json:"pushed"`
+	DryRun          bool        `json:"dryRun"`
+	PullRequest     PullRequest `json:"pullRequest"`
+	Summary         string      `json:"summary"`
+}
+
+// PullRequest contains PR metadata shared by CI operations.
+type PullRequest struct {
+	Number   int    `json:"number"`
+	URL      string `json:"url"`
+	Title    string `json:"title"`
+	HeadRef  string `json:"headRef,omitempty"`
+	HeadSHA  string `json:"headSha,omitempty"`
+	BaseRef  string `json:"baseRef,omitempty"`
+	Draft    bool   `json:"draft"`
+	Existing bool   `json:"existing"`
+}
+
+// StatusResult is the shared machine-readable output for ci status.
+type StatusResult struct {
+	ContractVersion    string        `json:"contractVersion"`
+	Branch             string        `json:"branch"`
+	SHA                string        `json:"sha"`
+	Status             string        `json:"status"`
+	ChecksDiscovered   bool          `json:"checksDiscovered"`
+	Wait               bool          `json:"wait"`
+	WaitTerminalReason string        `json:"waitTerminalReason"`
+	Checks             []StatusCheck `json:"checks"`
+	Totals             StatusTotals  `json:"totals"`
+	Summary            string        `json:"summary"`
+}
+
+// StatusCheck is one aggregated CI context.
+type StatusCheck struct {
+	Key    string `json:"key"`
+	Source string `json:"source"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	URL    string `json:"url,omitempty"`
+}
+
+// StatusTotals summarizes aggregated check counts.
+type StatusTotals struct {
+	Pending int `json:"pending"`
+	Failing int `json:"failing"`
+	Passing int `json:"passing"`
+}
+
+// FixResult is the shared machine-readable output for ci fix.
+type FixResult struct {
+	ContractVersion string   `json:"contractVersion"`
+	Attempt         int      `json:"attempt"`
+	MaxAttempts     int      `json:"maxAttempts,omitempty"`
+	Applied         bool     `json:"applied"`
+	Branch          string   `json:"branch"`
+	CommitSHA       string   `json:"commitSha,omitempty"`
+	Pushed          bool     `json:"pushed"`
+	FilesChanged    []string `json:"filesChanged,omitempty"`
+	Summary         string   `json:"summary"`
+}
+
+// MergeResult is the shared machine-readable output for ci merge.
+type MergeResult struct {
+	ContractVersion string `json:"contractVersion"`
+	PRNumber        int    `json:"prNumber"`
+	Strategy        string `json:"strategy"`
+	DryRun          bool   `json:"dryRun"`
+	Merged          bool   `json:"merged"`
+	MergeCommitSHA  string `json:"mergeCommitSha,omitempty"`
+	BranchDeleted   bool   `json:"branchDeleted"`
+	DeleteWarning   string `json:"deleteWarning,omitempty"`
+	Summary         string `json:"summary"`
+}

--- a/internal/ci/types_test.go
+++ b/internal/ci/types_test.go
@@ -1,0 +1,304 @@
+package ci
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestContractVersionConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "push", got: PushContractVersion, want: "ci-push-v1"},
+		{name: "status", got: StatusContractVersion, want: "ci-status-v1"},
+		{name: "fix", got: FixContractVersion, want: "ci-fix-v1"},
+		{name: "merge", got: MergeContractVersion, want: "ci-merge-v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("contract version = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitTerminalReasonConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "completed", got: WaitTerminalReasonCompleted, want: "completed"},
+		{name: "timeout", got: WaitTerminalReasonTimeout, want: "timeout"},
+		{name: "no_checks_detected", got: WaitTerminalReasonNoChecksDetected, want: "no_checks_detected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("terminal reason = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResultTypesHaveJSONTags(t *testing.T) {
+	types := []reflect.Type{
+		reflect.TypeOf(PushResult{}),
+		reflect.TypeOf(PullRequest{}),
+		reflect.TypeOf(StatusResult{}),
+		reflect.TypeOf(StatusCheck{}),
+		reflect.TypeOf(StatusTotals{}),
+		reflect.TypeOf(FixResult{}),
+		reflect.TypeOf(MergeResult{}),
+	}
+
+	for _, typ := range types {
+		t.Run(typ.Name(), func(t *testing.T) {
+			for i := 0; i < typ.NumField(); i++ {
+				field := typ.Field(i)
+				if !field.IsExported() {
+					continue
+				}
+
+				tag, ok := field.Tag.Lookup("json")
+				if !ok || tag == "" || tag == "-" {
+					t.Errorf("%s.%s missing explicit json tag", typ.Name(), field.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestPushResultJSONFields(t *testing.T) {
+	original := PushResult{
+		ContractVersion: PushContractVersion,
+		Branch:          "hal/ci-gap-free",
+		Pushed:          true,
+		DryRun:          false,
+		PullRequest: PullRequest{
+			Number:   42,
+			URL:      "https://github.com/acme/repo/pull/42",
+			Title:    "feat: add ci safety",
+			HeadRef:  "hal/ci-gap-free",
+			HeadSHA:  "abc123",
+			BaseRef:  "develop",
+			Draft:    true,
+			Existing: false,
+		},
+		Summary: "pushed branch and created pull request",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(payload) error = %v", err)
+	}
+
+	requiredTopLevel := []string{"contractVersion", "branch", "pushed", "dryRun", "pullRequest", "summary"}
+	for _, key := range requiredTopLevel {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing push JSON field %q", key)
+		}
+	}
+
+	pr, ok := raw["pullRequest"].(map[string]any)
+	if !ok {
+		t.Fatalf("pullRequest should be an object, got %T", raw["pullRequest"])
+	}
+	for _, key := range []string{"number", "url", "title", "headRef", "headSha", "baseRef", "draft", "existing"} {
+		if _, ok := pr[key]; !ok {
+			t.Errorf("missing pullRequest JSON field %q", key)
+		}
+	}
+
+	var decoded PushResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(round-trip) error = %v", err)
+	}
+	if !reflect.DeepEqual(decoded, original) {
+		t.Errorf("round-trip mismatch\n got: %#v\nwant: %#v", decoded, original)
+	}
+}
+
+func TestStatusResultJSONFields(t *testing.T) {
+	original := StatusResult{
+		ContractVersion:    StatusContractVersion,
+		Branch:             "hal/ci-gap-free",
+		SHA:                "def456",
+		Status:             StatusPending,
+		ChecksDiscovered:   false,
+		Wait:               true,
+		WaitTerminalReason: WaitTerminalReasonNoChecksDetected,
+		Checks: []StatusCheck{
+			{
+				Key:    "check:build",
+				Source: CheckSourceCheckRun,
+				Name:   "build",
+				Status: StatusPending,
+				URL:    "https://github.com/acme/repo/actions/runs/1",
+			},
+			{
+				Key:    "status:lint",
+				Source: CheckSourceStatus,
+				Name:   "lint",
+				Status: StatusFailing,
+			},
+		},
+		Totals: StatusTotals{
+			Pending: 1,
+			Failing: 1,
+			Passing: 0,
+		},
+		Summary: "checks are pending with no-checks grace terminal reason",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(payload) error = %v", err)
+	}
+
+	requiredTopLevel := []string{
+		"contractVersion",
+		"branch",
+		"sha",
+		"status",
+		"checksDiscovered",
+		"wait",
+		"waitTerminalReason",
+		"checks",
+		"totals",
+		"summary",
+	}
+	for _, key := range requiredTopLevel {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing status JSON field %q", key)
+		}
+	}
+
+	checks, ok := raw["checks"].([]any)
+	if !ok {
+		t.Fatalf("checks should be an array, got %T", raw["checks"])
+	}
+	if len(checks) != 2 {
+		t.Fatalf("checks length = %d, want 2", len(checks))
+	}
+
+	first, ok := checks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("checks[0] should be an object, got %T", checks[0])
+	}
+	for _, key := range []string{"key", "source", "name", "status", "url"} {
+		if _, ok := first[key]; !ok {
+			t.Errorf("missing check JSON field %q", key)
+		}
+	}
+
+	totals, ok := raw["totals"].(map[string]any)
+	if !ok {
+		t.Fatalf("totals should be an object, got %T", raw["totals"])
+	}
+	for _, key := range []string{"pending", "failing", "passing"} {
+		if _, ok := totals[key]; !ok {
+			t.Errorf("missing totals JSON field %q", key)
+		}
+	}
+
+	var decoded StatusResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(round-trip) error = %v", err)
+	}
+	if !reflect.DeepEqual(decoded, original) {
+		t.Errorf("round-trip mismatch\n got: %#v\nwant: %#v", decoded, original)
+	}
+}
+
+func TestFixResultJSONFields(t *testing.T) {
+	original := FixResult{
+		ContractVersion: FixContractVersion,
+		Attempt:         1,
+		MaxAttempts:     3,
+		Applied:         true,
+		Branch:          "hal/ci-gap-free",
+		CommitSHA:       "feedbeef",
+		Pushed:          true,
+		FilesChanged:    []string{"cmd/ci_fix.go", "internal/ci/fix.go"},
+		Summary:         "applied one fix attempt and pushed branch",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(payload) error = %v", err)
+	}
+
+	for _, key := range []string{"contractVersion", "attempt", "maxAttempts", "applied", "branch", "commitSha", "pushed", "filesChanged", "summary"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing fix JSON field %q", key)
+		}
+	}
+
+	var decoded FixResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(round-trip) error = %v", err)
+	}
+	if !reflect.DeepEqual(decoded, original) {
+		t.Errorf("round-trip mismatch\n got: %#v\nwant: %#v", decoded, original)
+	}
+}
+
+func TestMergeResultJSONFields(t *testing.T) {
+	original := MergeResult{
+		ContractVersion: MergeContractVersion,
+		PRNumber:        42,
+		Strategy:        "squash",
+		DryRun:          false,
+		Merged:          true,
+		MergeCommitSHA:  "1234abcd",
+		BranchDeleted:   false,
+		DeleteWarning:   "remote branch delete failed with 500",
+		Summary:         "merged pull request with warning",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("json.Unmarshal(payload) error = %v", err)
+	}
+
+	for _, key := range []string{"contractVersion", "prNumber", "strategy", "dryRun", "merged", "mergeCommitSha", "branchDeleted", "deleteWarning", "summary"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing merge JSON field %q", key)
+		}
+	}
+
+	var decoded MergeResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal(round-trip) error = %v", err)
+	}
+	if !reflect.DeepEqual(decoded, original) {
+		t.Errorf("round-trip mismatch\n got: %#v\nwant: %#v", decoded, original)
+	}
+}

--- a/internal/compound/pipeline.go
+++ b/internal/compound/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jywlabs/hal/internal/ci"
 	"github.com/jywlabs/hal/internal/engine"
 	"github.com/jywlabs/hal/internal/loop"
 	"github.com/jywlabs/hal/internal/skills"
@@ -20,20 +21,22 @@ var stateFileName = template.AutoStateFile
 
 // Pipeline orchestrates the compound engineering automation process.
 type Pipeline struct {
-	config       *AutoConfig
-	engine       engine.Engine
-	engineConfig *engine.EngineConfig
-	display      *engine.Display
-	dir          string
+	config          *AutoConfig
+	engine          engine.Engine
+	engineConfig    *engine.EngineConfig
+	display         *engine.Display
+	dir             string
+	pushAndCreatePR func(context.Context, ci.PushOptions) (ci.PushResult, error)
 }
 
 // NewPipeline creates a new pipeline instance.
 func NewPipeline(config *AutoConfig, eng engine.Engine, display *engine.Display, dir string) *Pipeline {
 	return &Pipeline{
-		config:  config,
-		engine:  eng,
-		display: display,
-		dir:     dir,
+		config:          config,
+		engine:          eng,
+		display:         display,
+		dir:             dir,
+		pushAndCreatePR: ci.PushAndCreatePR,
 	}
 }
 
@@ -655,11 +658,13 @@ func (p *Pipeline) runPRStep(ctx context.Context, state *PipelineState, opts Run
 		return nil
 	}
 
-	// Push the branch
-	p.display.ShowInfo("   Pushing branch: %s\n", state.BranchName)
-	if err := PushBranch(state.BranchName); err != nil {
-		return fmt.Errorf("failed to push branch: %w", err)
+	pushAndCreatePR := p.pushAndCreatePR
+	if pushAndCreatePR == nil {
+		pushAndCreatePR = ci.PushAndCreatePR
 	}
+
+	// Push the branch and create/reuse PR through shared CI core.
+	p.display.ShowInfo("   Pushing branch: %s\n", state.BranchName)
 
 	taskStatus := ""
 	if prd, err := engine.LoadPRDFile(filepath.Join(p.dir, template.HalDir), template.AutoPRDFile); err == nil {
@@ -675,13 +680,22 @@ func (p *Pipeline) runPRStep(ctx context.Context, state *PipelineState, opts Run
 		prTitle = "Compound: " + state.BranchName
 	}
 
-	// Create draft PR
+	draft := true
 	p.display.ShowInfo("   Creating draft PR...\n")
-	prURL, err := CreatePR(prTitle, prBody, state.BaseBranch, state.BranchName)
+	pushResult, err := pushAndCreatePR(ctx, ci.PushOptions{
+		BaseRef: state.BaseBranch,
+		Title:   prTitle,
+		Body:    prBody,
+		Draft:   &draft,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create PR: %w", err)
 	}
 
+	prURL := strings.TrimSpace(pushResult.PullRequest.URL)
+	if prURL == "" {
+		return fmt.Errorf("failed to create PR: empty pull request URL")
+	}
 	p.display.ShowInfo("   PR created: %s\n", prURL)
 
 	// Clear state on successful completion

--- a/internal/compound/pipeline.go
+++ b/internal/compound/pipeline.go
@@ -27,6 +27,7 @@ type Pipeline struct {
 	display         *engine.Display
 	dir             string
 	pushAndCreatePR func(context.Context, ci.PushOptions) (ci.PushResult, error)
+	currentBranch   func(string) (string, error)
 }
 
 // NewPipeline creates a new pipeline instance.
@@ -36,7 +37,10 @@ func NewPipeline(config *AutoConfig, eng engine.Engine, display *engine.Display,
 		engine:          eng,
 		display:         display,
 		dir:             dir,
-		pushAndCreatePR: ci.PushAndCreatePR,
+		pushAndCreatePR: func(ctx context.Context, opts ci.PushOptions) (ci.PushResult, error) {
+			return ci.PushAndCreatePRInDir(ctx, dir, opts)
+		},
+		currentBranch:   CurrentBranchInDir,
 	}
 }
 
@@ -658,9 +662,23 @@ func (p *Pipeline) runPRStep(ctx context.Context, state *PipelineState, opts Run
 		return nil
 	}
 
+	currentBranch := p.currentBranch
+	if currentBranch == nil {
+		currentBranch = CurrentBranchInDir
+	}
+	activeBranch, err := currentBranch(p.dir)
+	if err != nil {
+		return fmt.Errorf("failed to determine current branch before PR step: %w", err)
+	}
+	if strings.TrimSpace(activeBranch) != state.BranchName {
+		return fmt.Errorf("current branch %q does not match pipeline state branch %q", strings.TrimSpace(activeBranch), state.BranchName)
+	}
+
 	pushAndCreatePR := p.pushAndCreatePR
 	if pushAndCreatePR == nil {
-		pushAndCreatePR = ci.PushAndCreatePR
+		pushAndCreatePR = func(ctx context.Context, opts ci.PushOptions) (ci.PushResult, error) {
+			return ci.PushAndCreatePRInDir(ctx, p.dir, opts)
+		}
 	}
 
 	// Push the branch and create/reuse PR through shared CI core.

--- a/internal/compound/pipeline_pr_test.go
+++ b/internal/compound/pipeline_pr_test.go
@@ -1,0 +1,190 @@
+package compound
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/ci"
+	"github.com/jywlabs/hal/internal/engine"
+)
+
+func newPRStepTestPipeline(t *testing.T) (*Pipeline, *bytes.Buffer) {
+	t.Helper()
+
+	var out bytes.Buffer
+	display := engine.NewDisplay(&out)
+	cfg := DefaultAutoConfig()
+	pipeline := NewPipeline(&cfg, nil, display, t.TempDir())
+
+	return pipeline, &out
+}
+
+func TestRunPRStep_SkipPR_PreservesBehavior(t *testing.T) {
+	pipeline, out := newPRStepTestPipeline(t)
+	if err := pipeline.saveState(&PipelineState{Step: StepPR}); err != nil {
+		t.Fatalf("saveState: %v", err)
+	}
+
+	called := false
+	pipeline.pushAndCreatePR = func(ctx context.Context, opts ci.PushOptions) (ci.PushResult, error) {
+		called = true
+		return ci.PushResult{}, nil
+	}
+
+	state := &PipelineState{Step: StepPR}
+	err := pipeline.runPRStep(context.Background(), state, RunOptions{SkipPR: true})
+	if err != nil {
+		t.Fatalf("runPRStep: %v", err)
+	}
+	if called {
+		t.Fatalf("pushAndCreatePR was called with --skip-pr")
+	}
+	if state.Step != StepDone {
+		t.Fatalf("state.Step = %q, want %q", state.Step, StepDone)
+	}
+	if pipeline.HasState() {
+		t.Fatalf("expected state to be cleared")
+	}
+	if !strings.Contains(out.String(), "Skipping PR creation (--skip-pr)") {
+		t.Fatalf("output = %q, want skip-pr message", out.String())
+	}
+}
+
+func TestRunPRStep_DryRun_PreservesBehavior(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      string
+		wantInLog string
+	}{
+		{
+			name:      "with base branch",
+			base:      "main",
+			wantInLog: "[dry-run] Would push branch compound/test-feature and create draft PR against main",
+		},
+		{
+			name:      "without base branch",
+			base:      "",
+			wantInLog: "[dry-run] Would push branch compound/test-feature and create draft PR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline, out := newPRStepTestPipeline(t)
+
+			called := false
+			pipeline.pushAndCreatePR = func(ctx context.Context, opts ci.PushOptions) (ci.PushResult, error) {
+				called = true
+				return ci.PushResult{}, nil
+			}
+
+			state := &PipelineState{Step: StepPR, BranchName: "compound/test-feature", BaseBranch: tt.base}
+			err := pipeline.runPRStep(context.Background(), state, RunOptions{DryRun: true})
+			if err != nil {
+				t.Fatalf("runPRStep: %v", err)
+			}
+			if called {
+				t.Fatalf("pushAndCreatePR was called in dry-run mode")
+			}
+			if state.Step != StepDone {
+				t.Fatalf("state.Step = %q, want %q", state.Step, StepDone)
+			}
+			if !strings.Contains(out.String(), tt.wantInLog) {
+				t.Fatalf("output = %q, want %q", out.String(), tt.wantInLog)
+			}
+		})
+	}
+}
+
+func TestRunPRStep_DelegatesToCIAndPreservesPRContent(t *testing.T) {
+	tests := []struct {
+		name         string
+		priorityItem string
+		wantTitle    string
+	}{
+		{
+			name:         "analysis title",
+			priorityItem: "Implement deterministic CI flow",
+			wantTitle:    "Implement deterministic CI flow",
+		},
+		{
+			name:         "fallback title",
+			priorityItem: "",
+			wantTitle:    "Compound: compound/ci-flow",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline, out := newPRStepTestPipeline(t)
+			if err := pipeline.saveState(&PipelineState{Step: StepPR}); err != nil {
+				t.Fatalf("saveState: %v", err)
+			}
+
+			state := &PipelineState{
+				Step:       StepPR,
+				BranchName: "compound/ci-flow",
+				BaseBranch: "main",
+				Analysis: &AnalysisResult{
+					PriorityItem:       tt.priorityItem,
+					Description:        "Ship CI command foundation",
+					Rationale:          "Safer PR automation",
+					AcceptanceCriteria: []string{"Push branch", "Open draft PR"},
+				},
+			}
+
+			expectedBody := buildPRBody(state, "")
+
+			var gotOpts ci.PushOptions
+			pipeline.pushAndCreatePR = func(ctx context.Context, opts ci.PushOptions) (ci.PushResult, error) {
+				gotOpts = opts
+				return ci.PushResult{
+					Branch: "compound/ci-flow",
+					PullRequest: ci.PullRequest{
+						URL: "https://github.com/acme/repo/pull/42",
+					},
+				}, nil
+			}
+
+			err := pipeline.runPRStep(context.Background(), state, RunOptions{})
+			if err != nil {
+				t.Fatalf("runPRStep: %v", err)
+			}
+			if state.Step != StepDone {
+				t.Fatalf("state.Step = %q, want %q", state.Step, StepDone)
+			}
+			if pipeline.HasState() {
+				t.Fatalf("expected state to be cleared")
+			}
+
+			if gotOpts.BaseRef != "main" {
+				t.Fatalf("push options base = %q, want %q", gotOpts.BaseRef, "main")
+			}
+			if gotOpts.Title != tt.wantTitle {
+				t.Fatalf("push options title = %q, want %q", gotOpts.Title, tt.wantTitle)
+			}
+			if gotOpts.Body != expectedBody {
+				t.Fatalf("push options body mismatch\n--- got ---\n%s\n--- want ---\n%s", gotOpts.Body, expectedBody)
+			}
+			if gotOpts.Draft == nil || !*gotOpts.Draft {
+				t.Fatalf("push options draft = %v, want true", gotOpts.Draft)
+			}
+
+			output := out.String()
+			if !strings.Contains(output, "Pushing branch: compound/ci-flow") {
+				t.Fatalf("output = %q, want push message", output)
+			}
+			if !strings.Contains(output, "Creating draft PR...") {
+				t.Fatalf("output = %q, want create message", output)
+			}
+			if !strings.Contains(output, "PR created: https://github.com/acme/repo/pull/42") {
+				t.Fatalf("output = %q, want PR URL", output)
+			}
+			if strings.Contains(output, "Waiting for CI") || strings.Contains(output, "CI green") {
+				t.Fatalf("unexpected CI loop output in StepPR: %q", output)
+			}
+		})
+	}
+}

--- a/internal/compound/pipeline_pr_test.go
+++ b/internal/compound/pipeline_pr_test.go
@@ -147,6 +147,9 @@ func TestRunPRStep_DelegatesToCIAndPreservesPRContent(t *testing.T) {
 					},
 				}, nil
 			}
+			pipeline.currentBranch = func(string) (string, error) {
+				return "compound/ci-flow", nil
+			}
 
 			err := pipeline.runPRStep(context.Background(), state, RunOptions{})
 			if err != nil {
@@ -186,5 +189,35 @@ func TestRunPRStep_DelegatesToCIAndPreservesPRContent(t *testing.T) {
 				t.Fatalf("unexpected CI loop output in StepPR: %q", output)
 			}
 		})
+	}
+}
+
+func TestRunPRStep_FailsWhenCurrentBranchDoesNotMatchState(t *testing.T) {
+	pipeline, _ := newPRStepTestPipeline(t)
+
+	called := false
+	pipeline.pushAndCreatePR = func(ctx context.Context, opts ci.PushOptions) (ci.PushResult, error) {
+		called = true
+		return ci.PushResult{}, nil
+	}
+	pipeline.currentBranch = func(string) (string, error) {
+		return "compound/other-branch", nil
+	}
+
+	state := &PipelineState{
+		Step:       StepPR,
+		BranchName: "compound/ci-flow",
+		BaseBranch: "main",
+	}
+
+	err := pipeline.runPRStep(context.Background(), state, RunOptions{})
+	if err == nil {
+		t.Fatal("expected branch mismatch error")
+	}
+	if !strings.Contains(err.Error(), `current branch "compound/other-branch" does not match pipeline state branch "compound/ci-flow"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("pushAndCreatePR should not be called on branch mismatch")
 	}
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -5,12 +5,17 @@
 package doctor
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/jywlabs/hal/internal/ci"
 	"github.com/jywlabs/hal/internal/skills"
 	"github.com/jywlabs/hal/internal/template"
 	"gopkg.in/yaml.v3"
@@ -36,9 +41,10 @@ const (
 
 // Remediation IDs.
 const (
-	RemediationNone             = "none"
-	RemediationRunHalInit       = "run_hal_init"
+	RemediationNone              = "none"
+	RemediationRunHalInit        = "run_hal_init"
 	RemediationRefreshCodexLinks = "refresh_codex_links"
+	RemediationRunGHAuthLogin    = "run_gh_auth_login"
 )
 
 // DoctorResult is the v1 machine-readable doctor contract.
@@ -64,10 +70,10 @@ const (
 
 // Scope values for checks.
 const (
-	ScopeRepo        = "repo"
-	ScopeEngineLocal = "engine_local"
+	ScopeRepo         = "repo"
+	ScopeEngineLocal  = "engine_local"
 	ScopeEngineGlobal = "engine_global"
-	ScopeMigration   = "migration"
+	ScopeMigration    = "migration"
 )
 
 // Check is a single health check result.
@@ -153,70 +159,77 @@ func Run(opts Options) DoctorResult {
 	// 3. config.yaml
 	checks = append(checks, checkConfigYAML(halDir))
 
-	// 4. Default engine CLI
+	// 4. GitHub auth readiness (only applicable for GitHub remotes)
+	githubAuthCheck := checkGitHubAuth(dir)
+	checks = append(checks, githubAuthCheck)
+	if githubAuthCheck.Status == StatusWarn {
+		warnings = append(warnings, "github_auth")
+	}
+
+	// 5. Default engine CLI
 	checks = append(checks, checkEngineCLI(engine))
 
-	// 5. Prompt template
+	// 6. Prompt template
 	promptCheck := checkPromptMD(halDir)
 	checks = append(checks, promptCheck)
 	if promptCheck.Status == StatusWarn {
 		warnings = append(warnings, "prompt_md")
 	}
 
-	// 6. Progress file
+	// 7. Progress file
 	progressCheck := checkProgressFile(halDir)
 	checks = append(checks, progressCheck)
 
-	// 7. PRD validity (only when prd.json exists)
+	// 8. PRD validity (only when prd.json exists)
 	prdCheck := checkPRDJSON(halDir)
 	checks = append(checks, prdCheck)
 	if prdCheck.Status == StatusWarn {
 		warnings = append(warnings, "prd_json")
 	}
 
-	// 8. Hal skills
+	// 9. Hal skills
 	skillCheck := checkSkills(dir)
 	checks = append(checks, skillCheck)
 	if skillCheck.Status == StatusFail {
 		failures = append(failures, "hal_skills")
 	}
 
-	// 6. Hal commands
+	// 10. Hal commands
 	cmdCheck := checkCommands(dir)
 	checks = append(checks, cmdCheck)
 	if cmdCheck.Status == StatusFail {
 		failures = append(failures, "hal_commands")
 	}
 
-	// 7. Engine-local skill links (.claude/skills, .pi/skills)
+	// 11. Engine-local skill links (.claude/skills, .pi/skills)
 	localLinksCheck := checkLocalSkillLinks(dir)
 	checks = append(checks, localLinksCheck)
 	if localLinksCheck.Status == StatusWarn {
 		warnings = append(warnings, "local_skill_links")
 	}
 
-	// 8. Codex global links (only applicable for codex engine)
+	// 12. Codex global links (only applicable for codex engine)
 	codexCheck := checkCodexLinks(dir, engine)
 	checks = append(checks, codexCheck)
 	if codexCheck.Status == StatusWarn {
 		warnings = append(warnings, "codex_global_links")
 	}
 
-	// 8. Legacy migration debris
+	// 13. Legacy migration debris
 	legacyCheck := checkLegacyDebris(dir)
 	checks = append(checks, legacyCheck)
 	if legacyCheck.Status == StatusWarn {
 		warnings = append(warnings, "legacy_debris")
 	}
 
-	// 9. Legacy sandbox state (.hal/sandbox.json)
+	// 14. Legacy sandbox state (.hal/sandbox.json)
 	legacySandboxCheck := checkLegacySandboxState(halDir)
 	checks = append(checks, legacySandboxCheck)
 	if legacySandboxCheck.Status == StatusWarn {
 		warnings = append(warnings, "legacy_sandbox_state")
 	}
 
-	// 10. Broken symlinks in engine skill directories
+	// 15. Broken symlinks in engine skill directories
 	brokenCheck := checkBrokenSkillLinks(dir)
 	checks = append(checks, brokenCheck)
 	if brokenCheck.Status == StatusWarn {
@@ -238,6 +251,13 @@ func Run(opts Options) DoctorResult {
 		case "git_repo", "hal_dir", "config_yaml", "prompt_md", "progress_file", "hal_skills", "hal_commands":
 			c.Scope = ScopeRepo
 			c.Applicability = ApplicabilityRequired
+		case "github_auth":
+			c.Scope = ScopeRepo
+			if c.Status == StatusSkip {
+				c.Applicability = ApplicabilityNotApplicable
+			} else {
+				c.Applicability = ApplicabilityOptional
+			}
 		case "default_engine_cli":
 			c.Scope = ScopeRepo
 			c.Applicability = ApplicabilityRequired
@@ -283,6 +303,8 @@ func Run(opts Options) DoctorResult {
 			switch w {
 			case "codex_global_links":
 				warnParts = append(warnParts, "refresh Codex global links")
+			case "github_auth":
+				warnParts = append(warnParts, "run gh auth login")
 			case "legacy_debris":
 				warnParts = append(warnParts, "run hal cleanup")
 			case "legacy_sandbox_state":
@@ -431,6 +453,142 @@ func checkEngineCLI(engine string) Check {
 		RemediationID: RemediationNone,
 		Message:       "The configured default engine CLI (" + cliName + ") was not found in PATH.",
 	}
+}
+
+var errNotGitRepository = errors.New("not a git repository")
+
+type githubAuthDeps struct {
+	originRemoteURL    func(string) (string, error)
+	selectGitHubClient func(context.Context) (ci.ClientSelection, error)
+}
+
+func checkGitHubAuth(dir string) Check {
+	return checkGitHubAuthWithDeps(dir, githubAuthDeps{
+		originRemoteURL:    gitOriginRemoteURL,
+		selectGitHubClient: ci.SelectGitHubClient,
+	})
+}
+
+func checkGitHubAuthWithDeps(dir string, deps githubAuthDeps) Check {
+	if deps.originRemoteURL == nil {
+		deps.originRemoteURL = gitOriginRemoteURL
+	}
+	if deps.selectGitHubClient == nil {
+		deps.selectGitHubClient = ci.SelectGitHubClient
+	}
+
+	remoteURL, err := deps.originRemoteURL(dir)
+	if err != nil {
+		switch {
+		case errors.Is(err, errNotGitRepository):
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusSkip,
+				Severity:      SeverityInfo,
+				RemediationID: RemediationNone,
+				Message:       "GitHub auth check is not applicable outside a git repository.",
+			}
+		case errors.Is(err, ci.ErrMissingOriginRemote):
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusSkip,
+				Severity:      SeverityInfo,
+				RemediationID: RemediationNone,
+				Message:       "GitHub auth check is not applicable: origin remote is not configured.",
+			}
+		default:
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusWarn,
+				Severity:      SeverityWarn,
+				RemediationID: RemediationNone,
+				Message:       "Unable to determine GitHub auth applicability: " + err.Error(),
+			}
+		}
+	}
+
+	if _, err := ci.ParseGitHubRepository(remoteURL); err != nil {
+		switch {
+		case errors.Is(err, ci.ErrNonGitHubOriginRemote):
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusSkip,
+				Severity:      SeverityInfo,
+				RemediationID: RemediationNone,
+				Message:       "GitHub auth check is not applicable: origin remote is not hosted on GitHub.",
+			}
+		case errors.Is(err, ci.ErrInvalidGitHubOriginRemote), errors.Is(err, ci.ErrMissingOriginRemote):
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusSkip,
+				Severity:      SeverityInfo,
+				RemediationID: RemediationNone,
+				Message:       "GitHub auth check is not applicable: origin remote is not a valid GitHub repository.",
+			}
+		default:
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusWarn,
+				Severity:      SeverityWarn,
+				RemediationID: RemediationNone,
+				Message:       "Unable to parse origin remote for GitHub auth check: " + err.Error(),
+			}
+		}
+	}
+
+	if _, err := deps.selectGitHubClient(context.Background()); err != nil {
+		if errors.Is(err, ci.ErrNoGitHubAuth) || errors.Is(err, ci.ErrInvalidEnvToken) {
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusWarn,
+				Severity:      SeverityWarn,
+				RemediationID: RemediationRunGHAuthLogin,
+				Message:       "GitHub auth not configured for this GitHub remote.",
+				Remediation:   &Remediation{Command: "gh auth login", Safe: false},
+			}
+		}
+		return Check{
+			ID:            "github_auth",
+			Status:        StatusWarn,
+			Severity:      SeverityWarn,
+			RemediationID: RemediationNone,
+			Message:       "Unable to verify GitHub auth state: " + err.Error(),
+		}
+	}
+
+	return Check{
+		ID:            "github_auth",
+		Status:        StatusPass,
+		Severity:      SeverityInfo,
+		RemediationID: RemediationNone,
+		Message:       "GitHub auth is available for GitHub remote operations.",
+	}
+}
+
+func gitOriginRemoteURL(dir string) (string, error) {
+	cmd := exec.Command("git", "-C", dir, "remote", "get-url", "origin")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		errText := strings.ToLower(strings.TrimSpace(stderr.String()))
+		switch {
+		case strings.Contains(errText, "not a git repository"):
+			return "", errNotGitRepository
+		case strings.Contains(errText, "no such remote") && strings.Contains(errText, "origin"):
+			return "", ci.ErrMissingOriginRemote
+		default:
+			return "", fmt.Errorf("failed to read git origin remote: %w", err)
+		}
+	}
+
+	remoteURL := strings.TrimSpace(stdout.String())
+	if remoteURL == "" {
+		return "", ci.ErrMissingOriginRemote
+	}
+	return remoteURL, nil
 }
 
 func checkSkills(dir string) Check {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -300,22 +300,7 @@ func Run(opts Options) DoctorResult {
 		// Build specific warning summary
 		warnParts := make([]string, 0, len(warnings))
 		for _, w := range warnings {
-			switch w {
-			case "codex_global_links":
-				warnParts = append(warnParts, "refresh Codex global links")
-			case "github_auth":
-				warnParts = append(warnParts, "run gh auth login")
-			case "legacy_debris":
-				warnParts = append(warnParts, "run hal cleanup")
-			case "legacy_sandbox_state":
-				warnParts = append(warnParts, "run hal sandbox migrate")
-			case "broken_skill_links":
-				warnParts = append(warnParts, "run hal links clean")
-			case "local_skill_links":
-				warnParts = append(warnParts, "run hal links refresh")
-			default:
-				warnParts = append(warnParts, w)
-			}
+			warnParts = append(warnParts, warningSummaryPart(w, checks))
 		}
 		if len(warnParts) > 0 {
 			summary = "Hal is usable with warnings: " + strings.Join(warnParts, "; ") + "."
@@ -347,6 +332,37 @@ func countPassed(checks []Check) int {
 		}
 	}
 	return n
+}
+
+func warningSummaryPart(warningID string, checks []Check) string {
+	switch warningID {
+	case "codex_global_links":
+		return "refresh Codex global links"
+	case "github_auth":
+		for _, c := range checks {
+			if c.ID != "github_auth" || c.Status != StatusWarn {
+				continue
+			}
+			if c.RemediationID == RemediationRunGHAuthLogin {
+				return "run gh auth login"
+			}
+			if strings.Contains(c.Message, "env token is invalid") {
+				return "set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it"
+			}
+			return "review GitHub auth configuration"
+		}
+		return "review GitHub auth configuration"
+	case "legacy_debris":
+		return "run hal cleanup"
+	case "legacy_sandbox_state":
+		return "run hal sandbox migrate"
+	case "broken_skill_links":
+		return "run hal links clean"
+	case "local_skill_links":
+		return "run hal links refresh"
+	default:
+		return warningID
+	}
 }
 
 func checkGitRepo(dir string) Check {
@@ -537,7 +553,16 @@ func checkGitHubAuthWithDeps(dir string, deps githubAuthDeps) Check {
 	}
 
 	if _, err := deps.selectGitHubClient(context.Background()); err != nil {
-		if errors.Is(err, ci.ErrNoGitHubAuth) || errors.Is(err, ci.ErrInvalidEnvToken) {
+		if errors.Is(err, ci.ErrInvalidEnvToken) {
+			return Check{
+				ID:            "github_auth",
+				Status:        StatusWarn,
+				Severity:      SeverityWarn,
+				RemediationID: RemediationNone,
+				Message:       "GitHub auth env token is invalid: set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it to use `gh auth login`.",
+			}
+		}
+		if errors.Is(err, ci.ErrNoGitHubAuth) {
 			return Check{
 				ID:            "github_auth",
 				Status:        StatusWarn,

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,12 +1,16 @@
 package doctor
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/jywlabs/hal/internal/ci"
 	"github.com/jywlabs/hal/internal/skills"
 	"github.com/jywlabs/hal/internal/template"
 )
@@ -551,6 +555,18 @@ func TestRun_ScopeAndApplicability(t *testing.T) {
 		}
 	}
 
+	// GitHub auth check should be not_applicable when there is no valid GitHub origin remote
+	for _, c := range result.Checks {
+		if c.ID == "github_auth" {
+			if c.Applicability != ApplicabilityNotApplicable {
+				t.Fatalf("github_auth applicability = %q, want %q", c.Applicability, ApplicabilityNotApplicable)
+			}
+			if c.Scope != ScopeRepo {
+				t.Fatalf("github_auth scope = %q, want %q", c.Scope, ScopeRepo)
+			}
+		}
+	}
+
 	// Codex check should be not_applicable for pi engine
 	for _, c := range result.Checks {
 		if c.ID == "codex_global_links" {
@@ -639,7 +655,7 @@ func TestRun_NoPRDJSON(t *testing.T) {
 }
 
 func TestRun_CheckCount(t *testing.T) {
-	// A fully healthy repo should have exactly 14 checks
+	// A fully healthy repo should have exactly 15 checks
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, ".git"), 0755)
 	halDir := setupHalDir(t, dir)
@@ -654,6 +670,7 @@ func TestRun_CheckCount(t *testing.T) {
 		"git_repo",
 		"hal_dir",
 		"config_yaml",
+		"github_auth",
 		"default_engine_cli",
 		"prompt_md",
 		"progress_file",
@@ -678,6 +695,140 @@ func TestRun_CheckCount(t *testing.T) {
 		if result.Checks[i].ID != expected {
 			t.Fatalf("check[%d].ID = %q, want %q", i, result.Checks[i].ID, expected)
 		}
+	}
+}
+
+func TestCheckGitHubAuth_NonGitDirectoryIsNotApplicable(t *testing.T) {
+	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
+		originRemoteURL: func(string) (string, error) {
+			return "", errNotGitRepository
+		},
+		selectGitHubClient: func(context.Context) (ci.ClientSelection, error) {
+			t.Fatal("selectGitHubClient should not be called when repository is not git")
+			return ci.ClientSelection{}, nil
+		},
+	})
+
+	if check.Status != StatusSkip {
+		t.Fatalf("status = %q, want %q", check.Status, StatusSkip)
+	}
+	if check.Severity != SeverityInfo {
+		t.Fatalf("severity = %q, want %q", check.Severity, SeverityInfo)
+	}
+}
+
+func TestCheckGitHubAuth_MissingOriginIsNotApplicable(t *testing.T) {
+	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
+		originRemoteURL: func(string) (string, error) {
+			return "", ci.ErrMissingOriginRemote
+		},
+		selectGitHubClient: func(context.Context) (ci.ClientSelection, error) {
+			t.Fatal("selectGitHubClient should not be called when origin remote is missing")
+			return ci.ClientSelection{}, nil
+		},
+	})
+
+	if check.Status != StatusSkip {
+		t.Fatalf("status = %q, want %q", check.Status, StatusSkip)
+	}
+	if check.Message != "GitHub auth check is not applicable: origin remote is not configured." {
+		t.Fatalf("message = %q", check.Message)
+	}
+}
+
+func TestCheckGitHubAuth_NonGitHubOriginIsNotApplicable(t *testing.T) {
+	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
+		originRemoteURL: func(string) (string, error) {
+			return "git@gitlab.com:acme/repo.git", nil
+		},
+		selectGitHubClient: func(context.Context) (ci.ClientSelection, error) {
+			t.Fatal("selectGitHubClient should not be called for non-GitHub origins")
+			return ci.ClientSelection{}, nil
+		},
+	})
+
+	if check.Status != StatusSkip {
+		t.Fatalf("status = %q, want %q", check.Status, StatusSkip)
+	}
+	if check.Message != "GitHub auth check is not applicable: origin remote is not hosted on GitHub." {
+		t.Fatalf("message = %q", check.Message)
+	}
+}
+
+func TestCheckGitHubAuth_GitHubOriginWithoutAuthWarns(t *testing.T) {
+	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
+		originRemoteURL: func(string) (string, error) {
+			return "git@github.com:acme/repo.git", nil
+		},
+		selectGitHubClient: func(context.Context) (ci.ClientSelection, error) {
+			return ci.ClientSelection{}, ci.ErrNoGitHubAuth
+		},
+	})
+
+	if check.Status != StatusWarn {
+		t.Fatalf("status = %q, want %q", check.Status, StatusWarn)
+	}
+	if check.RemediationID != RemediationRunGHAuthLogin {
+		t.Fatalf("remediationId = %q, want %q", check.RemediationID, RemediationRunGHAuthLogin)
+	}
+	if check.Remediation == nil {
+		t.Fatal("remediation should not be nil")
+	}
+	if check.Remediation.Command != "gh auth login" {
+		t.Fatalf("remediation.command = %q, want %q", check.Remediation.Command, "gh auth login")
+	}
+	if check.Remediation.Safe {
+		t.Fatal("remediation.safe = true, want false")
+	}
+}
+
+func TestCheckGitHubAuth_GitHubOriginWithAuthPasses(t *testing.T) {
+	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
+		originRemoteURL: func(string) (string, error) {
+			return "https://github.com/acme/repo.git", nil
+		},
+		selectGitHubClient: func(context.Context) (ci.ClientSelection, error) {
+			return ci.ClientSelection{Kind: ci.ClientKindGH}, nil
+		},
+	})
+
+	if check.Status != StatusPass {
+		t.Fatalf("status = %q, want %q", check.Status, StatusPass)
+	}
+	if check.Remediation != nil {
+		t.Fatalf("remediation = %+v, want nil", check.Remediation)
+	}
+}
+
+func TestGitOriginRemoteURL_NotGitRepository(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	remote, err := gitOriginRemoteURL(dir)
+	if remote != "" {
+		t.Fatalf("remote = %q, want empty", remote)
+	}
+	if !errors.Is(err, errNotGitRepository) {
+		t.Fatalf("error = %v, want errNotGitRepository", err)
+	}
+}
+
+func TestGitOriginRemoteURL_GitRepoMissingOrigin(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd := exec.Command("git", "-C", dir, "init")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	remote, err := gitOriginRemoteURL(dir)
+	if remote != "" {
+		t.Fatalf("remote = %q, want empty", remote)
+	}
+	if !errors.Is(err, ci.ErrMissingOriginRemote) {
+		t.Fatalf("error = %v, want ci.ErrMissingOriginRemote", err)
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -782,6 +782,59 @@ func TestCheckGitHubAuth_GitHubOriginWithoutAuthWarns(t *testing.T) {
 	}
 }
 
+func TestCheckGitHubAuth_GitHubOriginWithInvalidEnvTokenWarnsWithoutGHLoginRemediation(t *testing.T) {
+	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
+		originRemoteURL: func(string) (string, error) {
+			return "git@github.com:acme/repo.git", nil
+		},
+		selectGitHubClient: func(context.Context) (ci.ClientSelection, error) {
+			return ci.ClientSelection{}, ci.ErrInvalidEnvToken
+		},
+	})
+
+	if check.Status != StatusWarn {
+		t.Fatalf("status = %q, want %q", check.Status, StatusWarn)
+	}
+	if check.RemediationID != RemediationNone {
+		t.Fatalf("remediationId = %q, want %q", check.RemediationID, RemediationNone)
+	}
+	if check.Remediation != nil {
+		t.Fatalf("remediation = %+v, want nil", check.Remediation)
+	}
+	const want = "GitHub auth env token is invalid: set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it to use `gh auth login`."
+	if check.Message != want {
+		t.Fatalf("message = %q, want %q", check.Message, want)
+	}
+}
+
+func TestWarningSummaryPart_GitHubAuthNoAuth(t *testing.T) {
+	got := warningSummaryPart("github_auth", []Check{
+		{
+			ID:            "github_auth",
+			Status:        StatusWarn,
+			RemediationID: RemediationRunGHAuthLogin,
+			Message:       "GitHub auth not configured for this GitHub remote.",
+		},
+	})
+	if got != "run gh auth login" {
+		t.Fatalf("warningSummaryPart() = %q, want %q", got, "run gh auth login")
+	}
+}
+
+func TestWarningSummaryPart_GitHubAuthInvalidEnvToken(t *testing.T) {
+	got := warningSummaryPart("github_auth", []Check{
+		{
+			ID:            "github_auth",
+			Status:        StatusWarn,
+			RemediationID: RemediationNone,
+			Message:       "GitHub auth env token is invalid: set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it to use `gh auth login`.",
+		},
+	})
+	if got != "set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it" {
+		t.Fatalf("warningSummaryPart() = %q, want %q", got, "set a valid $GITHUB_TOKEN/$GH_TOKEN or unset it")
+	}
+}
+
 func TestCheckGitHubAuth_GitHubOriginWithAuthPasses(t *testing.T) {
 	check := checkGitHubAuthWithDeps(t.TempDir(), githubAuthDeps{
 		originRemoteURL: func(string) (string, error) {


### PR DESCRIPTION
## Summary

This update tightens CI workflow safety and GitHub integration reliability across `hal ci` and related doctor/compound flows.

### What changed
- Hardened GitHub auth selection and API behavior:
  - validate env tokens with GitHub `/rate_limit` before selecting API mode
  - scope `gh auth status` checks to `github.com`
  - introduce shared API request helpers with structured HTTP status errors
  - improve doctor warnings/remediation text for invalid env tokens
- Made push/PR flows directory-aware and safer:
  - add in-directory git/repo resolution (`PushAndCreatePRInDir`, `ResolveGitHubRepositoryInDir`)
  - resolve default PR base branch when unspecified
  - handle paginated PR lookup and ambiguous head/base matching explicitly
  - ensure compound PR step verifies active branch matches pipeline state
- Tightened fix/merge orchestration safeguards:
  - preserve porcelain status columns when parsing changed files
  - defer engine resolution until a failing status actually requires fixing
  - return last successful fix result when status clears before the next attempt
  - normalize merge strategy via shared helper and pass expected head SHA to merge API

## Commit breakdown

- `e112ddc` — **feat(ci): harden GitHub auth and API error handling**
- `8658520` — **feat(ci): make push and PR flows directory-aware**
- `09d07e2` — **fix(ci): tighten fix retries and merge safety guards**

## Testing

- `go test ./cmd ./internal/ci ./internal/doctor ./internal/compound`
