### PR TITLE
feat: recover restart-safe L7 cleanup ownership

### DIFF
--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/coordinator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/coordinator.go
@@ -551,11 +551,11 @@ func (s *Session) quarantineOnDrift(ctx context.Context, primary error) (Metadat
 			s.metadata = failedMetadata(s.identity)
 			return s.metadata, errors.Join(primary, ErrQuarantineFailed)
 		}
-		s.quarantined = true
-		s.metadata = Metadata{Identity: s.identity, Status: StatusQuarantined}
 		if err := s.save(ctx, journalStageQuarantined); err != nil {
 			return s.metadata, errors.Join(primary, ErrCleanupIncomplete)
 		}
+		s.quarantined = true
+		s.metadata = Metadata{Identity: s.identity, Status: StatusQuarantined}
 	}
 	return s.metadata, primary
 }
@@ -573,11 +573,11 @@ func (s *Session) Quarantine(ctx context.Context, identity Identity) error {
 		s.metadata = failedMetadata(s.identity)
 		return ErrQuarantineFailed
 	}
-	s.quarantined = true
-	s.metadata = Metadata{Identity: s.identity, Status: StatusQuarantined}
 	if err := s.save(ctx, journalStageQuarantined); err != nil {
 		return ErrCleanupIncomplete
 	}
+	s.quarantined = true
+	s.metadata = Metadata{Identity: s.identity, Status: StatusQuarantined}
 	return nil
 }
 
@@ -645,20 +645,20 @@ func (s *Session) CleanupAfterVMQuiesced(_ context.Context, identity Identity, b
 			s.metadata = failedMetadata(s.identity)
 			return ErrCleanupIncomplete
 		}
-		s.rulesRemoved = true
 		if err := s.save(ctx, journalStageRulesRemoved); err != nil {
 			return ErrCleanupIncomplete
 		}
+		s.rulesRemoved = true
 	}
 	if !s.tapRemoved && s.tap.name != "" {
 		if err := s.coordinator.options.TAP.Delete(ctx, s.namespace, s.tap, s.tapSpec); err != nil {
 			s.metadata = failedMetadata(s.identity)
 			return ErrCleanupIncomplete
 		}
-		s.tapRemoved = true
 		if err := s.save(ctx, journalStageTAPRemoved); err != nil {
 			return ErrCleanupIncomplete
 		}
+		s.tapRemoved = true
 	}
 	if !s.topologyRemoved {
 		if !interfaceIsNil(s.namespace) {
@@ -673,10 +673,10 @@ func (s *Session) CleanupAfterVMQuiesced(_ context.Context, identity Identity, b
 				return ErrCleanupIncomplete
 			}
 		}
-		s.topologyRemoved = true
 		if err := s.save(ctx, journalStageTopologyRemoved); err != nil {
 			return ErrCleanupIncomplete
 		}
+		s.topologyRemoved = true
 	}
 	if !s.proxyStopped && !interfaceIsNil(s.proxy) {
 		if err := s.coordinator.options.Proxy.Stop(ctx, s.plan, s.proxy); err != nil {
@@ -891,6 +891,11 @@ func validatedProxyEndpoint(endpoint string) (netip.Addr, uint16, netip.Addr, er
 func topologyMetadataMatches(metadata linuxtopology.Metadata, identity linuxtopology.Identity) bool {
 	return metadata.Identity == identity && metadata.Status == linuxtopology.StatusPrepared &&
 		metadata.StructuralInspected && metadata.MappingReachable
+}
+
+func recoveryTopologyMetadataMatches(metadata linuxtopology.Metadata, identity linuxtopology.Identity) bool {
+	return metadata.Identity == identity && metadata.Status == linuxtopology.StatusRecoveryOnly &&
+		!metadata.StructuralInspected && !metadata.MappingReachable
 }
 
 func inspectedRuleDigest(metadata networkenforcement.RuleLifecycleMetadata, expected networkenforcement.EnforcementCorrelation) (string, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/lifecycle_safety_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/lifecycle_safety_test.go
@@ -528,6 +528,7 @@ type retryNamespaceRecovery struct{ topology *retryNamespaceTopology }
 
 func (r *retryNamespaceRecovery) Recover(_ context.Context, identity Identity) (TopologyLifecycle, TopologySession, error) {
 	r.topology.session.identity = topologyIdentity(identity)
+	r.topology.session.recoveryOnly = true
 	return r.topology, r.topology.session, nil
 }
 
@@ -585,12 +586,16 @@ func (t *typedNilNamespaceTopology) Stop(context.Context, linuxtopology.Identity
 }
 
 type typedNilBorrowSession struct {
-	sequence *callSequence
-	identity linuxtopology.Identity
-	losses   chan linuxtopology.Loss
+	sequence     *callSequence
+	identity     linuxtopology.Identity
+	losses       chan linuxtopology.Loss
+	recoveryOnly bool
 }
 
 func (s *typedNilBorrowSession) Metadata() linuxtopology.Metadata {
+	if s.recoveryOnly {
+		return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusRecoveryOnly}
+	}
 	return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusPrepared, StructuralInspected: true, MappingReachable: true}
 }
 func (s *typedNilBorrowSession) Losses() <-chan linuxtopology.Loss { return s.losses }
@@ -623,9 +628,10 @@ func (r *typedNilRecoveryResult) Recover(_ context.Context, identity Identity) (
 		lifecycle = value
 	}
 	var session TopologySession = &typedNilBorrowSession{
-		sequence: r.sequence,
-		identity: topologyIdentity(identity),
-		losses:   make(chan linuxtopology.Loss, 1),
+		sequence:     r.sequence,
+		identity:     topologyIdentity(identity),
+		losses:       make(chan linuxtopology.Loss, 1),
+		recoveryOnly: true,
 	}
 	if r.sessionNil {
 		var value *typedNilBorrowSession

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler.go
@@ -84,7 +84,7 @@ func (r *Reconciler) Recover(ctx context.Context, identity Identity) (*Session, 
 		return session, nil
 	}
 	lifecycle, topology, err := r.options.Recovery.Recover(ctx, identity)
-	if err != nil || interfaceIsNil(lifecycle) || interfaceIsNil(topology) || !topologyMetadataMatches(topology.Metadata(), topologyIdentity(identity)) {
+	if err != nil || interfaceIsNil(lifecycle) || interfaceIsNil(topology) || !recoveryTopologyMetadataMatches(topology.Metadata(), topologyIdentity(identity)) {
 		return coordinator.releaseRecoveryJournal(session, ErrStaleTopologyUnverified)
 	}
 	coordinator.options.Topology = lifecycle

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement/linuxrules"
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement/linuxtopology"
 )
 
 func TestFirecrackerHostTopologyReconcilerQuarantinesBeforeVMStopHandoff(t *testing.T) {
@@ -29,8 +32,10 @@ func TestFirecrackerHostTopologyReconcilerQuarantinesBeforeVMStopHandoff(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if session.Metadata().Status != StatusQuarantined || session.Metadata().Status == StatusActive {
-		t.Fatalf("recovered metadata = %#v", session.Metadata())
+	metadata := session.Metadata()
+	if metadata.Status != StatusQuarantined || metadata.Status == StatusActive || metadata.StructuralInspected ||
+		metadata.TAPInspected || metadata.RulesInspected || metadata.RawPacketIsolationVerified || metadata.RuleDigest != "" {
+		t.Fatalf("recovered metadata = %#v, want quarantine without active/inspection proof", metadata)
 	}
 	if got, want := sequence.snapshot(), []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow", "rules_quarantine", "journal_save_quarantined"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("recovery sequence = %#v, want %#v", got, want)
@@ -104,6 +109,49 @@ func TestFirecrackerHostTopologyReconcilerRejectsPreparedProofAsRecoveryAuthorit
 type preparedRecoveryTopology struct {
 	sequence  *callSequence
 	lifecycle *fakeTopology
+}
+
+func TestFirecrackerHostTopologyPrepareRejectsCleanupOnlyRecoveryMetadata(t *testing.T) {
+	sequence := &callSequence{}
+	options := validCoordinatorOptions(sequence)
+	options.Topology = &cleanupOnlyStartTopology{sequence: sequence}
+	coordinator := mustCoordinator(t, options)
+	if session, err := coordinator.Prepare(context.Background(), PrepareRequest{Identity: testIdentity(), Plan: testPlan()}); session != nil || !errors.Is(err, ErrProofMismatch) {
+		t.Fatalf("Prepare(cleanup-only topology) = %T, %v", session, err)
+	}
+	if contains(sequence.snapshot(), "tap_create") || contains(sequence.snapshot(), "rules_apply_inspect") {
+		t.Fatalf("cleanup-only metadata reached proof-producing steps: %#v", sequence.snapshot())
+	}
+}
+
+type cleanupOnlyStartTopology struct{ sequence *callSequence }
+
+func (t *cleanupOnlyStartTopology) Start(_ context.Context, request linuxtopology.StartRequest) (TopologySession, error) {
+	t.sequence.add("topology_start")
+	return &cleanupOnlyTopologySession{sequence: t.sequence, identity: request.Identity}, nil
+}
+
+func (t *cleanupOnlyStartTopology) Stop(context.Context, linuxtopology.Identity) (linuxtopology.Metadata, error) {
+	t.sequence.add("topology_stop")
+	return linuxtopology.Metadata{Status: linuxtopology.StatusStopped}, nil
+}
+
+type cleanupOnlyTopologySession struct {
+	sequence *callSequence
+	identity linuxtopology.Identity
+}
+
+func (s *cleanupOnlyTopologySession) Metadata() linuxtopology.Metadata {
+	return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusRecoveryOnly}
+}
+func (*cleanupOnlyTopologySession) Losses() <-chan linuxtopology.Loss {
+	losses := make(chan linuxtopology.Loss)
+	close(losses)
+	return losses
+}
+func (s *cleanupOnlyTopologySession) BorrowNamespace() (NamespaceLease, error) {
+	s.sequence.add("topology_borrow")
+	return &fakeNamespaceLease{rules: linuxrules.NewNamespaceHandle(10, 11)}, nil
 }
 
 func (r *preparedRecoveryTopology) Recover(_ context.Context, identity Identity) (TopologyLifecycle, TopologySession, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler_test.go
@@ -172,6 +172,7 @@ func (r *fakeRecoveryTopology) Recover(_ context.Context, identity Identity) (To
 		return nil, nil, r.err
 	}
 	r.lifecycle.session.identity = topologyIdentity(identity)
+	r.lifecycle.session.recoveryOnly = true
 	return r.lifecycle, r.lifecycle.session, nil
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/reconciler_test.go
@@ -77,6 +77,41 @@ func TestFirecrackerHostTopologyReconcilerFailsClosedWithoutExactRecoveryProof(t
 	}
 }
 
+func TestFirecrackerHostTopologyReconcilerRejectsPreparedProofAsRecoveryAuthority(t *testing.T) {
+	sequence := &callSequence{}
+	identity := testIdentity()
+	spec := staticTAPSpec(identity, netip.MustParseAddr("192.0.2.2"), 43123)
+	record := journalRecord{identity: identity, stage: journalStageInspected, tapName: spec.name,
+		tapFingerprint: spec.fingerprint(), tapIfIndex: 41, proxyAddress: spec.proxyAddress.String(), proxyPort: spec.proxyPort}
+	topology := newFakeTopology(sequence)
+	reconciler, err := NewReconciler(ReconcilerOptions{
+		Recovery: &preparedRecoveryTopology{sequence: sequence, lifecycle: topology},
+		TAP:      &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+		VMTermination: &fakeVMTerminationVerifier{stopped: true, reaped: true},
+		Journal:       &loadedJournalStore{sequence: sequence, record: record},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session, recoverErr := reconciler.Recover(context.Background(), identity); session != nil || !errors.Is(recoverErr, ErrStaleTopologyUnverified) {
+		t.Fatalf("Recover(prepared proof) = %T, %v; want cleanup-only rejection", session, recoverErr)
+	}
+	if contains(sequence.snapshot(), "rules_quarantine") {
+		t.Fatalf("prepared proof authorized recovery mutation: %#v", sequence.snapshot())
+	}
+}
+
+type preparedRecoveryTopology struct {
+	sequence  *callSequence
+	lifecycle *fakeTopology
+}
+
+func (r *preparedRecoveryTopology) Recover(_ context.Context, identity Identity) (TopologyLifecycle, TopologySession, error) {
+	r.sequence.add("recovery_open")
+	r.lifecycle.session.identity = topologyIdentity(identity)
+	return r.lifecycle, r.lifecycle.session, nil
+}
+
 type fakeRecoveryTopology struct {
 	sequence  *callSequence
 	lifecycle *fakeTopology

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_adapter_linux_red_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_adapter_linux_red_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"syscall"
 	"testing"
 
 	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement/linuxtopology"
@@ -15,6 +16,14 @@ type adapterRecoveryProvider struct {
 	namespace *linuxtopology.NamespaceHandle
 	err       error
 	returned  *linuxtopology.NamespaceHandle
+}
+
+type adversarialRecoveryProvider struct {
+	acquire func(context.Context, Identity) (*linuxtopology.NamespaceHandle, error)
+}
+
+func (p *adversarialRecoveryProvider) AcquireLinuxRecoveryNamespace(ctx context.Context, identity Identity) (*linuxtopology.NamespaceHandle, error) {
+	return p.acquire(ctx, identity)
 }
 
 func (p *adapterRecoveryProvider) AcquireLinuxRecoveryNamespace(context.Context, Identity) (*linuxtopology.NamespaceHandle, error) {
@@ -143,6 +152,97 @@ func TestLinuxRecoveryTopologyRejectsTypedNilProvider(t *testing.T) {
 	}
 	if recovery, err := NewLinuxRecoveryTopology(lifecycle, provider); recovery != nil || !errors.Is(err, ErrInvalidConfiguration) {
 		t.Fatalf("NewLinuxRecoveryTopology(typed nil) = %T, %v", recovery, err)
+	}
+}
+
+func TestLinuxRecoveryTopologyProviderAdversarialMatrix(t *testing.T) {
+	privateErr := errors.New("private provider detail")
+	for _, test := range []struct {
+		name    string
+		acquire func(*testing.T) (*linuxtopology.NamespaceHandle, error)
+	}{
+		{name: "panic", acquire: func(*testing.T) (*linuxtopology.NamespaceHandle, error) { panic("private provider panic") }},
+		{name: "nil", acquire: func(*testing.T) (*linuxtopology.NamespaceHandle, error) { return nil, nil }},
+		{name: "nil plus error", acquire: func(*testing.T) (*linuxtopology.NamespaceHandle, error) { return nil, privateErr }},
+		{name: "closed", acquire: func(t *testing.T) (*linuxtopology.NamespaceHandle, error) {
+			namespace := newAdapterRecoveryNamespace(t)
+			if err := namespace.Close(); err != nil {
+				t.Fatal(err)
+			}
+			return namespace, nil
+		}},
+		{name: "value plus error", acquire: func(t *testing.T) (*linuxtopology.NamespaceHandle, error) {
+			return newAdapterRecoveryNamespace(t), privateErr
+		}},
+		{name: "close failure", acquire: func(t *testing.T) (*linuxtopology.NamespaceHandle, error) {
+			user, err := os.CreateTemp(t.TempDir(), "provider-user-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			network, err := os.CreateTemp(t.TempDir(), "provider-net-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			namespace, err := linuxtopology.NewNamespaceHandle(user, network)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = syscall.Close(int(user.Fd()))
+			_ = syscall.Close(int(network.Fd()))
+			return namespace, privateErr
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			provider := &adversarialRecoveryProvider{acquire: func(context.Context, Identity) (*linuxtopology.NamespaceHandle, error) {
+				return test.acquire(t)
+			}}
+			lifecycle, err := linuxtopology.New(linuxtopology.Config{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			recovery, err := NewLinuxRecoveryTopology(lifecycle, provider)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var topology TopologyLifecycle
+			var session TopologySession
+			var recoverErr error
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						t.Fatalf("LinuxRecoveryTopology.Recover panicked: %v", recovered)
+					}
+				}()
+				topology, session, recoverErr = recovery.Recover(context.Background(), testIdentity())
+			}()
+			if topology != nil || session != nil || !errors.Is(recoverErr, ErrStaleTopologyUnverified) || recoverErr.Error() != ErrStaleTopologyUnverified.Error() {
+				t.Fatalf("Recover(%s) = %T, %T, %v", test.name, topology, session, recoverErr)
+			}
+		})
+	}
+}
+
+func TestLinuxRecoveryTopologyRejectsReusedProviderHandle(t *testing.T) {
+	namespace := newAdapterRecoveryNamespace(t)
+	provider := &adversarialRecoveryProvider{acquire: func(context.Context, Identity) (*linuxtopology.NamespaceHandle, error) {
+		return namespace, nil
+	}}
+	lifecycle, err := linuxtopology.New(linuxtopology.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovery, err := NewLinuxRecoveryTopology(lifecycle, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for attempt := 0; attempt < 2; attempt++ {
+		if topology, session, err := recovery.Recover(context.Background(), testIdentity()); topology != nil || session != nil ||
+			!errors.Is(err, ErrStaleTopologyUnverified) {
+			t.Fatalf("Recover(reused handle %d) = %T, %T, %v", attempt, topology, session, err)
+		}
+	}
+	if !namespace.Closed() {
+		t.Fatal("adapter did not consume first provider transfer")
 	}
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_adapter_linux_red_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_adapter_linux_red_test.go
@@ -135,6 +135,17 @@ func TestLinuxRecoveryTopologyClosesNamespaceReturnedWithError(t *testing.T) {
 	}
 }
 
+func TestLinuxRecoveryTopologyRejectsTypedNilProvider(t *testing.T) {
+	var provider *adapterRecoveryProvider
+	lifecycle, err := linuxtopology.New(linuxtopology.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovery, err := NewLinuxRecoveryTopology(lifecycle, provider); recovery != nil || !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("NewLinuxRecoveryTopology(typed nil) = %T, %v", recovery, err)
+	}
+}
+
 func newAdapterRecoveryNamespace(t *testing.T) *linuxtopology.NamespaceHandle {
 	t.Helper()
 	user, err := os.CreateTemp(t.TempDir(), "user-ns-")

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_adapter_linux_red_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_adapter_linux_red_test.go
@@ -1,0 +1,157 @@
+//go:build linux
+
+package l7network
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement/linuxtopology"
+)
+
+type adapterRecoveryProvider struct {
+	namespace *linuxtopology.NamespaceHandle
+	err       error
+	returned  *linuxtopology.NamespaceHandle
+}
+
+func (p *adapterRecoveryProvider) AcquireLinuxRecoveryNamespace(context.Context, Identity) (*linuxtopology.NamespaceHandle, error) {
+	if p.namespace == nil {
+		return nil, p.err
+	}
+	duplicate, err := p.namespace.Duplicate()
+	if err != nil {
+		return nil, err
+	}
+	p.returned = duplicate
+	return duplicate, p.err
+}
+
+type adapterRecoveryOwnershipStore struct{}
+
+func (*adapterRecoveryOwnershipStore) Acquire(context.Context, linuxtopology.Identity) (linuxtopology.OwnershipLease, error) {
+	return &adapterRecoveryOwnershipLease{}, nil
+}
+
+func (*adapterRecoveryOwnershipStore) AcquireRecovery(_ context.Context, request linuxtopology.RecoveryRequest) (linuxtopology.RecoveredOwnership, error) {
+	namespace, err := request.Namespace.Duplicate()
+	if err != nil {
+		return linuxtopology.RecoveredOwnership{}, err
+	}
+	return linuxtopology.RecoveredOwnership{Lease: &adapterRecoveryOwnershipLease{}, Namespace: namespace}, nil
+}
+
+type adapterRecoveryOwnershipLease struct{}
+
+func (*adapterRecoveryOwnershipLease) Reconcile(context.Context) error { return nil }
+func (*adapterRecoveryOwnershipLease) Record(context.Context, linuxtopology.ProcessHandle, linuxtopology.ProcessHandle, *linuxtopology.NamespaceHandle) error {
+	return nil
+}
+func (*adapterRecoveryOwnershipLease) ArmMapping(context.Context, linuxtopology.ProcessHandle, *linuxtopology.NamespaceHandle) error {
+	return nil
+}
+func (*adapterRecoveryOwnershipLease) Retire(linuxtopology.Identity) error { return nil }
+func (*adapterRecoveryOwnershipLease) Release() error                      { return nil }
+
+type adapterUnusedStarter struct{}
+
+func (adapterUnusedStarter) Start(context.Context, linuxtopology.ProcessSpec) (linuxtopology.ProcessHandle, error) {
+	return nil, errors.New("unused")
+}
+
+type adapterUnusedRunner struct{}
+
+func (adapterUnusedRunner) Run(context.Context, linuxtopology.ProcessSpec) ([]byte, error) {
+	return nil, errors.New("unused")
+}
+
+type adapterUnusedProber struct{}
+
+func (adapterUnusedProber) Probe(context.Context, *linuxtopology.NamespaceHandle, linuxtopology.Identity, linuxtopology.Mapping) error {
+	return errors.New("unused")
+}
+
+func TestLinuxRecoveryTopologyAdaptsSupervisorNamespaceForCleanupOnly(t *testing.T) {
+	namespace := newAdapterRecoveryNamespace(t)
+	provider := &adapterRecoveryProvider{namespace: namespace}
+	lifecycle, err := linuxtopology.New(linuxtopology.Config{
+		Enabled: true,
+		Tools:   linuxtopology.ToolPaths{Unshare: "/bin/unused", Pasta: "/bin/unused", Nsenter: "/bin/unused", IP: "/bin/unused", NC: "/bin/unused", Keeper: "/bin/unused"},
+		Starter: adapterUnusedStarter{}, Runner: adapterUnusedRunner{},
+		OpenNamespaces: func(int) (*linuxtopology.NamespaceHandle, error) { return nil, errors.New("unused") },
+		Reachability:   adapterUnusedProber{}, Ownership: &adapterRecoveryOwnershipStore{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovery, err := NewLinuxRecoveryTopology(lifecycle, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := testIdentity()
+	topology, session, err := recovery.Recover(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata := session.Metadata()
+	if metadata.Identity != topologyIdentity(identity) || metadata.Status != linuxtopology.StatusRecoveryOnly || metadata.StructuralInspected || metadata.MappingReachable {
+		t.Fatalf("recovery metadata = %#v, want cleanup-only", metadata)
+	}
+	if provider.returned == nil || !provider.returned.Closed() {
+		t.Fatal("adapter did not close provider-owned transfer after lifecycle duplicated it")
+	}
+	lease, err := session.BorrowNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stopped, err := topology.Stop(context.Background(), topologyIdentity(identity))
+	if err != nil || stopped.Status != linuxtopology.StatusStopped {
+		t.Fatalf("Stop(recovery) = %#v, %v", stopped, err)
+	}
+}
+
+func TestLinuxRecoveryTopologyClosesNamespaceReturnedWithError(t *testing.T) {
+	namespace := newAdapterRecoveryNamespace(t)
+	provider := &adapterRecoveryProvider{namespace: namespace, err: errors.New("private supervisor endpoint")}
+	lifecycle, err := linuxtopology.New(linuxtopology.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovery, err := NewLinuxRecoveryTopology(lifecycle, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if topology, session, recoverErr := recovery.Recover(context.Background(), testIdentity()); topology != nil || session != nil ||
+		!errors.Is(recoverErr, ErrStaleTopologyUnverified) || recoverErr.Error() != ErrStaleTopologyUnverified.Error() {
+		t.Fatalf("Recover(provider error) = %T, %T, %v", topology, session, recoverErr)
+	}
+	if provider.returned == nil || !provider.returned.Closed() {
+		t.Fatal("adapter retained namespace returned with provider error")
+	}
+}
+
+func newAdapterRecoveryNamespace(t *testing.T) *linuxtopology.NamespaceHandle {
+	t.Helper()
+	user, err := os.CreateTemp(t.TempDir(), "user-ns-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	network, err := os.CreateTemp(t.TempDir(), "net-ns-")
+	if err != nil {
+		user.Close()
+		t.Fatal(err)
+	}
+	handle, err := linuxtopology.NewNamespaceHandle(user, network)
+	if err != nil {
+		user.Close()
+		network.Close()
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = handle.Close() })
+	return handle
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_metadata_red_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_metadata_red_test.go
@@ -1,0 +1,88 @@
+package l7network
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement/linuxrules"
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement/linuxtopology"
+)
+
+type fixedMetadataRecoveryTopology struct {
+	sequence  *callSequence
+	lifecycle *fakeTopology
+	metadata  linuxtopology.Metadata
+}
+
+func (r *fixedMetadataRecoveryTopology) Recover(context.Context, Identity) (TopologyLifecycle, TopologySession, error) {
+	r.sequence.add("recovery_open")
+	return r.lifecycle, &fixedMetadataRecoverySession{sequence: r.sequence, metadata: r.metadata}, nil
+}
+
+type fixedMetadataRecoverySession struct {
+	sequence *callSequence
+	metadata linuxtopology.Metadata
+}
+
+func (s *fixedMetadataRecoverySession) Metadata() linuxtopology.Metadata { return s.metadata }
+func (*fixedMetadataRecoverySession) Losses() <-chan linuxtopology.Loss {
+	losses := make(chan linuxtopology.Loss)
+	close(losses)
+	return losses
+}
+func (s *fixedMetadataRecoverySession) BorrowNamespace() (NamespaceLease, error) {
+	s.sequence.add("topology_borrow")
+	return &fakeNamespaceLease{rules: linuxrules.NewNamespaceHandle(10, 11)}, nil
+}
+
+func TestRecoveryTopologyMetadataMatchesMatrix(t *testing.T) {
+	identity := testIdentity()
+	exact := topologyIdentity(identity)
+	wrong := exact
+	wrong.ExecutionID = "execution-replaced"
+	for _, test := range []struct {
+		name     string
+		metadata linuxtopology.Metadata
+		accept   bool
+	}{
+		{name: "exact cleanup only", metadata: linuxtopology.Metadata{Identity: exact, Status: linuxtopology.StatusRecoveryOnly}, accept: true},
+		{name: "prepared proof", metadata: linuxtopology.Metadata{Identity: exact, Status: linuxtopology.StatusPrepared, StructuralInspected: true, MappingReachable: true}},
+		{name: "recovery structural proof", metadata: linuxtopology.Metadata{Identity: exact, Status: linuxtopology.StatusRecoveryOnly, StructuralInspected: true}},
+		{name: "recovery reachability proof", metadata: linuxtopology.Metadata{Identity: exact, Status: linuxtopology.StatusRecoveryOnly, MappingReachable: true}},
+		{name: "wrong status", metadata: linuxtopology.Metadata{Identity: exact, Status: linuxtopology.StatusCleanupIncomplete}},
+		{name: "wrong identity", metadata: linuxtopology.Metadata{Identity: wrong, Status: linuxtopology.StatusRecoveryOnly}},
+		{name: "zero identity", metadata: linuxtopology.Metadata{Status: linuxtopology.StatusRecoveryOnly}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sequence := &callSequence{}
+			spec := staticTAPSpec(identity, netip.MustParseAddr("192.0.2.2"), 43123)
+			record := journalRecord{identity: identity, stage: journalStageInspected, tapName: spec.name,
+				tapFingerprint: spec.fingerprint(), tapIfIndex: 41, proxyAddress: spec.proxyAddress.String(), proxyPort: spec.proxyPort}
+			lifecycle := newFakeTopology(sequence)
+			reconciler, err := NewReconciler(ReconcilerOptions{
+				Recovery: &fixedMetadataRecoveryTopology{sequence: sequence, lifecycle: lifecycle, metadata: test.metadata},
+				TAP:      &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+				VMTermination: &fakeVMTerminationVerifier{stopped: true, reaped: true},
+				Journal:       &loadedJournalStore{sequence: sequence, record: record},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, recoverErr := reconciler.Recover(context.Background(), identity)
+			if test.accept {
+				if recoverErr != nil || session == nil || session.Metadata().Status != StatusQuarantined {
+					t.Fatalf("Recover(exact cleanup metadata) = %T, %v", session, recoverErr)
+				}
+				return
+			}
+			if session != nil || !errors.Is(recoverErr, ErrStaleTopologyUnverified) {
+				t.Fatalf("Recover(invalid recovery metadata) = %T, %v", session, recoverErr)
+			}
+			if contains(sequence.snapshot(), "topology_borrow") || contains(sequence.snapshot(), "rules_quarantine") {
+				t.Fatalf("invalid recovery metadata authorized mutation: %#v", sequence.snapshot())
+			}
+		})
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_stage_red_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovery_stage_red_test.go
@@ -1,0 +1,199 @@
+package l7network
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"reflect"
+	"testing"
+)
+
+func recoveryStageRecord(identity Identity, stage journalStage) journalRecord {
+	spec := staticTAPSpec(identity, netip.MustParseAddr("192.0.2.2"), 43123)
+	return journalRecord{identity: identity, stage: stage, tapName: spec.name,
+		tapFingerprint: spec.fingerprint(), tapIfIndex: 41, proxyAddress: spec.proxyAddress.String(), proxyPort: spec.proxyPort}
+}
+
+func TestFirecrackerHostTopologyRecoveryJournalStageExactOrderMatrix(t *testing.T) {
+	identity := testIdentity()
+	for _, test := range []struct {
+		stage       journalStage
+		recoverWant []string
+		cleanupWant []string
+	}{
+		{stage: journalStageTAPCreated,
+			recoverWant: []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow", "rules_quarantine", "journal_save_quarantined"},
+			cleanupWant: []string{"rules_cleanup", "journal_save_rules_removed", "tap_delete", "journal_save_tap_removed", "topology_stop", "journal_save_topology_removed", "journal_remove", "journal_release"}},
+		{stage: journalStageRulesInspected,
+			recoverWant: []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow", "rules_quarantine", "journal_save_quarantined"},
+			cleanupWant: []string{"rules_cleanup", "journal_save_rules_removed", "tap_delete", "journal_save_tap_removed", "topology_stop", "journal_save_topology_removed", "journal_remove", "journal_release"}},
+		{stage: journalStageInspected,
+			recoverWant: []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow", "rules_quarantine", "journal_save_quarantined"},
+			cleanupWant: []string{"rules_cleanup", "journal_save_rules_removed", "tap_delete", "journal_save_tap_removed", "topology_stop", "journal_save_topology_removed", "journal_remove", "journal_release"}},
+		{stage: journalStageQuarantined,
+			recoverWant: []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow"},
+			cleanupWant: []string{"rules_cleanup", "journal_save_rules_removed", "tap_delete", "journal_save_tap_removed", "topology_stop", "journal_save_topology_removed", "journal_remove", "journal_release"}},
+		{stage: journalStageRulesRemoved,
+			recoverWant: []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow"},
+			cleanupWant: []string{"tap_delete", "journal_save_tap_removed", "topology_stop", "journal_save_topology_removed", "journal_remove", "journal_release"}},
+		{stage: journalStageTAPRemoved,
+			recoverWant: []string{"journal_acquire", "journal_load", "recovery_open", "topology_borrow"},
+			cleanupWant: []string{"topology_stop", "journal_save_topology_removed", "journal_remove", "journal_release"}},
+		{stage: journalStageTopologyRemoved,
+			recoverWant: []string{"journal_acquire", "journal_load"},
+			cleanupWant: []string{"journal_remove", "journal_release"}},
+	} {
+		t.Run(string(test.stage), func(t *testing.T) {
+			sequence := &callSequence{}
+			topology := newFakeTopology(sequence)
+			reconciler, err := NewReconciler(ReconcilerOptions{
+				Recovery: &fakeRecoveryTopology{sequence: sequence, lifecycle: topology},
+				TAP:      &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+				VMTermination: &fakeVMTerminationVerifier{stopped: true, reaped: true},
+				Journal:       &loadedJournalStore{sequence: sequence, record: recoveryStageRecord(identity, test.stage)},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := reconciler.Recover(context.Background(), identity)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := sequence.snapshot(); !reflect.DeepEqual(got, test.recoverWant) {
+				t.Fatalf("Recover sequence = %#v, want %#v", got, test.recoverWant)
+			}
+			sequence.reset()
+			if err := session.CleanupAfterVMQuiesced(context.Background(), identity, testTerminatedVMBinding()); err != nil {
+				t.Fatal(err)
+			}
+			if got := sequence.snapshot(); !reflect.DeepEqual(got, test.cleanupWant) {
+				t.Fatalf("Cleanup sequence = %#v, want %#v", got, test.cleanupWant)
+			}
+		})
+	}
+}
+
+type recoveryRetryJournalStore struct {
+	sequence    *callSequence
+	record      journalRecord
+	failStage   journalStage
+	failRemove  bool
+	failRelease bool
+	lease       *recoveryRetryJournalLease
+}
+
+func (s *recoveryRetryJournalStore) Acquire(context.Context, Identity) (JournalLease, error) {
+	s.sequence.add("journal_acquire")
+	s.lease = &recoveryRetryJournalLease{sequence: s.sequence, record: s.record, failStage: s.failStage,
+		failRemove: s.failRemove, failRelease: s.failRelease}
+	return s.lease, nil
+}
+
+type recoveryRetryJournalLease struct {
+	sequence      *callSequence
+	record        journalRecord
+	failStage     journalStage
+	failRemove    bool
+	failRelease   bool
+	failedStage   bool
+	failedRemove  bool
+	failedRelease bool
+}
+
+func (l *recoveryRetryJournalLease) Load() (journalRecord, error) {
+	l.sequence.add("journal_load")
+	return l.record, nil
+}
+func (l *recoveryRetryJournalLease) Save(_ context.Context, record journalRecord) error {
+	l.sequence.add("journal_save_" + string(record.stage))
+	if record.stage == l.failStage && !l.failedStage {
+		l.failedStage = true
+		return errors.New("private journal save failure")
+	}
+	l.record = record
+	return nil
+}
+func (l *recoveryRetryJournalLease) Remove() error {
+	l.sequence.add("journal_remove")
+	if l.failRemove && !l.failedRemove {
+		l.failedRemove = true
+		return errors.New("private journal remove failure")
+	}
+	return nil
+}
+func (l *recoveryRetryJournalLease) Release() error {
+	l.sequence.add("journal_release")
+	if l.failRelease && !l.failedRelease {
+		l.failedRelease = true
+		return errors.New("private journal release failure")
+	}
+	return nil
+}
+
+func TestFirecrackerHostTopologyRecoveryJournalRetryOrderMatrix(t *testing.T) {
+	identity := testIdentity()
+	for _, test := range []struct {
+		name        string
+		failStage   journalStage
+		failRemove  bool
+		failRelease bool
+		mustRepeat  string
+	}{
+		{name: "quarantine save", failStage: journalStageQuarantined, mustRepeat: "journal_save_quarantined"},
+		{name: "rules removed save", failStage: journalStageRulesRemoved, mustRepeat: "journal_save_rules_removed"},
+		{name: "tap removed save", failStage: journalStageTAPRemoved, mustRepeat: "journal_save_tap_removed"},
+		{name: "topology removed save", failStage: journalStageTopologyRemoved, mustRepeat: "journal_save_topology_removed"},
+		{name: "journal remove", failRemove: true, mustRepeat: "journal_remove"},
+		{name: "journal release", failRelease: true, mustRepeat: "journal_release"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sequence := &callSequence{}
+			store := &recoveryRetryJournalStore{sequence: sequence, record: recoveryStageRecord(identity, journalStageInspected),
+				failStage: test.failStage, failRemove: test.failRemove, failRelease: test.failRelease}
+			topology := newFakeTopology(sequence)
+			reconciler, err := NewReconciler(ReconcilerOptions{
+				Recovery: &fakeRecoveryTopology{sequence: sequence, lifecycle: topology},
+				TAP:      &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+				VMTermination: &fakeVMTerminationVerifier{stopped: true, reaped: true}, Journal: store,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, recoverErr := reconciler.Recover(context.Background(), identity)
+			if test.failStage == journalStageQuarantined {
+				if session == nil || !errors.Is(recoverErr, ErrCleanupIncomplete) {
+					t.Fatalf("Recover(quarantine save failure) = %T, %v", session, recoverErr)
+				}
+				sequence.reset()
+				if err := session.Quarantine(context.Background(), identity); err != nil {
+					t.Fatalf("retry Quarantine() = %v", err)
+				}
+			} else {
+				if recoverErr != nil {
+					t.Fatal(recoverErr)
+				}
+				sequence.reset()
+				if err := session.CleanupAfterVMQuiesced(context.Background(), identity, testTerminatedVMBinding()); !errors.Is(err, ErrCleanupIncomplete) {
+					t.Fatalf("first Cleanup() = %v, want retained journal failure", err)
+				}
+				sequence.reset()
+				if err := session.CleanupAfterVMQuiesced(context.Background(), identity, testTerminatedVMBinding()); err != nil {
+					t.Fatalf("retry Cleanup() = %v", err)
+				}
+			}
+			if countSequence(sequence.snapshot(), test.mustRepeat) != 1 {
+				t.Fatalf("retry sequence = %#v, want exact retry of %q", sequence.snapshot(), test.mustRepeat)
+			}
+		})
+	}
+}
+
+func countSequence(sequence []string, value string) int {
+	count := 0
+	for _, item := range sequence {
+		if item == value {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/topology_adapter.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/topology_adapter.go
@@ -11,6 +11,19 @@ import (
 
 type LinuxTopology struct{ lifecycle *linuxtopology.Lifecycle }
 
+// LinuxRecoveryNamespaceProvider returns a fresh caller-owned duplicate of the
+// exact supervisor-retained user/network namespace authority for one recovery.
+type LinuxRecoveryNamespaceProvider interface {
+	AcquireLinuxRecoveryNamespace(context.Context, Identity) (*linuxtopology.NamespaceHandle, error)
+}
+
+// LinuxRecoveryTopology adapts cleanup-only linuxtopology recovery to the
+// Reconciler's exact-ownership boundary.
+type LinuxRecoveryTopology struct {
+	lifecycle *linuxtopology.Lifecycle
+	provider  LinuxRecoveryNamespaceProvider
+}
+
 type linuxTopologySession struct{ session *linuxtopology.Session }
 
 type linuxNamespaceLease struct {
@@ -23,6 +36,17 @@ func NewLinuxTopology(lifecycle *linuxtopology.Lifecycle) (*LinuxTopology, error
 		return nil, ErrInvalidConfiguration
 	}
 	return &LinuxTopology{lifecycle: lifecycle}, nil
+}
+
+func NewLinuxRecoveryTopology(lifecycle *linuxtopology.Lifecycle, provider LinuxRecoveryNamespaceProvider) (*LinuxRecoveryTopology, error) {
+	if lifecycle == nil || interfaceIsNil(provider) {
+		return nil, ErrInvalidConfiguration
+	}
+	return &LinuxRecoveryTopology{lifecycle: lifecycle, provider: provider}, nil
+}
+
+func (t *LinuxRecoveryTopology) Recover(context.Context, Identity) (TopologyLifecycle, TopologySession, error) {
+	return nil, nil, ErrStaleTopologyUnverified
 }
 
 func (t *LinuxTopology) Start(ctx context.Context, request linuxtopology.StartRequest) (TopologySession, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/topology_adapter.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/topology_adapter.go
@@ -45,8 +45,29 @@ func NewLinuxRecoveryTopology(lifecycle *linuxtopology.Lifecycle, provider Linux
 	return &LinuxRecoveryTopology{lifecycle: lifecycle, provider: provider}, nil
 }
 
-func (t *LinuxRecoveryTopology) Recover(context.Context, Identity) (TopologyLifecycle, TopologySession, error) {
-	return nil, nil, ErrStaleTopologyUnverified
+func (t *LinuxRecoveryTopology) Recover(ctx context.Context, identity Identity) (topology TopologyLifecycle, session TopologySession, err error) {
+	defer func() {
+		if panicked := recover(); panicked != nil {
+			topology, session, err = nil, nil, ErrStaleTopologyUnverified
+		}
+	}()
+	if t == nil || t.lifecycle == nil || interfaceIsNil(t.provider) || !validIdentity(identity) {
+		return nil, nil, ErrStaleTopologyUnverified
+	}
+	namespace, acquireErr := t.provider.AcquireLinuxRecoveryNamespace(ctx, identity)
+	if namespace != nil {
+		defer func() { _ = namespace.Close() }()
+	}
+	if acquireErr != nil || namespace == nil || namespace.Closed() {
+		return nil, nil, ErrStaleTopologyUnverified
+	}
+	recovered, recoverErr := t.lifecycle.Recover(ctx, linuxtopology.RecoveryRequest{
+		Identity: topologyIdentity(identity), Namespace: namespace,
+	})
+	if recoverErr != nil || recovered == nil {
+		return nil, nil, ErrStaleTopologyUnverified
+	}
+	return &LinuxTopology{lifecycle: t.lifecycle}, &linuxTopologySession{session: recovered}, nil
 }
 
 func (t *LinuxTopology) Start(ctx context.Context, request linuxtopology.StartRequest) (TopologySession, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/topology_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/topology_test.go
@@ -619,13 +619,17 @@ func (t *fakeTopology) Stop(context.Context, linuxtopology.Identity) (linuxtopol
 }
 
 type fakeTopologySession struct {
-	sequence  *callSequence
-	identity  linuxtopology.Identity
-	borrowErr error
-	losses    chan linuxtopology.Loss
+	sequence     *callSequence
+	identity     linuxtopology.Identity
+	borrowErr    error
+	losses       chan linuxtopology.Loss
+	recoveryOnly bool
 }
 
 func (s *fakeTopologySession) Metadata() linuxtopology.Metadata {
+	if s.recoveryOnly {
+		return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusRecoveryOnly}
+	}
 	return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusPrepared, StructuralInspected: true, MappingReachable: true}
 }
 func (s *fakeTopologySession) BorrowNamespace() (NamespaceLease, error) {
@@ -674,14 +678,18 @@ func (t *retryNamespaceTopology) Stop(context.Context, linuxtopology.Identity) (
 }
 
 type retryNamespaceSession struct {
-	sequence  *callSequence
-	identity  linuxtopology.Identity
-	lease     *retryNamespaceLease
-	borrowErr error
-	losses    chan linuxtopology.Loss
+	sequence     *callSequence
+	identity     linuxtopology.Identity
+	lease        *retryNamespaceLease
+	borrowErr    error
+	losses       chan linuxtopology.Loss
+	recoveryOnly bool
 }
 
 func (s *retryNamespaceSession) Metadata() linuxtopology.Metadata {
+	if s.recoveryOnly {
+		return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusRecoveryOnly}
+	}
 	return linuxtopology.Metadata{Identity: s.identity, Status: linuxtopology.StatusPrepared, StructuralInspected: true, MappingReachable: true}
 }
 

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/contracts.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/contracts.go
@@ -48,6 +48,7 @@ type Status string
 
 const (
 	StatusPrepared          Status = "prepared"
+	StatusRecoveryOnly      Status = "recovery_only"
 	StatusLost              Status = "lost"
 	StatusStopping          Status = "stopping"
 	StatusStopped           Status = "stopped"
@@ -94,6 +95,14 @@ type StartRequest struct {
 	Mapping  Mapping  `json:"-"`
 }
 
+// RecoveryRequest carries the exact externally retained namespace authority
+// required to reopen one topology for cleanup after daemon restart. Namespace
+// remains caller-owned; Recover duplicates it before retaining any authority.
+type RecoveryRequest struct {
+	Identity  Identity         `json:"identity"`
+	Namespace *NamespaceHandle `json:"-"`
+}
+
 // ToolPaths are live-only absolute executable paths.
 type ToolPaths struct {
 	Unshare string `json:"-"`
@@ -137,6 +146,22 @@ type ReachabilityProber interface {
 
 type OwnershipStore interface {
 	Acquire(context.Context, Identity) (OwnershipLease, error)
+}
+
+// RecoveryOwnershipStore is implemented only by stores that can claim and
+// validate a complete private ownership journal under its exclusive lock.
+type RecoveryOwnershipStore interface {
+	AcquireRecovery(context.Context, RecoveryRequest) (RecoveredOwnership, error)
+}
+
+// RecoveredOwnership contains cleanup authority only. Nil process handles mean
+// the exact recorded process was positively absent while the supplied
+// namespace capability continued to retain the recorded namespace.
+type RecoveredOwnership struct {
+	Lease     OwnershipLease
+	Keeper    ProcessHandle
+	Mapper    ProcessHandle
+	Namespace *NamespaceHandle
 }
 
 type OwnershipLease interface {

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/lifecycle.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/lifecycle.go
@@ -241,13 +241,6 @@ func (l *Lifecycle) Start(ctx context.Context, request StartRequest) (*Session, 
 	return session, nil
 }
 
-// Recover reopens exact durable topology authority for cleanup only. The
-// implementation is intentionally frozen red until the ownership journal can
-// prove boot, process, and namespace correlation under its exclusive lock.
-func (l *Lifecycle) Recover(context.Context, RecoveryRequest) (*Session, error) {
-	return nil, ErrStaleTopologyUnverified
-}
-
 func (l *Lifecycle) Stop(_ context.Context, identity Identity) (Metadata, error) {
 	if l == nil || !l.config.Enabled {
 		return Metadata{}, ErrDisabled
@@ -515,10 +508,10 @@ func (l *Lifecycle) acquireSandboxOperation(sandboxID string) func() {
 }
 
 func finalizeOwnership(lease OwnershipLease, identity Identity) error {
-	if err := lease.Retire(identity); err != nil {
+	if err := guardedCleanup(func() error { return lease.Retire(identity) }); err != nil {
 		return err
 	}
-	return lease.Release()
+	return guardedCleanup(func() error { return lease.Release() })
 }
 
 func sanitizeOwnershipError(err error) error {
@@ -539,13 +532,13 @@ func (l *Lifecycle) cleanup(mapper ProcessHandle, owned *NamespaceHandle, keeper
 	defer cancel()
 	var result error
 	if mapper != nil {
-		result = errors.Join(result, mapper.Terminate(ctx))
+		result = errors.Join(result, guardedCleanup(func() error { return mapper.Terminate(ctx) }))
 	}
 	if owned != nil {
-		result = errors.Join(result, owned.Close())
+		result = errors.Join(result, guardedCleanup(func() error { return owned.Close() }))
 	}
 	if keeper != nil {
-		result = errors.Join(result, keeper.Terminate(ctx))
+		result = errors.Join(result, guardedCleanup(func() error { return keeper.Terminate(ctx) }))
 	}
 	return result
 }
@@ -574,8 +567,14 @@ func (s *Session) NamespaceHandle() (*NamespaceHandle, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.namespace == nil || s.stopping || s.metadata.Status != StatusPrepared ||
-		!s.metadata.StructuralInspected || !s.metadata.MappingReachable {
+	if s.namespace == nil || s.stopping {
+		return nil, ErrStopped
+	}
+	if s.recoveryOnly {
+		if s.metadata.Status != StatusRecoveryOnly {
+			return nil, ErrStopped
+		}
+	} else if s.metadata.Status != StatusPrepared || !s.metadata.StructuralInspected || !s.metadata.MappingReachable {
 		return nil, ErrStopped
 	}
 	s.borrows.Add(1)

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/lifecycle.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/lifecycle.go
@@ -27,19 +27,20 @@ type sandboxOperationLock struct {
 }
 
 type Session struct {
-	mu          sync.Mutex
-	identity    Identity
-	mapping     Mapping
-	metadata    Metadata
-	keeper      ProcessHandle
-	mapper      ProcessHandle
-	namespace   *NamespaceHandle
-	losses      chan Loss
-	lossOnce    sync.Once
-	stopping    bool
-	stopAttempt *lifecycleStopAttempt
-	borrows     sync.WaitGroup
-	ownership   OwnershipLease
+	mu           sync.Mutex
+	identity     Identity
+	mapping      Mapping
+	metadata     Metadata
+	keeper       ProcessHandle
+	mapper       ProcessHandle
+	namespace    *NamespaceHandle
+	losses       chan Loss
+	lossOnce     sync.Once
+	stopping     bool
+	stopAttempt  *lifecycleStopAttempt
+	borrows      sync.WaitGroup
+	ownership    OwnershipLease
+	recoveryOnly bool
 }
 
 type lifecycleStopAttempt struct {
@@ -238,6 +239,13 @@ func (l *Lifecycle) Start(ctx context.Context, request StartRequest) (*Session, 
 	go session.watch(ProcessRoleKeeper, keeper)
 	go session.watch(ProcessRoleMapping, mapper)
 	return session, nil
+}
+
+// Recover reopens exact durable topology authority for cleanup only. The
+// implementation is intentionally frozen red until the ownership journal can
+// prove boot, process, and namespace correlation under its exclusive lock.
+func (l *Lifecycle) Recover(context.Context, RecoveryRequest) (*Session, error) {
+	return nil, ErrStaleTopologyUnverified
 }
 
 func (l *Lifecycle) Stop(_ context.Context, identity Identity) (Metadata, error) {

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/ownership_linux.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/ownership_linux.go
@@ -209,6 +209,10 @@ func (l *fileOwnershipLease) Reconcile(ctx context.Context) error {
 	if json.Unmarshal(payload, &journal) != nil || journal.Version != privateJournalVersion || !validIdentity(journal.Identity) {
 		return ErrStaleTopologyUnverified
 	}
+	bootID, err := readHostBootID()
+	if err != nil || journal.HostBootID == "" || journal.HostBootID != bootID {
+		return ErrStaleTopologyUnverified
+	}
 	if journal.Identity.SandboxID != l.identity.SandboxID {
 		return ErrIdentityMismatch
 	}
@@ -746,11 +750,12 @@ func validHostBootID(value string) bool {
 }
 
 type recoveredProcess struct {
-	mu     sync.Mutex
-	record privateProcessRecord
-	pidfd  int
-	done   chan struct{}
-	once   sync.Once
+	mu        sync.Mutex
+	record    privateProcessRecord
+	pidfd     int
+	pidfdOpen bool
+	done      chan struct{}
+	once      sync.Once
 }
 
 func claimRecordedProcess(record privateProcessRecord, namespace *privateNamespaceRecord) (ProcessHandle, error) {
@@ -777,16 +782,12 @@ func claimRecordedProcess(record privateProcessRecord, namespace *privateNamespa
 		_ = syscall.Close(int(pidfd))
 		return nil, ErrIdentityMismatch
 	}
-	if state == 'Z' || state == 'X' {
-		_ = syscall.Close(int(pidfd))
-		return nil, ErrStaleTopologyUnverified
-	}
 	if namespace != nil && !recordedNamespaceMatches(record.PID, *namespace) {
 		_ = syscall.Close(int(pidfd))
 		return nil, ErrIdentityMismatch
 	}
 	startAfter, stateAfter, err := inspectProcessStat(record.PID)
-	if err != nil || startAfter != record.StartTime || stateAfter != state {
+	if err != nil || !recordedProcessSnapshotsMatch(start, state, startAfter, stateAfter) {
 		_ = syscall.Close(int(pidfd))
 		return nil, ErrStaleTopologyUnverified
 	}
@@ -797,7 +798,12 @@ func claimRecordedProcess(record privateProcessRecord, namespace *privateNamespa
 		_ = syscall.Close(int(pidfd))
 		return nil, ErrStaleTopologyUnverified
 	}
-	return &recoveredProcess{record: record, pidfd: int(pidfd), done: make(chan struct{})}, nil
+	return &recoveredProcess{record: record, pidfd: int(pidfd), pidfdOpen: true, done: make(chan struct{})}, nil
+}
+
+func recordedProcessSnapshotsMatch(beforeStart string, beforeState byte, afterStart string, afterState byte) bool {
+	return beforeStart != "" && beforeStart == afterStart &&
+		beforeState != 'Z' && beforeState != 'X' && afterState != 'Z' && afterState != 'X'
 }
 
 func inspectProcessStat(pid int) (string, byte, error) {
@@ -857,9 +863,11 @@ func (p *recoveredProcess) closePIDFD() {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.pidfd == 0 {
+	if !p.pidfdOpen {
 		return
 	}
-	_ = syscall.Close(p.pidfd)
-	p.pidfd = 0
+	pidfd := p.pidfd
+	p.pidfd = -1
+	p.pidfdOpen = false
+	_ = syscall.Close(pidfd)
 }

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/ownership_linux.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/ownership_linux.go
@@ -3,6 +3,7 @@
 package linuxtopology
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -49,6 +51,7 @@ type privateNamespaceRecord struct {
 
 type privateOwnershipJournal struct {
 	Version        int                     `json:"version"`
+	HostBootID     string                  `json:"hostBootId,omitempty"`
 	Identity       Identity                `json:"identity"`
 	Keeper         *privateProcessRecord   `json:"keeper,omitempty"`
 	Mapper         *privateProcessRecord   `json:"mapper,omitempty"`
@@ -66,6 +69,84 @@ func newFileOwnershipStore(root string) (*fileOwnershipStore, error) {
 
 func (s *fileOwnershipStore) Acquire(ctx context.Context, identity Identity) (OwnershipLease, error) {
 	return s.acquire(ctx, identity)
+}
+
+func (s *fileOwnershipStore) AcquireRecovery(ctx context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+	if s == nil || !validIdentity(request.Identity) || request.Namespace == nil || request.Namespace.Closed() {
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	if err := verifyExistingPrivateDirectory(s.root); err != nil {
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	dir := filepath.Join(s.root, request.Identity.SandboxID)
+	if err := verifyExistingPrivateDirectory(dir); err != nil {
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	lock, err := openPrivateRegular(filepath.Join(dir, "ownership.lock"), syscall.O_RDWR, 0o600)
+	if err != nil {
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lock.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return RecoveredOwnership{}, ErrTopologyCollision
+		}
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	lease := &fileOwnershipLease{
+		store: s, identity: request.Identity, dir: dir,
+		journalPath: filepath.Join(dir, "ownership.json"), lock: lock,
+	}
+	retired := filepath.Join(dir, "retired-"+request.Identity.TopologyGenerationID)
+	if marker, err := openPrivateRegular(retired, syscall.O_RDONLY, 0o600); err == nil {
+		_ = marker.Close()
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrStaleGeneration
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	if ctx.Err() != nil {
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	journal, err := loadRecoveryJournal(lease.journalPath)
+	if err != nil {
+		_ = lease.Release()
+		return RecoveredOwnership{}, err
+	}
+	if journal.Identity != request.Identity {
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrIdentityMismatch
+	}
+	bootID, err := readHostBootID()
+	if err != nil || journal.HostBootID != bootID {
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	if !namespaceMatchesRecord(request.Namespace, *journal.Namespace) {
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	owned, err := request.Namespace.Duplicate()
+	if err != nil {
+		_ = lease.Release()
+		return RecoveredOwnership{}, ErrStaleTopologyUnverified
+	}
+	keeper, err := claimRecordedProcess(*journal.Keeper, journal.Namespace)
+	if err != nil {
+		_ = owned.Close()
+		_ = lease.Release()
+		return RecoveredOwnership{}, err
+	}
+	mapper, err := claimRecordedProcess(*journal.Mapper, nil)
+	if err != nil {
+		closeRecoveredProcesses(keeper)
+		_ = owned.Close()
+		_ = lease.Release()
+		return RecoveredOwnership{}, err
+	}
+	return RecoveredOwnership{Lease: lease, Keeper: keeper, Mapper: mapper, Namespace: owned}, nil
 }
 
 func (s *fileOwnershipStore) acquire(ctx context.Context, identity Identity) (*fileOwnershipLease, error) {
@@ -169,8 +250,11 @@ func (l *fileOwnershipLease) Record(_ context.Context, keeper, mapper ProcessHan
 	if l == nil || l.lock == nil || l.released {
 		return ErrCleanupIncomplete
 	}
-	journal := privateOwnershipJournal{Version: privateJournalVersion, Identity: l.identity}
-	var err error
+	bootID, err := readHostBootID()
+	if err != nil {
+		return ErrCleanupIncomplete
+	}
+	journal := privateOwnershipJournal{Version: privateJournalVersion, HostBootID: bootID, Identity: l.identity}
 	if keeper != nil {
 		journal.Keeper, err = recordProcess(keeper)
 		if err != nil {
@@ -215,8 +299,12 @@ func (l *fileOwnershipLease) ArmMapping(_ context.Context, keeper ProcessHandle,
 	if err != nil {
 		return ErrCleanupIncomplete
 	}
+	bootID, bootErr := readHostBootID()
+	if bootErr != nil {
+		return ErrCleanupIncomplete
+	}
 	journal := privateOwnershipJournal{
-		Version: privateJournalVersion, Identity: l.identity,
+		Version: privateJournalVersion, HostBootID: bootID, Identity: l.identity,
 		Keeper: keeperRecord, Namespace: namespaceRecord,
 		MappingArmed: true, MappingCreator: creatorRecord,
 	}
@@ -484,4 +572,294 @@ func recordedNamespaceMatches(pid int, record privateNamespaceRecord) bool {
 	netStat, netOK := network.Sys().(*syscall.Stat_t)
 	return userOK && netOK && uint64(userStat.Dev) == record.UserDevice && userStat.Ino == record.UserInode &&
 		uint64(netStat.Dev) == record.NetDevice && netStat.Ino == record.NetInode
+}
+
+func verifyExistingPrivateDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() {
+		return ErrStaleTopologyUnverified
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != uint32(os.Geteuid()) {
+		return ErrStaleTopologyUnverified
+	}
+	return nil
+}
+
+func loadRecoveryJournal(path string) (privateOwnershipJournal, error) {
+	payload, err := readPrivateBounded(path, maxOutputLimit)
+	if err != nil || len(payload) == 0 {
+		return privateOwnershipJournal{}, ErrStaleTopologyUnverified
+	}
+	if !strictRecoveryJournalKeys(payload) {
+		return privateOwnershipJournal{}, ErrStaleTopologyUnverified
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var journal privateOwnershipJournal
+	if decoder.Decode(&journal) != nil || decoder.Decode(&struct{}{}) != io.EOF ||
+		journal.Version != privateJournalVersion || journal.HostBootID == "" || !validIdentity(journal.Identity) ||
+		journal.Keeper == nil || journal.Mapper == nil || journal.Namespace == nil || journal.MappingArmed ||
+		journal.MappingCreator != nil {
+		return privateOwnershipJournal{}, ErrStaleTopologyUnverified
+	}
+	return journal, nil
+}
+
+func strictRecoveryJournalKeys(payload []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return false
+	}
+	allowed := map[string]bool{
+		"version": true, "hostBootId": true, "identity": true, "keeper": true, "mapper": true,
+		"namespace": true, "mappingArmed": true, "mappingCreator": true,
+	}
+	required := []string{"version", "hostBootId", "identity", "keeper", "mapper", "namespace"}
+	seen := map[string]bool{}
+	for decoder.More() {
+		key, err := decoder.Token()
+		name, ok := key.(string)
+		if err != nil || !ok || !allowed[name] || seen[name] {
+			return false
+		}
+		seen[name] = true
+		switch name {
+		case "identity":
+			if !consumeExactObject(decoder, identityJournalKeys(), identityJournalKeys()) {
+				return false
+			}
+		case "keeper", "mapper", "mappingCreator":
+			if !consumeExactObject(decoder, map[string]bool{"pid": true, "startTime": true}, map[string]bool{"pid": true, "startTime": true}) {
+				return false
+			}
+		case "namespace":
+			if !consumeExactObject(decoder, map[string]bool{
+				"userDevice": true, "userInode": true, "netDevice": true, "netInode": true,
+			}, map[string]bool{"userDevice": true, "userInode": true, "netDevice": true, "netInode": true}) {
+				return false
+			}
+		default:
+			var raw json.RawMessage
+			if decoder.Decode(&raw) != nil {
+				return false
+			}
+		}
+	}
+	token, err = decoder.Token()
+	if err != nil || token != json.Delim('}') {
+		return false
+	}
+	for _, name := range required {
+		if !seen[name] {
+			return false
+		}
+	}
+	if seen["mappingArmed"] || seen["mappingCreator"] {
+		return false
+	}
+	_, err = decoder.Token()
+	return err == io.EOF
+}
+
+func identityJournalKeys() map[string]bool {
+	return map[string]bool{
+		"sandboxId": true, "executionId": true, "workerId": true, "runtimeId": true, "planId": true,
+		"policySnapshotId": true, "proxySessionId": true, "proxyGenerationId": true, "topologyGenerationId": true,
+	}
+}
+
+func consumeExactObject(decoder *json.Decoder, allowed, required map[string]bool) bool {
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return false
+	}
+	seen := map[string]bool{}
+	for decoder.More() {
+		key, err := decoder.Token()
+		name, ok := key.(string)
+		if err != nil || !ok || !allowed[name] || seen[name] {
+			return false
+		}
+		seen[name] = true
+		var raw json.RawMessage
+		if decoder.Decode(&raw) != nil {
+			return false
+		}
+	}
+	token, err = decoder.Token()
+	if err != nil || token != json.Delim('}') {
+		return false
+	}
+	for name := range required {
+		if !seen[name] {
+			return false
+		}
+	}
+	return true
+}
+
+func namespaceMatchesRecord(namespace *NamespaceHandle, record privateNamespaceRecord) bool {
+	if namespace == nil {
+		return false
+	}
+	namespace.mu.Lock()
+	defer namespace.mu.Unlock()
+	if namespace.closed || namespace.userInfo == nil || namespace.netInfo == nil {
+		return false
+	}
+	user, userOK := namespace.userInfo.Sys().(*syscall.Stat_t)
+	network, networkOK := namespace.netInfo.Sys().(*syscall.Stat_t)
+	return userOK && networkOK && uint64(user.Dev) == record.UserDevice && user.Ino == record.UserInode &&
+		uint64(network.Dev) == record.NetDevice && network.Ino == record.NetInode
+}
+
+func readHostBootID() (string, error) {
+	payload, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSuffix(string(payload), "\n")
+	if string(payload) != value+"\n" || !validHostBootID(value) {
+		return "", ErrStaleTopologyUnverified
+	}
+	return value, nil
+}
+
+func validHostBootID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, character := range value {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if character != '-' {
+				return false
+			}
+			continue
+		}
+		if !(character >= '0' && character <= '9' || character >= 'a' && character <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+type recoveredProcess struct {
+	mu     sync.Mutex
+	record privateProcessRecord
+	pidfd  int
+	done   chan struct{}
+	once   sync.Once
+}
+
+func claimRecordedProcess(record privateProcessRecord, namespace *privateNamespaceRecord) (ProcessHandle, error) {
+	if record.PID <= 1 || record.StartTime == "" {
+		return nil, ErrStaleTopologyUnverified
+	}
+	pidfd, _, errno := syscall.Syscall(uintptr(sysPIDFDOpen), uintptr(record.PID), 0, 0)
+	if errno == syscall.ESRCH {
+		return nil, nil
+	}
+	if errno != 0 {
+		return nil, ErrStaleTopologyUnverified
+	}
+	start, state, err := inspectProcessStat(record.PID)
+	if errors.Is(err, fs.ErrNotExist) {
+		_ = syscall.Close(int(pidfd))
+		return nil, nil
+	}
+	if err != nil {
+		_ = syscall.Close(int(pidfd))
+		return nil, ErrStaleTopologyUnverified
+	}
+	if start != record.StartTime {
+		_ = syscall.Close(int(pidfd))
+		return nil, ErrIdentityMismatch
+	}
+	if state == 'Z' || state == 'X' {
+		_ = syscall.Close(int(pidfd))
+		return nil, ErrStaleTopologyUnverified
+	}
+	if namespace != nil && !recordedNamespaceMatches(record.PID, *namespace) {
+		_ = syscall.Close(int(pidfd))
+		return nil, ErrIdentityMismatch
+	}
+	startAfter, stateAfter, err := inspectProcessStat(record.PID)
+	if err != nil || startAfter != record.StartTime || stateAfter != state {
+		_ = syscall.Close(int(pidfd))
+		return nil, ErrStaleTopologyUnverified
+	}
+	if errno := pidfdSignal(int(pidfd), 0); errno == syscall.ESRCH {
+		_ = syscall.Close(int(pidfd))
+		return nil, nil
+	} else if errno != 0 {
+		_ = syscall.Close(int(pidfd))
+		return nil, ErrStaleTopologyUnverified
+	}
+	return &recoveredProcess{record: record, pidfd: int(pidfd), done: make(chan struct{})}, nil
+}
+
+func inspectProcessStat(pid int) (string, byte, error) {
+	payload, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return "", 0, err
+	}
+	closing := strings.LastIndexByte(string(payload), ')')
+	if closing < 0 {
+		return "", 0, ErrStaleTopologyUnverified
+	}
+	fields := strings.Fields(string(payload[closing+1:]))
+	if len(fields) <= 19 || len(fields[0]) != 1 {
+		return "", 0, ErrStaleTopologyUnverified
+	}
+	if _, err := strconv.ParseUint(fields[19], 10, 64); err != nil {
+		return "", 0, ErrStaleTopologyUnverified
+	}
+	return fields[19], fields[0][0], nil
+}
+
+func (p *recoveredProcess) PID() int {
+	if p == nil {
+		return 0
+	}
+	return p.record.PID
+}
+
+func (p *recoveredProcess) Done() <-chan struct{} {
+	if p == nil {
+		closed := make(chan struct{})
+		close(closed)
+		return closed
+	}
+	return p.done
+}
+
+func (p *recoveredProcess) Terminate(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	err := terminateRecordedProcess(ctx, p.record, nil)
+	p.closePIDFD()
+	p.once.Do(func() { close(p.done) })
+	if err != nil && !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ESRCH) {
+		if errors.Is(err, ErrIdentityMismatch) {
+			return ErrCleanupIncomplete
+		}
+		return err
+	}
+	return nil
+}
+
+func (p *recoveredProcess) closePIDFD() {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.pidfd == 0 {
+		return
+	}
+	_ = syscall.Close(p.pidfd)
+	p.pidfd = 0
 }

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/ownership_other.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/ownership_other.go
@@ -11,6 +11,9 @@ func newFileOwnershipStore(string) (*fileOwnershipStore, error) { return nil, Er
 func (*fileOwnershipStore) Acquire(context.Context, Identity) (OwnershipLease, error) {
 	return nil, ErrUnsupported
 }
+func (*fileOwnershipStore) AcquireRecovery(context.Context, RecoveryRequest) (RecoveredOwnership, error) {
+	return RecoveredOwnership{}, ErrUnsupported
+}
 func (*fileOwnershipStore) acquire(context.Context, Identity) (*fileOwnershipLease, error) {
 	return nil, ErrUnsupported
 }

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery.go
@@ -1,0 +1,286 @@
+package linuxtopology
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"time"
+)
+
+func (l *Lifecycle) acquireSandboxOperationContext(ctx context.Context, sandboxID string) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	l.mu.Lock()
+	operation := l.operations[sandboxID]
+	if operation == nil {
+		operation = &sandboxOperationLock{}
+		l.operations[sandboxID] = operation
+	}
+	operation.references++
+	l.mu.Unlock()
+
+	timer := time.NewTimer(time.Millisecond)
+	defer timer.Stop()
+	for {
+		if operation.mu.TryLock() {
+			return func() {
+				operation.mu.Unlock()
+				l.mu.Lock()
+				operation.references--
+				if operation.references == 0 && l.operations[sandboxID] == operation {
+					delete(l.operations, sandboxID)
+				}
+				l.mu.Unlock()
+			}, nil
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(time.Millisecond)
+		select {
+		case <-ctx.Done():
+			l.mu.Lock()
+			operation.references--
+			if operation.references == 0 && l.operations[sandboxID] == operation {
+				delete(l.operations, sandboxID)
+			}
+			l.mu.Unlock()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+// Recover reopens exact durable topology authority for cleanup only. It never
+// restores prepared, inspected, or reachable proof, never consumes the
+// caller-owned namespace, and never presents unknown or interrupted state as
+// running.
+func (l *Lifecycle) Recover(ctx context.Context, request RecoveryRequest) (session *Session, err error) {
+	var recovered RecoveredOwnership
+	defer func() {
+		if panicked := recover(); panicked != nil {
+			abandonRecoveredOwnership(request, recovered)
+			session = nil
+			err = ErrStaleTopologyUnverified
+		}
+	}()
+	if l == nil || !l.config.Enabled {
+		return nil, ErrDisabled
+	}
+	if !l.supported {
+		return nil, ErrUnsupported
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if ctx.Err() != nil || !validIdentity(request.Identity) || request.Namespace == nil || request.Namespace.Closed() {
+		return nil, ErrStaleTopologyUnverified
+	}
+
+	releaseOperation, err := l.acquireSandboxOperationContext(ctx, request.Identity.SandboxID)
+	if err != nil {
+		return nil, ErrStaleTopologyUnverified
+	}
+	defer releaseOperation()
+	if ctx.Err() != nil {
+		return nil, ErrStaleTopologyUnverified
+	}
+
+	l.mu.Lock()
+	current := l.active[request.Identity.SandboxID]
+	if current != nil {
+		current.mu.Lock()
+		same := current.identity == request.Identity && current.recoveryOnly &&
+			current.metadata.Status == StatusRecoveryOnly && current.namespace != nil &&
+			current.namespace.Correlates(request.Namespace)
+		current.mu.Unlock()
+		l.mu.Unlock()
+		if same {
+			return current, nil
+		}
+		return nil, ErrTopologyCollision
+	}
+	if stopped, ok := l.stopped[request.Identity.SandboxID]; ok && stopped.Identity == request.Identity {
+		l.mu.Unlock()
+		return nil, ErrStaleGeneration
+	}
+	l.mu.Unlock()
+
+	if valueIsNil(l.ownership) {
+		return nil, ErrStaleTopologyUnverified
+	}
+	store, ok := l.ownership.(RecoveryOwnershipStore)
+	if !ok || valueIsNil(store) {
+		return nil, ErrStaleTopologyUnverified
+	}
+
+	recovered, recoverErr := claimRecoveredOwnership(ctx, store, request)
+	if recoverErr != nil {
+		abandonRecoveredOwnership(request, recovered)
+		recovered = RecoveredOwnership{}
+		return nil, sanitizeRecoveryError(recoverErr)
+	}
+	owned, processes, valid := acceptRecoveredOwnership(request, recovered)
+	if !valid {
+		abandonRecoveredOwnership(request, recovered)
+		if owned != nil {
+			_ = owned.Close()
+		}
+		closeRecoveredProcesses(processes.keeper, processes.mapper)
+		recovered = RecoveredOwnership{}
+		return nil, ErrStaleTopologyUnverified
+	}
+	recovered.Namespace = nil
+
+	session = &Session{
+		identity:     request.Identity,
+		metadata:     Metadata{Identity: request.Identity, Status: StatusRecoveryOnly},
+		keeper:       processes.keeper,
+		mapper:       processes.mapper,
+		namespace:    owned,
+		losses:       make(chan Loss, 1),
+		ownership:    recovered.Lease,
+		recoveryOnly: true,
+	}
+	l.mu.Lock()
+	if existing := l.active[request.Identity.SandboxID]; existing != nil {
+		l.mu.Unlock()
+		abandonRecoveredOwnership(request, RecoveredOwnership{Lease: recovered.Lease, Namespace: owned, Keeper: processes.keeper, Mapper: processes.mapper})
+		recovered = RecoveredOwnership{}
+		return nil, ErrTopologyCollision
+	}
+	l.active[request.Identity.SandboxID] = session
+	l.mu.Unlock()
+	recovered = RecoveredOwnership{}
+	return session, nil
+}
+
+type recoveredProcesses struct {
+	keeper ProcessHandle
+	mapper ProcessHandle
+}
+
+func claimRecoveredOwnership(ctx context.Context, store RecoveryOwnershipStore, request RecoveryRequest) (recovered RecoveredOwnership, err error) {
+	defer func() {
+		if panicked := recover(); panicked != nil {
+			abandonRecoveredOwnership(request, recovered)
+			recovered = RecoveredOwnership{}
+			err = ErrStaleTopologyUnverified
+		}
+	}()
+	recovered, err = store.AcquireRecovery(ctx, request)
+	if err != nil {
+		return recovered, err
+	}
+	return recovered, nil
+}
+
+func acceptRecoveredOwnership(request RecoveryRequest, recovered RecoveredOwnership) (*NamespaceHandle, recoveredProcesses, bool) {
+	if recovered.Lease == nil || valueIsNil(recovered.Lease) {
+		return nil, recoveredProcesses{}, false
+	}
+	if recovered.Namespace == nil || recovered.Namespace == request.Namespace || recovered.Namespace.Closed() ||
+		!recovered.Namespace.Correlates(request.Namespace) {
+		return nil, recoveredProcesses{}, false
+	}
+	keeper, keeperOK := acceptedRecoveryProcess(recovered.Keeper)
+	mapper, mapperOK := acceptedRecoveryProcess(recovered.Mapper)
+	if !keeperOK || !mapperOK {
+		return nil, recoveredProcesses{}, false
+	}
+	if keeper != nil && mapper != nil && (keeper == mapper || sameProcessPID(keeper, mapper)) {
+		return nil, recoveredProcesses{}, false
+	}
+	owned, err := recovered.Namespace.Duplicate()
+	if err != nil || owned == nil || !owned.Correlates(request.Namespace) {
+		return nil, recoveredProcesses{}, false
+	}
+	if closeErr := recovered.Namespace.Close(); closeErr != nil {
+		_ = owned.Close()
+		return nil, recoveredProcesses{}, false
+	}
+	recovered.Namespace = nil
+	return owned, recoveredProcesses{keeper: keeper, mapper: mapper}, true
+}
+
+func acceptedRecoveryProcess(handle ProcessHandle) (ProcessHandle, bool) {
+	if handle == nil {
+		return nil, true
+	}
+	if valueIsNil(handle) {
+		return nil, false
+	}
+	return handle, true
+}
+
+func sameProcessPID(left, right ProcessHandle) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	pid := left.PID()
+	return pid > 0 && pid == right.PID()
+}
+
+func abandonRecoveredOwnership(request RecoveryRequest, recovered RecoveredOwnership) {
+	defer func() { _ = recover() }()
+	if recovered.Namespace != nil && recovered.Namespace != request.Namespace {
+		_ = recovered.Namespace.Close()
+	}
+	closeRecoveredProcesses(recovered.Keeper, recovered.Mapper)
+	if recovered.Lease != nil && !valueIsNil(recovered.Lease) {
+		_ = recovered.Lease.Release()
+	}
+}
+
+func closeRecoveredProcesses(handles ...ProcessHandle) {
+	for _, handle := range handles {
+		if closer, ok := handle.(interface{ closePIDFD() }); ok {
+			closer.closePIDFD()
+		}
+	}
+}
+
+func valueIsNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func sanitizeRecoveryError(err error) error {
+	switch {
+	case err == nil:
+		return ErrStaleTopologyUnverified
+	case errors.Is(err, ErrTopologyCollision):
+		return ErrTopologyCollision
+	case errors.Is(err, ErrStaleGeneration):
+		return ErrStaleGeneration
+	case errors.Is(err, ErrIdentityMismatch):
+		return ErrIdentityMismatch
+	case errors.Is(err, ErrInvalidIdentity):
+		return ErrInvalidIdentity
+	case errors.Is(err, ErrStaleTopologyUnverified):
+		return ErrStaleTopologyUnverified
+	default:
+		return ErrStaleTopologyUnverified
+	}
+}
+
+func guardedCleanup(fn func() error) (err error) {
+	defer func() {
+		if panicked := recover(); panicked != nil {
+			err = ErrCleanupIncomplete
+		}
+	}()
+	return fn()
+}

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery.go
@@ -199,7 +199,7 @@ func acceptRecoveredOwnership(request RecoveryRequest, recovered RecoveredOwners
 	if err != nil || owned == nil || !owned.Correlates(request.Namespace) {
 		return nil, recoveredProcesses{}, false
 	}
-	if closeErr := recovered.Namespace.Close(); closeErr != nil {
+	if closeErr := guardedCleanup(recovered.Namespace.Close); closeErr != nil {
 		_ = owned.Close()
 		return nil, recoveredProcesses{}, false
 	}
@@ -226,20 +226,22 @@ func sameProcessPID(left, right ProcessHandle) bool {
 }
 
 func abandonRecoveredOwnership(request RecoveryRequest, recovered RecoveredOwnership) {
-	defer func() { _ = recover() }()
 	if recovered.Namespace != nil && recovered.Namespace != request.Namespace {
-		_ = recovered.Namespace.Close()
+		_ = guardedCleanup(recovered.Namespace.Close)
 	}
 	closeRecoveredProcesses(recovered.Keeper, recovered.Mapper)
 	if recovered.Lease != nil && !valueIsNil(recovered.Lease) {
-		_ = recovered.Lease.Release()
+		_ = guardedCleanup(recovered.Lease.Release)
 	}
 }
 
 func closeRecoveredProcesses(handles ...ProcessHandle) {
 	for _, handle := range handles {
 		if closer, ok := handle.(interface{ closePIDFD() }); ok {
-			closer.closePIDFD()
+			_ = guardedCleanup(func() error {
+				closer.closePIDFD()
+				return nil
+			})
 		}
 	}
 }

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_adversarial_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_adversarial_red_test.go
@@ -1,0 +1,310 @@
+//go:build linux
+
+package linuxtopology
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+)
+
+type adversarialRecoveryStore struct {
+	base    *memoryOwnershipStore
+	recover func(context.Context, RecoveryRequest) (RecoveredOwnership, error)
+}
+
+func (s *adversarialRecoveryStore) Acquire(ctx context.Context, identity Identity) (OwnershipLease, error) {
+	return s.base.Acquire(ctx, identity)
+}
+func (s *adversarialRecoveryStore) AcquireRecovery(ctx context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+	return s.recover(ctx, request)
+}
+
+type adversarialRecoveryLease struct {
+	retireCalls  int
+	releaseCalls int
+	retireErr    error
+	releaseErr   error
+	retirePanic  bool
+	releasePanic bool
+}
+
+func (*adversarialRecoveryLease) Reconcile(context.Context) error { return nil }
+func (*adversarialRecoveryLease) Record(context.Context, ProcessHandle, ProcessHandle, *NamespaceHandle) error {
+	return nil
+}
+func (*adversarialRecoveryLease) ArmMapping(context.Context, ProcessHandle, *NamespaceHandle) error {
+	return nil
+}
+func (l *adversarialRecoveryLease) Retire(Identity) error {
+	l.retireCalls++
+	if l.retirePanic {
+		panic("private retire panic")
+	}
+	return l.retireErr
+}
+func (l *adversarialRecoveryLease) Release() error {
+	l.releaseCalls++
+	if l.releasePanic {
+		panic("private release panic")
+	}
+	return l.releaseErr
+}
+
+type adversarialRecoveryProcess struct {
+	pid            int
+	done           chan struct{}
+	terminateCalls int
+	terminateErr   error
+	terminatePanic bool
+}
+
+func newAdversarialRecoveryProcess(pid int) *adversarialRecoveryProcess {
+	return &adversarialRecoveryProcess{pid: pid, done: make(chan struct{})}
+}
+func (p *adversarialRecoveryProcess) PID() int { return p.pid }
+func (p *adversarialRecoveryProcess) Done() <-chan struct{} {
+	if p == nil {
+		return nil
+	}
+	return p.done
+}
+func (p *adversarialRecoveryProcess) Terminate(context.Context) error {
+	p.terminateCalls++
+	if p.terminatePanic {
+		panic("private process panic")
+	}
+	return p.terminateErr
+}
+
+func newAdversarialRecoveryLifecycle(t *testing.T, store OwnershipStore) (*Lifecycle, *NamespaceHandle) {
+	t.Helper()
+	return newSerializedRecoveryLifecycle(t, store)
+}
+
+func duplicateRecoveryNamespace(t *testing.T, namespace *NamespaceHandle) *NamespaceHandle {
+	t.Helper()
+	duplicate, err := namespace.Duplicate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return duplicate
+}
+
+func callLifecycleRecoverNoPanic(t *testing.T, lifecycle *Lifecycle, request RecoveryRequest) (session *Session, err error) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("Lifecycle.Recover panicked: %v", recovered)
+		}
+	}()
+	return lifecycle.Recover(context.Background(), request)
+}
+
+func callLifecycleStopNoPanic(t *testing.T, lifecycle *Lifecycle, identity Identity) (metadata Metadata, err error) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("Lifecycle.Stop panicked: %v", recovered)
+		}
+	}()
+	return lifecycle.Stop(context.Background(), identity)
+}
+
+func TestLinuxTopologyRecoveryOwnershipResultMatrix(t *testing.T) {
+	privateErr := errors.New("private ownership error")
+	for _, test := range []struct {
+		name  string
+		build func(*testing.T, RecoveryRequest, *adversarialRecoveryLease) (RecoveredOwnership, error)
+	}{
+		{name: "value plus error", build: func(t *testing.T, request RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			return RecoveredOwnership{Lease: lease, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, privateErr
+		}},
+		{name: "nil lease", build: func(t *testing.T, request RecoveryRequest, _ *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			return RecoveredOwnership{Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+		}},
+		{name: "typed nil lease", build: func(t *testing.T, request RecoveryRequest, _ *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			var lease *adversarialRecoveryLease
+			return RecoveredOwnership{Lease: lease, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+		}},
+		{name: "nil namespace", build: func(_ *testing.T, _ RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			return RecoveredOwnership{Lease: lease}, nil
+		}},
+		{name: "closed namespace", build: func(t *testing.T, request RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			namespace := duplicateRecoveryNamespace(t, request.Namespace)
+			if err := namespace.Close(); err != nil {
+				t.Fatal(err)
+			}
+			return RecoveredOwnership{Lease: lease, Namespace: namespace}, nil
+		}},
+		{name: "caller namespace alias", build: func(_ *testing.T, request RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			return RecoveredOwnership{Lease: lease, Namespace: request.Namespace}, nil
+		}},
+		{name: "unusable duplicate", build: func(t *testing.T, request RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			namespace := duplicateRecoveryNamespace(t, request.Namespace)
+			namespace.mu.Lock()
+			_ = syscall.Close(int(namespace.user.Fd()))
+			_ = syscall.Close(int(namespace.network.Fd()))
+			namespace.mu.Unlock()
+			return RecoveredOwnership{Lease: lease, Namespace: namespace}, nil
+		}},
+		{name: "typed nil keeper", build: func(t *testing.T, request RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			var process *adversarialRecoveryProcess
+			return RecoveredOwnership{Lease: lease, Keeper: process, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+		}},
+		{name: "duplicate process handle", build: func(t *testing.T, request RecoveryRequest, lease *adversarialRecoveryLease) (RecoveredOwnership, error) {
+			process := newAdversarialRecoveryProcess(8101)
+			return RecoveredOwnership{Lease: lease, Keeper: process, Mapper: process, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lease := &adversarialRecoveryLease{}
+			store := &adversarialRecoveryStore{base: newMemoryOwnershipStore()}
+			store.recover = func(ctx context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+				return test.build(t, request, lease)
+			}
+			lifecycle, namespace := newAdversarialRecoveryLifecycle(t, store)
+			session, err := callLifecycleRecoverNoPanic(t, lifecycle, RecoveryRequest{Identity: testIdentity("topology-gen-result-matrix"), Namespace: namespace})
+			if session != nil || !errors.Is(err, ErrStaleTopologyUnverified) {
+				t.Fatalf("Recover(adversarial result) = %T, %v", session, err)
+			}
+			if namespace.Closed() {
+				t.Fatal("adversarial result consumed caller namespace")
+			}
+			if test.name != "nil lease" && test.name != "typed nil lease" && lease.releaseCalls != 1 {
+				t.Fatalf("invalid recovery lease releases = %d, want one", lease.releaseCalls)
+			}
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveryStorePanicAndCleanupPanicMatrix(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		panicAt string
+	}{
+		{name: "store panic", panicAt: "store"},
+		{name: "value error release panic", panicAt: "release"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lease := &adversarialRecoveryLease{releasePanic: test.panicAt == "release"}
+			store := &adversarialRecoveryStore{base: newMemoryOwnershipStore()}
+			store.recover = func(_ context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+				if test.panicAt == "store" {
+					panic("private store panic")
+				}
+				return RecoveredOwnership{Lease: lease, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, errors.New("private value error")
+			}
+			lifecycle, namespace := newAdversarialRecoveryLifecycle(t, store)
+			session, err := callLifecycleRecoverNoPanic(t, lifecycle, RecoveryRequest{Identity: testIdentity("topology-gen-panic-matrix"), Namespace: namespace})
+			if session != nil || !errors.Is(err, ErrStaleTopologyUnverified) {
+				t.Fatalf("Recover(%s) = %T, %v", test.name, session, err)
+			}
+			if namespace.Closed() {
+				t.Fatal("panic path consumed caller namespace")
+			}
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveredStopAdversarialMatrix(t *testing.T) {
+	privateErr := errors.New("private cleanup error")
+	for _, test := range []struct {
+		name      string
+		configure func(*adversarialRecoveryLease, *adversarialRecoveryProcess)
+	}{
+		{name: "process error", configure: func(_ *adversarialRecoveryLease, process *adversarialRecoveryProcess) {
+			process.terminateErr = privateErr
+		}},
+		{name: "process panic", configure: func(_ *adversarialRecoveryLease, process *adversarialRecoveryProcess) { process.terminatePanic = true }},
+		{name: "retire error", configure: func(lease *adversarialRecoveryLease, _ *adversarialRecoveryProcess) { lease.retireErr = privateErr }},
+		{name: "retire panic", configure: func(lease *adversarialRecoveryLease, _ *adversarialRecoveryProcess) { lease.retirePanic = true }},
+		{name: "release error", configure: func(lease *adversarialRecoveryLease, _ *adversarialRecoveryProcess) { lease.releaseErr = privateErr }},
+		{name: "release panic", configure: func(lease *adversarialRecoveryLease, _ *adversarialRecoveryProcess) { lease.releasePanic = true }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lease := &adversarialRecoveryLease{}
+			process := newAdversarialRecoveryProcess(8201)
+			test.configure(lease, process)
+			store := &adversarialRecoveryStore{base: newMemoryOwnershipStore()}
+			store.recover = func(_ context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+				return RecoveredOwnership{Lease: lease, Keeper: process, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+			}
+			lifecycle, namespace := newAdversarialRecoveryLifecycle(t, store)
+			identity := testIdentity("topology-gen-stop-adversarial")
+			session, err := callLifecycleRecoverNoPanic(t, lifecycle, RecoveryRequest{Identity: identity, Namespace: namespace})
+			if err != nil || session == nil {
+				t.Fatalf("Recover() = %T, %v", session, err)
+			}
+			metadata, stopErr := callLifecycleStopNoPanic(t, lifecycle, identity)
+			if !errors.Is(stopErr, ErrCleanupIncomplete) || metadata.Status != StatusCleanupIncomplete {
+				t.Fatalf("Stop(%s) = %#v, %v", test.name, metadata, stopErr)
+			}
+			if namespace.Closed() {
+				t.Fatal("failed Stop consumed caller namespace")
+			}
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveredStopRetainsNamespaceCloseFailure(t *testing.T) {
+	lease := &adversarialRecoveryLease{}
+	store := &adversarialRecoveryStore{base: newMemoryOwnershipStore()}
+	store.recover = func(_ context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+		return RecoveredOwnership{Lease: lease, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+	}
+	lifecycle, namespace := newAdversarialRecoveryLifecycle(t, store)
+	identity := testIdentity("topology-gen-close-failure")
+	session, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session.namespace.mu.Lock()
+	_ = syscall.Close(int(session.namespace.user.Fd()))
+	_ = syscall.Close(int(session.namespace.network.Fd()))
+	session.namespace.mu.Unlock()
+	metadata, err := callLifecycleStopNoPanic(t, lifecycle, identity)
+	if !errors.Is(err, ErrCleanupIncomplete) || metadata.Status != StatusCleanupIncomplete || lease.retireCalls != 0 {
+		t.Fatalf("Stop(namespace close failure) = %#v, %v; retire=%d", metadata, err, lease.retireCalls)
+	}
+	if namespace.Closed() {
+		t.Fatal("namespace close failure consumed caller namespace")
+	}
+}
+
+func TestLinuxTopologyRecoveredStopHandlesNilProcessAsPositiveAbsence(t *testing.T) {
+	lease := &adversarialRecoveryLease{}
+	store := &adversarialRecoveryStore{base: newMemoryOwnershipStore()}
+	store.recover = func(_ context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+		return RecoveredOwnership{Lease: lease, Namespace: duplicateRecoveryNamespace(t, request.Namespace)}, nil
+	}
+	lifecycle, namespace := newAdversarialRecoveryLifecycle(t, store)
+	identity := testIdentity("topology-gen-nil-process")
+	if _, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace}); err != nil {
+		t.Fatal(err)
+	}
+	metadata, err := lifecycle.Stop(context.Background(), identity)
+	if err != nil || metadata.Status != StatusStopped || lease.retireCalls != 1 || lease.releaseCalls != 1 {
+		t.Fatalf("Stop(absent processes) = %#v, %v; retire=%d release=%d", metadata, err, lease.retireCalls, lease.releaseCalls)
+	}
+}
+
+func makeNamespaceCloseFailure(t *testing.T) *NamespaceHandle {
+	t.Helper()
+	user, err := os.CreateTemp(t.TempDir(), "close-user-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	network, err := os.CreateTemp(t.TempDir(), "close-net-")
+	if err != nil {
+		user.Close()
+		t.Fatal(err)
+	}
+	handle, err := NewNamespaceHandle(user, network)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handle
+}

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_adversarial_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_adversarial_red_test.go
@@ -61,6 +61,19 @@ type adversarialRecoveryProcess struct {
 	terminatePanic bool
 }
 
+type adversarialRecoveryCloseProcess struct {
+	*adversarialRecoveryProcess
+	closeCalls int
+	closePanic bool
+}
+
+func (p *adversarialRecoveryCloseProcess) closePIDFD() {
+	p.closeCalls++
+	if p.closePanic {
+		panic("private process close panic")
+	}
+}
+
 func newAdversarialRecoveryProcess(pid int) *adversarialRecoveryProcess {
 	return &adversarialRecoveryProcess{pid: pid, done: make(chan struct{})}
 }
@@ -204,6 +217,43 @@ func TestLinuxTopologyRecoveryStorePanicAndCleanupPanicMatrix(t *testing.T) {
 			}
 			if namespace.Closed() {
 				t.Fatal("panic path consumed caller namespace")
+			}
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveryAbandonContinuesAfterCleanupPanic(t *testing.T) {
+	privateErr := errors.New("private recovery failure")
+	for _, test := range []struct {
+		name           string
+		namespacePanic bool
+		keeperPanic    bool
+	}{
+		{name: "namespace close panic", namespacePanic: true},
+		{name: "first process close panic", keeperPanic: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			lease := &adversarialRecoveryLease{}
+			keeper := &adversarialRecoveryCloseProcess{adversarialRecoveryProcess: newAdversarialRecoveryProcess(8111), closePanic: test.keeperPanic}
+			mapper := &adversarialRecoveryCloseProcess{adversarialRecoveryProcess: newAdversarialRecoveryProcess(8112)}
+			store := &adversarialRecoveryStore{base: newMemoryOwnershipStore()}
+			store.recover = func(_ context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+				namespace := duplicateRecoveryNamespace(t, request.Namespace)
+				if test.namespacePanic {
+					namespace.release = func() { panic("private namespace close panic") }
+				}
+				return RecoveredOwnership{Lease: lease, Keeper: keeper, Mapper: mapper, Namespace: namespace}, privateErr
+			}
+			lifecycle, namespace := newAdversarialRecoveryLifecycle(t, store)
+			session, err := callLifecycleRecoverNoPanic(t, lifecycle, RecoveryRequest{Identity: testIdentity("topology-gen-cleanup-panic"), Namespace: namespace})
+			if session != nil || !errors.Is(err, ErrStaleTopologyUnverified) {
+				t.Fatalf("Recover(cleanup panic) = %T, %v", session, err)
+			}
+			if keeper.closeCalls != 1 || mapper.closeCalls != 1 || lease.releaseCalls != 1 {
+				t.Fatalf("cleanup attempts = keeper %d mapper %d lease %d, want all exactly once", keeper.closeCalls, mapper.closeCalls, lease.releaseCalls)
+			}
+			if namespace.Closed() {
+				t.Fatal("cleanup panic consumed caller namespace")
 			}
 		})
 	}

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_linux_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_linux_red_test.go
@@ -1,0 +1,159 @@
+//go:build linux
+
+package linuxtopology
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestLinuxTopologyOwnershipJournalIsBootBound(t *testing.T) {
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := &execBoundary{}
+	keeper, err := boundary.Start(context.Background(), ProcessSpec{Role: ProcessRoleKeeper, Path: sleep, Args: []string{"30"}, OutputLimit: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = keeper.Terminate(ctx)
+	}()
+	store, err := newFileOwnershipStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := testIdentity("topology-gen-boot-bound")
+	lease, err := store.acquire(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+	if err := lease.Record(context.Background(), keeper, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := os.ReadFile(lease.journalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatal(err)
+	}
+	bootID, ok := raw["hostBootId"].(string)
+	if !ok || bootID == "" {
+		t.Fatalf("ownership journal = %s, want exact hostBootId", payload)
+	}
+}
+
+func TestLinuxTopologyFileOwnershipRecoversExactSuppliedNamespace(t *testing.T) {
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := &execBoundary{}
+	keeper, err := boundary.Start(context.Background(), ProcessSpec{Role: ProcessRoleKeeper, Path: sleep, Args: []string{"30"}, OutputLimit: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapper, err := boundary.Start(context.Background(), ProcessSpec{Role: ProcessRoleMapping, Path: sleep, Args: []string{"30"}, OutputLimit: 1024})
+	if err != nil {
+		terminateTestProcess(t, keeper)
+		t.Fatal(err)
+	}
+	defer terminateTestProcess(t, keeper)
+	defer terminateTestProcess(t, mapper)
+	namespace, err := openRecordedTestNamespaces(keeper.PID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer namespace.Close()
+	store, err := newFileOwnershipStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := testIdentity("topology-gen-file-recovery")
+	lease, err := store.acquire(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Record(context.Background(), keeper, mapper, namespace); err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	recoveryStore, ok := any(store).(RecoveryOwnershipStore)
+	if !ok {
+		t.Fatal("file ownership store exposes no exact recovery claim")
+	}
+	recovered, err := recoveryStore.AcquireRecovery(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Lease.Release()
+	defer recovered.Namespace.Close()
+	if recovered.Keeper == nil || recovered.Mapper == nil || !recovered.Namespace.Correlates(namespace) {
+		t.Fatalf("recovered authority = keeper %T mapper %T namespace %T", recovered.Keeper, recovered.Mapper, recovered.Namespace)
+	}
+	wrongUser, err := os.Open(filepath.Join("/proc", "self", "ns", "user"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongNet, err := os.Open(filepath.Join("/proc", "1", "ns", "net"))
+	if err != nil {
+		wrongUser.Close()
+		t.Fatal(err)
+	}
+	wrong, err := NewNamespaceHandle(wrongUser, wrongNet)
+	if err != nil {
+		wrongUser.Close()
+		wrongNet.Close()
+		t.Fatal(err)
+	}
+	defer wrong.Close()
+	if _, err := recoveryStore.AcquireRecovery(context.Background(), RecoveryRequest{Identity: identity, Namespace: wrong}); !errors.Is(err, ErrTopologyCollision) {
+		// The first exact claim intentionally retains the journal lock; a second
+		// caller cannot inspect or mutate it, even with wrong namespace authority.
+		t.Fatalf("concurrent wrong recovery = %v, want collision", err)
+	}
+}
+
+func openRecordedTestNamespaces(pid int) (*NamespaceHandle, error) {
+	user, err := os.Open(filepath.Join("/proc", fmtInt(pid), "ns", "user"))
+	if err != nil {
+		return nil, err
+	}
+	network, err := os.Open(filepath.Join("/proc", fmtInt(pid), "ns", "net"))
+	if err != nil {
+		user.Close()
+		return nil, err
+	}
+	handle, err := NewNamespaceHandle(user, network)
+	if err != nil {
+		user.Close()
+		network.Close()
+	}
+	return handle, err
+}
+
+func fmtInt(value int) string {
+	return strconv.Itoa(value)
+}
+
+func terminateTestProcess(t *testing.T, process ProcessHandle) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = process.Terminate(ctx)
+}

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_linux_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_linux_red_test.go
@@ -112,22 +112,10 @@ func TestLinuxTopologyFileOwnershipRecoversExactSuppliedNamespace(t *testing.T) 
 	if recovered.Keeper == nil || recovered.Mapper == nil || !recovered.Namespace.Correlates(namespace) {
 		t.Fatalf("recovered authority = keeper %T mapper %T namespace %T", recovered.Keeper, recovered.Mapper, recovered.Namespace)
 	}
-	wrongUser, err := os.Open(filepath.Join("/proc", "self", "ns", "user"))
-	if err != nil {
-		t.Fatal(err)
+	wrong := newFakeNamespaces(t, nil).base
+	if wrong.Correlates(namespace) {
+		t.Fatal("wrong-namespace fixture accidentally correlates")
 	}
-	wrongNet, err := os.Open(filepath.Join("/proc", "1", "ns", "net"))
-	if err != nil {
-		wrongUser.Close()
-		t.Fatal(err)
-	}
-	wrong, err := NewNamespaceHandle(wrongUser, wrongNet)
-	if err != nil {
-		wrongUser.Close()
-		wrongNet.Close()
-		t.Fatal(err)
-	}
-	defer wrong.Close()
 	if _, err := recoveryStore.AcquireRecovery(context.Background(), RecoveryRequest{Identity: identity, Namespace: wrong}); !errors.Is(err, ErrTopologyCollision) {
 		// The first exact claim intentionally retains the journal lock; a second
 		// caller cannot inspect or mutate it, even with wrong namespace authority.

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_linux_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_linux_red_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -51,7 +52,12 @@ func TestLinuxTopologyOwnershipJournalIsBootBound(t *testing.T) {
 		t.Fatal(err)
 	}
 	bootID, ok := raw["hostBootId"].(string)
-	if !ok || bootID == "" {
+	expectedBootIDBytes, err := os.ReadFile("/proc/sys/kernel/random/boot_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedBootID := strings.TrimSuffix(string(expectedBootIDBytes), "\n")
+	if !ok || bootID != expectedBootID || string(expectedBootIDBytes) != bootID+"\n" {
 		t.Fatalf("ownership journal = %s, want exact hostBootId", payload)
 	}
 }

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_red_test.go
@@ -1,0 +1,128 @@
+package linuxtopology
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type recoveryTestOwnershipStore struct {
+	base   *memoryOwnershipStore
+	keeper ProcessHandle
+	mapper ProcessHandle
+	err    error
+}
+
+func (s *recoveryTestOwnershipStore) Acquire(ctx context.Context, identity Identity) (OwnershipLease, error) {
+	return s.base.Acquire(ctx, identity)
+}
+
+func (s *recoveryTestOwnershipStore) AcquireRecovery(ctx context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+	if s.err != nil {
+		return RecoveredOwnership{}, s.err
+	}
+	lease, err := s.base.Acquire(ctx, request.Identity)
+	if err != nil {
+		return RecoveredOwnership{}, err
+	}
+	namespace, err := request.Namespace.Duplicate()
+	if err != nil {
+		_ = lease.Release()
+		return RecoveredOwnership{}, err
+	}
+	return RecoveredOwnership{Lease: lease, Keeper: s.keeper, Mapper: s.mapper, Namespace: namespace}, nil
+}
+
+func TestLinuxTopologyRecoverInstallsCleanupOnlySession(t *testing.T) {
+	starter := newFakeStarter()
+	namespaces := newFakeNamespaces(t, &starter.events)
+	keeper := newFakeProcess(7101, ProcessRoleKeeper, &starter.events)
+	mapper := newFakeProcess(7102, ProcessRoleMapping, &starter.events)
+	ownership := &recoveryTestOwnershipStore{base: newMemoryOwnershipStore(), keeper: keeper, mapper: mapper}
+	lifecycle, err := New(Config{
+		Enabled: true, Tools: testTools(), Starter: starter,
+		Runner: &fakeRunner{output: goodLinkJSON()}, OpenNamespaces: namespaces.Open,
+		Reachability: &fakeReachabilityProber{}, Ownership: ownership,
+		CleanupTimeout: 250 * time.Millisecond, InspectionTimeout: 250 * time.Millisecond,
+		InspectionInterval: time.Millisecond, OutputLimit: 8 << 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := namespaces.base.Duplicate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.Close()
+	identity := testIdentity("topology-gen-recovery-only")
+	session, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: input})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata := session.Metadata()
+	if metadata.Identity != identity || metadata.Status != StatusRecoveryOnly || metadata.StructuralInspected || metadata.MappingReachable {
+		t.Fatalf("recovered metadata = %#v, want cleanup-only authority", metadata)
+	}
+	borrowed, err := session.NamespaceHandle()
+	if err != nil {
+		t.Fatalf("borrow recovered namespace: %v", err)
+	}
+	if !borrowed.Correlates(input) {
+		t.Fatal("recovered namespace did not preserve exact kernel identity")
+	}
+	if err := borrowed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if input.Closed() {
+		t.Fatal("Recover consumed caller-owned namespace")
+	}
+	stopped, err := lifecycle.Stop(context.Background(), identity)
+	if err != nil || stopped.Status != StatusStopped || stopped.StructuralInspected || stopped.MappingReachable {
+		t.Fatalf("Stop(recovered) = %#v, %v", stopped, err)
+	}
+	if keeper.terminateCount != 1 || mapper.terminateCount != 1 {
+		t.Fatalf("cleanup counts = keeper %d mapper %d, want one each", keeper.terminateCount, mapper.terminateCount)
+	}
+}
+
+func TestLinuxTopologyRecoverRejectsUnprovedAuthorityWithoutMutation(t *testing.T) {
+	starter := newFakeStarter()
+	namespaces := newFakeNamespaces(t, &starter.events)
+	ownership := &recoveryTestOwnershipStore{base: newMemoryOwnershipStore(), err: errors.New("private pid and namespace detail")}
+	lifecycle, err := New(Config{
+		Enabled: true, Tools: testTools(), Starter: starter,
+		Runner: &fakeRunner{output: goodLinkJSON()}, OpenNamespaces: namespaces.Open,
+		Reachability: &fakeReachabilityProber{}, Ownership: ownership,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := namespaces.base.Duplicate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer input.Close()
+	for _, request := range []RecoveryRequest{
+		{Identity: testIdentity("topology-gen-recovery-missing")},
+		{Identity: testIdentity("topology-gen-recovery-unsafe"), Namespace: input},
+	} {
+		if request.Namespace != nil {
+			request.Identity.WorkerID = "../private"
+		}
+		if session, recoverErr := lifecycle.Recover(context.Background(), request); session != nil || recoverErr == nil {
+			t.Fatalf("Recover(%#v) = %T, %v; want fail closed", request.Identity, session, recoverErr)
+		}
+	}
+	identity := testIdentity("topology-gen-recovery-private")
+	if session, recoverErr := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: input}); session != nil ||
+		!errors.Is(recoverErr, ErrStaleTopologyUnverified) || recoverErr.Error() != ErrStaleTopologyUnverified.Error() {
+		t.Fatalf("Recover(private failure) = %T, %v; want sanitized stale error", session, recoverErr)
+	}
+	if keeper := starter.latest(ProcessRoleKeeper); keeper != nil {
+		t.Fatal("recovery failure started or mutated a process")
+	}
+	if input.Closed() {
+		t.Fatal("recovery failure consumed caller namespace")
+	}
+}

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
@@ -1,0 +1,442 @@
+//go:build linux
+
+package linuxtopology
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fileRecoveryFixture struct {
+	store       *fileOwnershipStore
+	identity    Identity
+	namespace   *NamespaceHandle
+	keeper      ProcessHandle
+	mapper      ProcessHandle
+	journalPath string
+}
+
+func newFileRecoveryFixture(t *testing.T) *fileRecoveryFixture {
+	t.Helper()
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	boundary := &execBoundary{}
+	keeper, err := boundary.Start(context.Background(), ProcessSpec{Role: ProcessRoleKeeper, Path: sleep, Args: []string{"30"}, OutputLimit: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mapper, err := boundary.Start(context.Background(), ProcessSpec{Role: ProcessRoleMapping, Path: sleep, Args: []string{"30"}, OutputLimit: 1024})
+	if err != nil {
+		terminateTestProcess(t, keeper)
+		t.Fatal(err)
+	}
+	namespace, err := openRecordedTestNamespaces(keeper.PID())
+	if err != nil {
+		terminateTestProcess(t, mapper)
+		terminateTestProcess(t, keeper)
+		t.Fatal(err)
+	}
+	store, err := newFileOwnershipStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := testIdentity("topology-gen-hardening")
+	lease, err := store.acquire(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := lease.Record(context.Background(), keeper, mapper, namespace); err != nil {
+		_ = lease.Release()
+		t.Fatal(err)
+	}
+	journalPath := lease.journalPath
+	if err := lease.Release(); err != nil {
+		t.Fatal(err)
+	}
+	fixture := &fileRecoveryFixture{store: store, identity: identity, namespace: namespace, keeper: keeper, mapper: mapper, journalPath: journalPath}
+	t.Cleanup(func() {
+		_ = namespace.Close()
+		terminateTestProcess(t, mapper)
+		terminateTestProcess(t, keeper)
+	})
+	return fixture
+}
+
+func (f *fileRecoveryFixture) recoveryStore(t *testing.T) RecoveryOwnershipStore {
+	t.Helper()
+	store, ok := any(f.store).(RecoveryOwnershipStore)
+	if !ok {
+		t.Fatal("file ownership store exposes no exact recovery claim")
+	}
+	return store
+}
+
+func (f *fileRecoveryFixture) rewriteJournal(t *testing.T, mutate func(map[string]any)) {
+	t.Helper()
+	payload, err := os.ReadFile(f.journalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		t.Fatal(err)
+	}
+	mutate(raw)
+	payload, err = json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writePrivateAtomic(f.journalPath, payload); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertRecoveryRejectedAndRetained(t *testing.T, fixture *fileRecoveryFixture, identity Identity, namespace *NamespaceHandle) {
+	t.Helper()
+	recovered, err := fixture.recoveryStore(t).AcquireRecovery(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+	if err == nil {
+		if recovered.Namespace != nil {
+			_ = recovered.Namespace.Close()
+		}
+		if recovered.Lease != nil {
+			_ = recovered.Lease.Release()
+		}
+		t.Fatal("unsafe recovery unexpectedly succeeded")
+	}
+	if !errors.Is(err, ErrStaleTopologyUnverified) && !errors.Is(err, ErrIdentityMismatch) && !errors.Is(err, ErrStaleGeneration) {
+		t.Fatalf("recovery error = %v, want sanitized fail-closed class", err)
+	}
+	if namespace == nil || namespace.Closed() {
+		t.Fatal("failed recovery consumed caller-owned namespace")
+	}
+	if _, statErr := os.Lstat(fixture.journalPath); statErr != nil {
+		t.Fatalf("failed recovery removed private journal: %v", statErr)
+	}
+}
+
+func TestLinuxTopologyRecoveryRejectsReleasedLockWrongNamespace(t *testing.T) {
+	fixture := newFileRecoveryFixture(t)
+	wrong := newFakeNamespaces(t, nil).base
+	if wrong.Correlates(fixture.namespace) {
+		t.Fatal("wrong-namespace fixture accidentally correlates")
+	}
+	assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, wrong)
+}
+
+func TestLinuxTopologyRecoveryRejectsBootAndProcessIdentityMismatch(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{name: "host boot", mutate: func(raw map[string]any) { raw["hostBootId"] = "00000000-0000-4000-8000-000000000000" }},
+		{name: "keeper start time", mutate: func(raw map[string]any) { raw["keeper"].(map[string]any)["startTime"] = "1" }},
+		{name: "mapper start time", mutate: func(raw map[string]any) { raw["mapper"].(map[string]any)["startTime"] = "1" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			fixture.rewriteJournal(t, test.mutate)
+			assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveryAcceptsDefinitelyAbsentHelpersWithRetainedNamespace(t *testing.T) {
+	fixture := newFileRecoveryFixture(t)
+	terminateTestProcess(t, fixture.mapper)
+	terminateTestProcess(t, fixture.keeper)
+	recovered, err := fixture.recoveryStore(t).AcquireRecovery(context.Background(), RecoveryRequest{Identity: fixture.identity, Namespace: fixture.namespace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recovered.Namespace.Close()
+	defer recovered.Lease.Release()
+	if recovered.Keeper != nil || recovered.Mapper != nil || recovered.Namespace == nil || !recovered.Namespace.Correlates(fixture.namespace) {
+		t.Fatalf("absent recovery = keeper %T mapper %T namespace %T", recovered.Keeper, recovered.Mapper, recovered.Namespace)
+	}
+}
+
+func TestLinuxTopologyRecoveryRejectsIncompleteOrAmbiguousJournal(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mutate  func(map[string]any)
+		rewrite func([]byte) []byte
+	}{
+		{name: "missing mapper", mutate: func(raw map[string]any) { delete(raw, "mapper") }},
+		{name: "mapping armed", mutate: func(raw map[string]any) {
+			raw["mappingArmed"] = true
+			raw["mappingCreator"] = raw["keeper"]
+		}},
+		{name: "malformed", rewrite: func([]byte) []byte { return []byte(`{"version":`) }},
+		{name: "duplicate key", rewrite: func(payload []byte) []byte {
+			marker := []byte(`"version":`)
+			at := bytes.Index(payload, marker)
+			if at < 0 {
+				return payload
+			}
+			end := at + len(marker)
+			for end < len(payload) && payload[end] >= '0' && payload[end] <= '9' {
+				end++
+			}
+			return append(append(append([]byte(nil), payload[:end]...), []byte(`,"version":`)...), append(payload[at+len(marker):end], payload[end:]...)...)
+		}},
+		{name: "case variant", rewrite: func(payload []byte) []byte {
+			return bytes.Replace(payload, []byte(`"version"`), []byte(`"Version"`), 1)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			if test.mutate != nil {
+				fixture.rewriteJournal(t, test.mutate)
+			} else {
+				payload, err := os.ReadFile(fixture.journalPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := writePrivateAtomic(fixture.journalPath, test.rewrite(payload)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveryRejectsStaleCompleteIdentity(t *testing.T) {
+	for _, mutate := range []func(*Identity){
+		func(identity *Identity) { identity.ExecutionID = "execution-replaced" },
+		func(identity *Identity) { identity.TopologyGenerationID = "topology-gen-replaced" },
+	} {
+		fixture := newFileRecoveryFixture(t)
+		identity := fixture.identity
+		mutate(&identity)
+		assertRecoveryRejectedAndRetained(t, fixture, identity, fixture.namespace)
+	}
+}
+
+func TestLinuxTopologyRecoveryRejectsUnsafeJournalFile(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, *fileRecoveryFixture)
+	}{
+		{name: "mode", mutate: func(t *testing.T, fixture *fileRecoveryFixture) {
+			if err := os.Chmod(fixture.journalPath, 0o640); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "symlink", mutate: func(t *testing.T, fixture *fileRecoveryFixture) {
+			payload, err := os.ReadFile(fixture.journalPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(filepath.Dir(filepath.Dir(fixture.journalPath)), "outside.json")
+			if err := os.WriteFile(target, payload, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(fixture.journalPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, fixture.journalPath); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "nonregular", mutate: func(t *testing.T, fixture *fileRecoveryFixture) {
+			if err := os.Remove(fixture.journalPath); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(fixture.journalPath, 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			test.mutate(t, fixture)
+			assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+		})
+	}
+}
+
+func TestLinuxTopologyRecoverySourceRetainsPrivateOwnerAndPIDFDGuards(t *testing.T) {
+	payload, err := os.ReadFile("ownership_linux.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(payload)
+	for _, required := range []string{
+		"AcquireRecovery", "stat.Uid != uint32(os.Geteuid())", "sysPIDFDOpen", "readProcessStartTime",
+		"recordedNamespaceMatches", "HostBootID", "DisallowUnknownFields",
+	} {
+		if !strings.Contains(text, required) {
+			t.Errorf("production recovery source lacks %q", required)
+		}
+	}
+}
+
+type serializedRecoveryStore struct {
+	base       *memoryOwnershipStore
+	entered    chan struct{}
+	release    chan struct{}
+	once       sync.Once
+	mu         sync.Mutex
+	recoveries int
+}
+
+func newSerializedRecoveryStore() *serializedRecoveryStore {
+	return &serializedRecoveryStore{base: newMemoryOwnershipStore(), entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (s *serializedRecoveryStore) Acquire(ctx context.Context, identity Identity) (OwnershipLease, error) {
+	return s.base.Acquire(ctx, identity)
+}
+
+func (s *serializedRecoveryStore) AcquireRecovery(ctx context.Context, request RecoveryRequest) (RecoveredOwnership, error) {
+	s.mu.Lock()
+	s.recoveries++
+	s.mu.Unlock()
+	s.once.Do(func() { close(s.entered) })
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return RecoveredOwnership{}, ctx.Err()
+	}
+	lease, err := s.base.Acquire(ctx, request.Identity)
+	if err != nil {
+		return RecoveredOwnership{}, err
+	}
+	namespace, err := request.Namespace.Duplicate()
+	if err != nil {
+		_ = lease.Release()
+		return RecoveredOwnership{}, err
+	}
+	return RecoveredOwnership{Lease: lease, Namespace: namespace}, nil
+}
+
+func (s *serializedRecoveryStore) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.recoveries
+}
+
+func newSerializedRecoveryLifecycle(t *testing.T, store OwnershipStore) (*Lifecycle, *NamespaceHandle) {
+	t.Helper()
+	starter := newFakeStarter()
+	namespaces := newFakeNamespaces(t, &starter.events)
+	lifecycle, err := New(Config{Enabled: true, Tools: testTools(), Starter: starter,
+		Runner: &fakeRunner{output: goodLinkJSON()}, OpenNamespaces: namespaces.Open,
+		Reachability: &fakeReachabilityProber{}, Ownership: store,
+		CleanupTimeout: 250 * time.Millisecond, InspectionTimeout: 250 * time.Millisecond,
+		InspectionInterval: time.Millisecond, OutputLimit: 8 << 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	namespace, err := namespaces.base.Duplicate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = namespace.Close() })
+	return lifecycle, namespace
+}
+
+func TestLinuxTopologySerializesStartAgainstRecovery(t *testing.T) {
+	store := newSerializedRecoveryStore()
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	identity := testIdentity("topology-gen-serialized-start")
+	recovered := make(chan error, 1)
+	go func() {
+		_, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+		recovered <- err
+	}()
+	select {
+	case <-store.entered:
+	case err := <-recovered:
+		t.Fatalf("Recover returned before ownership claim: %v", err)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Recover did not enter ownership claim")
+	}
+	started := make(chan error, 1)
+	go func() {
+		request := testRequest(identity.TopologyGenerationID)
+		_, err := lifecycle.Start(context.Background(), request)
+		started <- err
+	}()
+	select {
+	case err := <-started:
+		t.Fatalf("Start bypassed same-sandbox recovery: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(store.release)
+	if err := <-recovered; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-started; err == nil {
+		t.Fatal("Start replaced recovered cleanup authority")
+	}
+	_, _ = lifecycle.Stop(context.Background(), identity)
+}
+
+func TestLinuxTopologySerializesAndCoalescesExactRecovery(t *testing.T) {
+	store := newSerializedRecoveryStore()
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	identity := testIdentity("topology-gen-serialized-recover")
+	type result struct {
+		session *Session
+		err     error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			session, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+			results <- result{session: session, err: err}
+		}()
+	}
+	select {
+	case <-store.entered:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("Recover did not enter ownership claim")
+	}
+	close(store.release)
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil || first.session == nil || first.session != second.session {
+		t.Fatalf("coalesced recovery = (%T,%v) (%T,%v)", first.session, first.err, second.session, second.err)
+	}
+	if store.count() != 1 {
+		t.Fatalf("durable recovery claims = %d, want one", store.count())
+	}
+	_, _ = lifecycle.Stop(context.Background(), identity)
+}
+
+type typedNilRecoveryStore struct{}
+
+func (*typedNilRecoveryStore) Acquire(context.Context, Identity) (OwnershipLease, error) {
+	panic("typed-nil ownership store called")
+}
+func (*typedNilRecoveryStore) AcquireRecovery(context.Context, RecoveryRequest) (RecoveredOwnership, error) {
+	panic("typed-nil recovery store called")
+}
+
+func TestLinuxTopologyRecoverRejectsTypedNilStoreAndPreservesCallerNamespace(t *testing.T) {
+	var store *typedNilRecoveryStore
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("Recover panicked through typed-nil store: %v", recovered)
+		}
+	}()
+	if session, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: testIdentity("topology-gen-typed-nil"), Namespace: namespace}); session != nil || !errors.Is(err, ErrStaleTopologyUnverified) {
+		t.Fatalf("Recover(typed nil) = %T, %v", session, err)
+	}
+	if namespace.Closed() {
+		t.Fatal("typed-nil failure consumed caller namespace")
+	}
+}

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
@@ -10,8 +10,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -151,6 +154,140 @@ func TestLinuxTopologyRecoveryRejectsBootAndProcessIdentityMismatch(t *testing.T
 	}
 }
 
+func TestLinuxTopologyRecoveryRejectsExactZombieAndPermissionUncertainty(t *testing.T) {
+	t.Run("zombie mapper", func(t *testing.T) {
+		fixture := newFileRecoveryFixture(t)
+		zombie, start := startDeterministicZombie(t)
+		defer zombie.Wait()
+		fixture.rewriteJournal(t, func(raw map[string]any) {
+			raw["mapper"] = map[string]any{"pid": zombie.Process.Pid, "startTime": start}
+		})
+		assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+	})
+	t.Run("foreign namespace permission or mismatch", func(t *testing.T) {
+		fixture := newFileRecoveryFixture(t)
+		start, err := readProcessStartTime(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixture.rewriteJournal(t, func(raw map[string]any) {
+			raw["keeper"] = map[string]any{"pid": 1, "startTime": start}
+		})
+		assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+		if _, err := os.Stat("/proc/1"); err != nil {
+			t.Fatalf("recovery disturbed foreign process 1: %v", err)
+		}
+	})
+}
+
+func startDeterministicZombie(t *testing.T) (*exec.Cmd, string) {
+	t.Helper()
+	gateRead, gateWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("/bin/sh", "-c", "read ignored <&3")
+	command.ExtraFiles = []*os.File{gateRead}
+	if err := command.Start(); err != nil {
+		gateRead.Close()
+		gateWrite.Close()
+		t.Fatal(err)
+	}
+	gateRead.Close()
+	start, err := readProcessStartTime(command.Process.Pid)
+	if err != nil {
+		gateWrite.Close()
+		_ = command.Process.Kill()
+		_ = command.Wait()
+		t.Fatal(err)
+	}
+	if err := gateWrite.Close(); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		payload, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(command.Process.Pid), "stat"))
+		if err != nil {
+			_ = command.Wait()
+			t.Fatalf("zombie disappeared before inspection: %v", err)
+		}
+		closing := strings.LastIndexByte(string(payload), ')')
+		fields := strings.Fields(string(payload[closing+1:]))
+		if len(fields) > 0 && fields[0] == "Z" {
+			return command, start
+		}
+		if time.Now().After(deadline) {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+			t.Fatal("child did not enter zombie state")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestLinuxTopologyRecoveryProcessExitRaceNeverAuthorizesReplacement(t *testing.T) {
+	for attempt := 0; attempt < 12; attempt++ {
+		fixture := newFileRecoveryFixture(t)
+		done := make(chan struct{})
+		go func() {
+			runtime.Gosched()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			_ = fixture.mapper.Terminate(ctx)
+			cancel()
+			close(done)
+		}()
+		recovered, err := fixture.recoveryStore(t).AcquireRecovery(context.Background(), RecoveryRequest{Identity: fixture.identity, Namespace: fixture.namespace})
+		<-done
+		if err == nil {
+			if recovered.Lease == nil || recovered.Namespace == nil || !recovered.Namespace.Correlates(fixture.namespace) {
+				t.Fatalf("race recovery returned uncorrelated authority: %#v", recovered)
+			}
+			_ = recovered.Namespace.Close()
+			_ = recovered.Lease.Release()
+		} else if !errors.Is(err, ErrStaleTopologyUnverified) && !errors.Is(err, ErrIdentityMismatch) {
+			t.Fatalf("race recovery leaked unstable outcome: %v", err)
+		}
+		if fixture.namespace.Closed() {
+			t.Fatal("race recovery consumed caller namespace")
+		}
+	}
+}
+
+func TestLinuxTopologyRecoveryClosesEveryFailedClaimHandle(t *testing.T) {
+	fixture := newFileRecoveryFixture(t)
+	wrong := newFakeNamespaces(t, nil).base
+	before := countOpenFileDescriptors(t)
+	for range 32 {
+		recovered, err := fixture.recoveryStore(t).AcquireRecovery(context.Background(), RecoveryRequest{Identity: fixture.identity, Namespace: wrong})
+		if err == nil {
+			if recovered.Namespace != nil {
+				_ = recovered.Namespace.Close()
+			}
+			if recovered.Lease != nil {
+				_ = recovered.Lease.Release()
+			}
+			t.Fatal("wrong namespace recovery succeeded")
+		}
+	}
+	runtime.GC()
+	after := countOpenFileDescriptors(t)
+	if after > before {
+		t.Fatalf("failed recovery leaked descriptors: before=%d after=%d", before, after)
+	}
+	if _, err := syscall.Getpgid(os.Getpid()); err != nil {
+		t.Fatalf("process state changed during handle-close matrix: %v", err)
+	}
+}
+
+func countOpenFileDescriptors(t *testing.T) int {
+	t.Helper()
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return len(entries)
+}
+
 func TestLinuxTopologyRecoveryAcceptsDefinitelyAbsentHelpersWithRetainedNamespace(t *testing.T) {
 	fixture := newFileRecoveryFixture(t)
 	terminateTestProcess(t, fixture.mapper)
@@ -163,6 +300,96 @@ func TestLinuxTopologyRecoveryAcceptsDefinitelyAbsentHelpersWithRetainedNamespac
 	defer recovered.Lease.Release()
 	if recovered.Keeper != nil || recovered.Mapper != nil || recovered.Namespace == nil || !recovered.Namespace.Correlates(fixture.namespace) {
 		t.Fatalf("absent recovery = keeper %T mapper %T namespace %T", recovered.Keeper, recovered.Mapper, recovered.Namespace)
+	}
+}
+
+func TestLinuxTopologyFreshLifecycleRecoverStopProductionStoreMatrix(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		stopKeeper bool
+		stopMapper bool
+		wantKeeper bool
+		wantMapper bool
+	}{
+		{name: "live", wantKeeper: true, wantMapper: true},
+		{name: "partial keeper only", stopMapper: true, wantKeeper: true},
+		{name: "partial mapper only", stopKeeper: true, wantMapper: true},
+		{name: "absent", stopKeeper: true, stopMapper: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			keeperPID, mapperPID := fixture.keeper.PID(), fixture.mapper.PID()
+			if test.stopKeeper {
+				terminateTestProcess(t, fixture.keeper)
+			}
+			if test.stopMapper {
+				terminateTestProcess(t, fixture.mapper)
+			}
+			lifecycle, _ := newSerializedRecoveryLifecycle(t, fixture.store)
+			session, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: fixture.identity, Namespace: fixture.namespace})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (session.keeper != nil) != test.wantKeeper || (session.mapper != nil) != test.wantMapper {
+				t.Fatalf("recovered processes = keeper %T mapper %T", session.keeper, session.mapper)
+			}
+			metadata := session.Metadata()
+			if metadata.Status != StatusRecoveryOnly || metadata.StructuralInspected || metadata.MappingReachable {
+				t.Fatalf("recovered metadata = %#v", metadata)
+			}
+			owned := session.namespace
+			stopped, err := lifecycle.Stop(context.Background(), fixture.identity)
+			if err != nil || stopped.Status != StatusStopped {
+				t.Fatalf("Stop(recovered) = %#v, %v", stopped, err)
+			}
+			if owned == nil || !owned.Closed() {
+				t.Fatal("Stop did not close lifecycle-owned namespace duplicate")
+			}
+			if fixture.namespace.Closed() {
+				t.Fatal("Stop consumed supervisor-owned namespace authority")
+			}
+			assertProcessPathAbsent(t, keeperPID)
+			assertProcessPathAbsent(t, mapperPID)
+			if _, err := os.Lstat(fixture.journalPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("ownership journal remains after Stop: %v", err)
+			}
+			retired := filepath.Join(filepath.Dir(fixture.journalPath), "retired-"+fixture.identity.TopologyGenerationID)
+			if info, err := os.Lstat(retired); err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+				t.Fatalf("retirement tombstone = %#v, %v", info, err)
+			}
+			if lease, err := fixture.store.acquire(context.Background(), fixture.identity); lease != nil || !errors.Is(err, ErrStaleGeneration) {
+				t.Fatalf("retired generation claim = %T, %v", lease, err)
+			}
+			fresh := fixture.identity
+			fresh.ExecutionID = "execution-after-recovery"
+			fresh.ProxyGenerationID = "proxy-generation-after-recovery"
+			fresh.TopologyGenerationID = "topology-gen-after-recovery"
+			lease, err := fixture.store.acquire(context.Background(), fresh)
+			if err != nil {
+				t.Fatalf("ownership lock remained held: %v", err)
+			}
+			if err := lease.Release(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func assertProcessPathAbsent(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, err := os.Stat(filepath.Join("/proc", fmtInt(pid)))
+		if errors.Is(err, os.ErrNotExist) {
+			return
+		}
+		if err != nil {
+			t.Fatalf("inspect process %d: %v", pid, err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process %d remained after recovered Stop", pid)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -213,15 +440,135 @@ func TestLinuxTopologyRecoveryRejectsIncompleteOrAmbiguousJournal(t *testing.T) 
 }
 
 func TestLinuxTopologyRecoveryRejectsStaleCompleteIdentity(t *testing.T) {
-	for _, mutate := range []func(*Identity){
-		func(identity *Identity) { identity.ExecutionID = "execution-replaced" },
-		func(identity *Identity) { identity.TopologyGenerationID = "topology-gen-replaced" },
+	for _, test := range []struct {
+		name   string
+		mutate func(*Identity)
+	}{
+		{name: "sandbox", mutate: func(identity *Identity) { identity.SandboxID = "sandbox-replaced" }},
+		{name: "execution", mutate: func(identity *Identity) { identity.ExecutionID = "execution-replaced" }},
+		{name: "worker", mutate: func(identity *Identity) { identity.WorkerID = "worker-replaced" }},
+		{name: "runtime", mutate: func(identity *Identity) { identity.RuntimeID = "runtime-replaced" }},
+		{name: "plan", mutate: func(identity *Identity) { identity.PlanID = "plan-replaced" }},
+		{name: "policy", mutate: func(identity *Identity) { identity.PolicySnapshotID = "policy-replaced" }},
+		{name: "proxy session", mutate: func(identity *Identity) { identity.ProxySessionID = "proxy-session-replaced" }},
+		{name: "proxy generation", mutate: func(identity *Identity) { identity.ProxyGenerationID = "proxy-generation-replaced" }},
+		{name: "topology generation", mutate: func(identity *Identity) { identity.TopologyGenerationID = "topology-gen-replaced" }},
 	} {
-		fixture := newFileRecoveryFixture(t)
-		identity := fixture.identity
-		mutate(&identity)
-		assertRecoveryRejectedAndRetained(t, fixture, identity, fixture.namespace)
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			identity := fixture.identity
+			test.mutate(&identity)
+			assertRecoveryRejectedAndRetained(t, fixture, identity, fixture.namespace)
+		})
 	}
+}
+
+func TestLinuxTopologyRecoveryRejectsIndependentUserOrNetworkNamespaceMismatch(t *testing.T) {
+	for _, mismatch := range []string{"user", "network"} {
+		t.Run(mismatch, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			user, err := os.Open(filepath.Join("/proc", fmtInt(fixture.keeper.PID()), "ns", "user"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			network, err := os.Open(filepath.Join("/proc", fmtInt(fixture.keeper.PID()), "ns", "net"))
+			if err != nil {
+				user.Close()
+				t.Fatal(err)
+			}
+			wrong, err := os.CreateTemp(t.TempDir(), mismatch+"-mismatch-")
+			if err != nil {
+				user.Close()
+				network.Close()
+				t.Fatal(err)
+			}
+			if mismatch == "user" {
+				user.Close()
+				user = wrong
+			} else {
+				network.Close()
+				network = wrong
+			}
+			handle, err := NewNamespaceHandle(user, network)
+			if err != nil {
+				user.Close()
+				network.Close()
+				t.Fatal(err)
+			}
+			defer handle.Close()
+			assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, handle)
+		})
+	}
+}
+
+func TestLinuxTopologyRecoveryStrictJournalFieldMatrix(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		mutate  func(map[string]any)
+		rewrite func([]byte) []byte
+	}{
+		{name: "missing version", mutate: func(raw map[string]any) { delete(raw, "version") }},
+		{name: "missing boot", mutate: func(raw map[string]any) { delete(raw, "hostBootId") }},
+		{name: "missing identity", mutate: func(raw map[string]any) { delete(raw, "identity") }},
+		{name: "missing keeper", mutate: func(raw map[string]any) { delete(raw, "keeper") }},
+		{name: "missing mapper", mutate: func(raw map[string]any) { delete(raw, "mapper") }},
+		{name: "missing namespace", mutate: func(raw map[string]any) { delete(raw, "namespace") }},
+		{name: "unknown top level", mutate: func(raw map[string]any) { raw["endpoint"] = "private.example" }},
+		{name: "unknown identity", mutate: func(raw map[string]any) { raw["identity"].(map[string]any)["pid"] = 42 }},
+		{name: "unknown keeper", mutate: func(raw map[string]any) { raw["keeper"].(map[string]any)["path"] = "/private" }},
+		{name: "unknown namespace", mutate: func(raw map[string]any) { raw["namespace"].(map[string]any)["fd"] = 9 }},
+		{name: "stray creator", mutate: func(raw map[string]any) { raw["mappingCreator"] = raw["keeper"] }},
+		{name: "trailing object", rewrite: func(payload []byte) []byte { return append(payload, []byte(`{}`)...) }},
+		{name: "nested duplicate keeper pid", rewrite: func(payload []byte) []byte { return duplicateFirstJSONField(payload, "pid") }},
+		{name: "nested duplicate identity", rewrite: func(payload []byte) []byte { return duplicateFirstJSONField(payload, "sandboxId") }},
+		{name: "nested case variant", rewrite: func(payload []byte) []byte {
+			return bytes.Replace(payload, []byte(`"startTime"`), []byte(`"StartTime"`), 1)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			if test.mutate != nil {
+				fixture.rewriteJournal(t, test.mutate)
+			} else {
+				payload, err := os.ReadFile(fixture.journalPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := writePrivateAtomic(fixture.journalPath, test.rewrite(payload)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+		})
+	}
+}
+
+func duplicateFirstJSONField(payload []byte, field string) []byte {
+	marker := []byte(`"` + field + `":`)
+	at := bytes.Index(payload, marker)
+	if at < 0 {
+		return payload
+	}
+	valueStart := at + len(marker)
+	valueEnd := valueStart
+	if valueEnd < len(payload) && payload[valueEnd] == '"' {
+		valueEnd++
+		for valueEnd < len(payload) && payload[valueEnd] != '"' {
+			valueEnd++
+		}
+		if valueEnd < len(payload) {
+			valueEnd++
+		}
+	} else {
+		for valueEnd < len(payload) && payload[valueEnd] >= '0' && payload[valueEnd] <= '9' {
+			valueEnd++
+		}
+	}
+	duplicate := append(append([]byte(nil), marker...), payload[valueStart:valueEnd]...)
+	result := append([]byte(nil), payload[:valueEnd]...)
+	result = append(result, ',')
+	result = append(result, duplicate...)
+	return append(result, payload[valueEnd:]...)
 }
 
 func TestLinuxTopologyRecoveryRejectsUnsafeJournalFile(t *testing.T) {
@@ -258,6 +605,12 @@ func TestLinuxTopologyRecoveryRejectsUnsafeJournalFile(t *testing.T) {
 				t.Fatal(err)
 			}
 		}},
+		{name: "multiple links", mutate: func(t *testing.T, fixture *fileRecoveryFixture) {
+			outside := filepath.Join(filepath.Dir(filepath.Dir(fixture.journalPath)), "journal-hardlink")
+			if err := os.Link(fixture.journalPath, outside); err != nil {
+				t.Fatal(err)
+			}
+		}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			fixture := newFileRecoveryFixture(t)
@@ -267,6 +620,45 @@ func TestLinuxTopologyRecoveryRejectsUnsafeJournalFile(t *testing.T) {
 	}
 }
 
+func TestLinuxTopologyRecoveryRejectsRootAndSandboxAncestorReplacement(t *testing.T) {
+	for _, ancestor := range []string{"root", "sandbox"} {
+		t.Run(ancestor, func(t *testing.T) {
+			fixture := newFileRecoveryFixture(t)
+			var path string
+			if ancestor == "root" {
+				path = fixture.store.root
+			} else {
+				path = filepath.Dir(fixture.journalPath)
+			}
+			real := path + "-replaced"
+			if err := os.Rename(path, real); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(real, path); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				_ = os.Remove(path)
+				_ = os.Rename(real, path)
+			})
+			assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+		})
+	}
+	t.Run("fresh store through root symlink", func(t *testing.T) {
+		fixture := newFileRecoveryFixture(t)
+		link := fixture.store.root + "-link"
+		if err := os.Symlink(fixture.store.root, link); err != nil {
+			t.Fatal(err)
+		}
+		store, err := newFileOwnershipStore(link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixture.store = store
+		assertRecoveryRejectedAndRetained(t, fixture, fixture.identity, fixture.namespace)
+	})
+}
+
 func TestLinuxTopologyRecoverySourceRetainsPrivateOwnerAndPIDFDGuards(t *testing.T) {
 	payload, err := os.ReadFile("ownership_linux.go")
 	if err != nil {
@@ -274,8 +666,8 @@ func TestLinuxTopologyRecoverySourceRetainsPrivateOwnerAndPIDFDGuards(t *testing
 	}
 	text := string(payload)
 	for _, required := range []string{
-		"AcquireRecovery", "stat.Uid != uint32(os.Geteuid())", "sysPIDFDOpen", "readProcessStartTime",
-		"recordedNamespaceMatches", "HostBootID", "DisallowUnknownFields",
+		"AcquireRecovery", "stat.Uid != uint32(os.Geteuid())", "stat.Nlink != 1", "syscall.O_NOFOLLOW",
+		"sysPIDFDOpen", "readProcessStartTime", "recordedNamespaceMatches", "HostBootID", "DisallowUnknownFields",
 	} {
 		if !strings.Contains(text, required) {
 			t.Errorf("production recovery source lacks %q", required)
@@ -284,12 +676,13 @@ func TestLinuxTopologyRecoverySourceRetainsPrivateOwnerAndPIDFDGuards(t *testing
 }
 
 type serializedRecoveryStore struct {
-	base       *memoryOwnershipStore
-	entered    chan struct{}
-	release    chan struct{}
-	once       sync.Once
-	mu         sync.Mutex
-	recoveries int
+	base           *memoryOwnershipStore
+	entered        chan struct{}
+	release        chan struct{}
+	once           sync.Once
+	mu             sync.Mutex
+	recoveries     int
+	blockedSandbox string
 }
 
 func newSerializedRecoveryStore() *serializedRecoveryStore {
@@ -304,11 +697,13 @@ func (s *serializedRecoveryStore) AcquireRecovery(ctx context.Context, request R
 	s.mu.Lock()
 	s.recoveries++
 	s.mu.Unlock()
-	s.once.Do(func() { close(s.entered) })
-	select {
-	case <-s.release:
-	case <-ctx.Done():
-		return RecoveredOwnership{}, ctx.Err()
+	if s.blockedSandbox == "" || s.blockedSandbox == request.Identity.SandboxID {
+		s.once.Do(func() { close(s.entered) })
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return RecoveredOwnership{}, ctx.Err()
+		}
 	}
 	lease, err := s.base.Acquire(ctx, request.Identity)
 	if err != nil {
@@ -320,6 +715,29 @@ func (s *serializedRecoveryStore) AcquireRecovery(ctx context.Context, request R
 		return RecoveredOwnership{}, err
 	}
 	return RecoveredOwnership{Lease: lease, Namespace: namespace}, nil
+}
+
+func TestLinuxTopologyStartFirstRejectsRecoveryWithoutClaim(t *testing.T) {
+	store := newSerializedRecoveryStore()
+	close(store.release)
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	request := testRequest("topology-gen-start-first-recovery")
+	started, err := lifecycle.Start(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: request.Identity, Namespace: namespace}); recovered != nil || err == nil {
+		t.Fatalf("Recover(after Start) = %T, %v", recovered, err)
+	}
+	if store.count() != 0 {
+		t.Fatalf("Recover after live Start reached durable recovery store %d times", store.count())
+	}
+	if namespace.Closed() {
+		t.Fatal("Recover after Start consumed caller namespace")
+	}
+	if _, err := lifecycle.Stop(context.Background(), started.identity); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func (s *serializedRecoveryStore) count() int {
@@ -412,6 +830,110 @@ func TestLinuxTopologySerializesAndCoalescesExactRecovery(t *testing.T) {
 	}
 	if store.count() != 1 {
 		t.Fatalf("durable recovery claims = %d, want one", store.count())
+	}
+	_, _ = lifecycle.Stop(context.Background(), identity)
+}
+
+func TestLinuxTopologyRecoveryNeverCoalescesMismatchedIdentityOrNamespace(t *testing.T) {
+	store := newSerializedRecoveryStore()
+	close(store.release)
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	identity := testIdentity("topology-gen-no-unsafe-coalesce")
+	first, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongIdentity := identity
+	wrongIdentity.ExecutionID = "execution-no-coalesce"
+	wrongNamespace := newFakeNamespaces(t, nil).base
+	for _, request := range []RecoveryRequest{
+		{Identity: wrongIdentity, Namespace: namespace},
+		{Identity: identity, Namespace: wrongNamespace},
+	} {
+		if session, err := lifecycle.Recover(context.Background(), request); session != nil || err == nil {
+			t.Fatalf("unsafe coalesced Recover = %T, %v", session, err)
+		}
+		if request.Namespace.Closed() {
+			t.Fatal("noncoalesced recovery consumed caller namespace")
+		}
+	}
+	if store.count() != 1 {
+		t.Fatalf("mismatched recovery reached store: claims=%d", store.count())
+	}
+	if first.Metadata().Status != StatusRecoveryOnly {
+		t.Fatalf("first recovery metadata changed: %#v", first.Metadata())
+	}
+	_, _ = lifecycle.Stop(context.Background(), identity)
+}
+
+func TestLinuxTopologyRecoveryDoesNotBlockIndependentSandbox(t *testing.T) {
+	firstIdentity := testIdentity("topology-gen-independent-recovery-a")
+	firstIdentity.SandboxID = "sandbox-recovery-a"
+	store := newSerializedRecoveryStore()
+	store.blockedSandbox = firstIdentity.SandboxID
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: firstIdentity, Namespace: namespace})
+		firstResult <- err
+	}()
+	select {
+	case <-store.entered:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("first recovery did not block at ownership claim")
+	}
+	secondIdentity := testIdentity("topology-gen-independent-recovery-b")
+	secondIdentity.SandboxID = "sandbox-recovery-b"
+	secondIdentity.ExecutionID = "execution-recovery-b"
+	secondIdentity.ProxyGenerationID = "proxy-generation-recovery-b"
+	second, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: secondIdentity, Namespace: namespace})
+	if err != nil || second == nil {
+		close(store.release)
+		t.Fatalf("independent recovery = %T, %v", second, err)
+	}
+	close(store.release)
+	if err := <-firstResult; err != nil {
+		t.Fatal(err)
+	}
+	_, _ = lifecycle.Stop(context.Background(), firstIdentity)
+	_, _ = lifecycle.Stop(context.Background(), secondIdentity)
+}
+
+func TestLinuxTopologyCanceledRecoveryWaiterCannotCoalesce(t *testing.T) {
+	store := newSerializedRecoveryStore()
+	lifecycle, namespace := newSerializedRecoveryLifecycle(t, store)
+	identity := testIdentity("topology-gen-canceled-waiter")
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := lifecycle.Recover(context.Background(), RecoveryRequest{Identity: identity, Namespace: namespace})
+		firstResult <- err
+	}()
+	select {
+	case <-store.entered:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("first recovery did not enter claim")
+	}
+	waiterContext, cancel := context.WithCancel(context.Background())
+	waiterResult := make(chan error, 1)
+	go func() {
+		_, err := lifecycle.Recover(waiterContext, RecoveryRequest{Identity: identity, Namespace: namespace})
+		waiterResult <- err
+	}()
+	cancel()
+	close(store.release)
+	if err := <-firstResult; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-waiterResult:
+		if err == nil {
+			t.Fatal("canceled recovery waiter coalesced live authority")
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("canceled recovery waiter remained blocked")
+	}
+	if namespace.Closed() {
+		t.Fatal("canceled waiter consumed caller namespace")
 	}
 	_, _ = lifecycle.Stop(context.Background(), identity)
 }

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
@@ -225,6 +225,29 @@ func TestRecoveredProcessClosesOwnedDescriptorZero(t *testing.T) {
 	}
 }
 
+func TestRecordedProcessSnapshotAllowsLiveStateTransition(t *testing.T) {
+	for _, test := range []struct {
+		name                 string
+		beforeStart          string
+		beforeState          byte
+		afterStart           string
+		afterState           byte
+		wantExactLiveProcess bool
+	}{
+		{name: "sleeping to runnable", beforeStart: "41", beforeState: 'S', afterStart: "41", afterState: 'R', wantExactLiveProcess: true},
+		{name: "runnable to sleeping", beforeStart: "41", beforeState: 'R', afterStart: "41", afterState: 'S', wantExactLiveProcess: true},
+		{name: "pid reused", beforeStart: "41", beforeState: 'S', afterStart: "42", afterState: 'S'},
+		{name: "became zombie", beforeStart: "41", beforeState: 'S', afterStart: "41", afterState: 'Z'},
+		{name: "was zombie", beforeStart: "41", beforeState: 'Z', afterStart: "41", afterState: 'S'},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := recordedProcessSnapshotsMatch(test.beforeStart, test.beforeState, test.afterStart, test.afterState); got != test.wantExactLiveProcess {
+				t.Fatalf("recordedProcessSnapshotsMatch() = %t, want %t", got, test.wantExactLiveProcess)
+			}
+		})
+	}
+}
+
 func TestLinuxTopologyRecoveryRejectsExactZombieAndPermissionUncertainty(t *testing.T) {
 	t.Run("zombie mapper", func(t *testing.T) {
 		fixture := newFileRecoveryFixture(t)

--- a/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
+++ b/internal/sandboxruntime/networkenforcement/linuxtopology/recovery_store_hardening_red_test.go
@@ -154,6 +154,77 @@ func TestLinuxTopologyRecoveryRejectsBootAndProcessIdentityMismatch(t *testing.T
 	}
 }
 
+func TestLinuxTopologyReconcileRejectsCrossBootJournalBeforeCleanup(t *testing.T) {
+	fixture := newFileRecoveryFixture(t)
+	fixture.rewriteJournal(t, func(raw map[string]any) {
+		raw["hostBootId"] = "00000000-0000-4000-8000-000000000000"
+	})
+
+	replacement := fixture.identity
+	replacement.ExecutionID = "execution-cross-boot-reconcile"
+	replacement.ProxyGenerationID = "proxy-generation-cross-boot-reconcile"
+	replacement.TopologyGenerationID = "topology-generation-cross-boot-reconcile"
+	lease, err := fixture.store.acquire(context.Background(), replacement)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Release()
+
+	if err := lease.Reconcile(context.Background()); !errors.Is(err, ErrStaleTopologyUnverified) {
+		t.Fatalf("Reconcile(cross-boot journal) = %v, want fail-closed", err)
+	}
+	if processDone(fixture.keeper) || processDone(fixture.mapper) {
+		t.Fatal("cross-boot journal authorized process cleanup")
+	}
+}
+
+func TestRecoveredProcessClosesOwnedDescriptorZero(t *testing.T) {
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command(sleep, "30")
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	}()
+	start, err := readProcessStartTime(command.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	backup, err := syscall.Dup(0)
+	if err != nil {
+		t.Skipf("stdin is unavailable for descriptor-zero ownership test: %v", err)
+	}
+	defer syscall.Close(backup)
+	defer func() {
+		if err := syscall.Dup2(backup, 0); err != nil {
+			t.Errorf("restore stdin: %v", err)
+		}
+	}()
+	if err := syscall.Close(0); err != nil {
+		t.Fatal(err)
+	}
+
+	handle, err := claimRecordedProcess(privateProcessRecord{PID: command.Process.Pid, StartTime: start}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovered, ok := handle.(*recoveredProcess)
+	if !ok || recovered.pidfd != 0 {
+		t.Fatalf("recovered process = %T pidfd=%d, want owned descriptor zero", handle, recovered.pidfd)
+	}
+	recovered.closePIDFD()
+	var stat syscall.Stat_t
+	if err := syscall.Fstat(0, &stat); !errors.Is(err, syscall.EBADF) {
+		t.Fatalf("owned pidfd zero remained open: %v", err)
+	}
+}
+
 func TestLinuxTopologyRecoveryRejectsExactZombieAndPermissionUncertainty(t *testing.T) {
 	t.Run("zombie mapper", func(t *testing.T) {
 		fixture := newFileRecoveryFixture(t)


### PR DESCRIPTION
## Summary

Stacked on `feature/sandbox-runtime-secure-default-v2` (`058e727f`) / working PR https://github.com/j-yw/hal/pull/37.

GREEN for restart-safe L7 cleanup recovery. Independent Grok review of the RED tip (`3d5ba549`) was **fix-then-merge** because `Lifecycle.Recover` / `LinuxRecoveryTopology.Recover` were fail-closed stubs. This successor implements recovery under proved ownership only.

Does not implement L8 credential recovery. Does not claim L10/L11.

## Scope

- Cleanup-only `Recover` (`status=recovery_only`, no prepared proof)
- File ownership store `AcquireRecovery` (boot/process/namespace correlation)
- Adapter duplicates caller namespace, closes provider transfer, including error/panic/reused-handle
- Reconciler recovery metadata matcher no longer treats prepared proof as recovery authority

## Tests

```
go test ./internal/sandboxruntime/networkenforcement/linuxtopology/
go test ./internal/sandboxruntime/microvm/firecrackerhost/l7network/
```

## Queue

Do not merge to `develop`. Codex review should wait until PR https://github.com/j-yw/hal/pull/38 is idle (tmux `c` is already on that loop). Also queued behind https://github.com/j-yw/hal/pull/39.