### PR TITLE
feat: implement L8 runtime-owner supervisor

### DIFF
--- a/cmd/hal-firecracker-runtime-owner/main.go
+++ b/cmd/hal-firecracker-runtime-owner/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost"
+)
+
+func main() {
+	os.Exit(firecrackerhost.RunPrivateL8RuntimeOwnerExecutable(os.Args[1:], os.NewFile))
+}

--- a/cmd/l8_d6_runtime_owner_contract_test.go
+++ b/cmd/l8_d6_runtime_owner_contract_test.go
@@ -60,6 +60,11 @@ const l8D6RuntimeOwnerRecordDocBlock = `type firecrackerRuntimeOwnerRecordV1 str
 	ContractVersion              string ` + "`json:\"contractVersion\"`" + `
 	Revision                     uint64 ` + "`json:\"revision\"`" + `
 	State                        string ` + "`json:\"state\"`" + `
+	ControllerState              string ` + "`json:\"controllerState\"`" + `
+	AbsenceKind                  string ` + "`json:\"absenceKind\"`" + `
+	AbsenceRevision              uint64 ` + "`json:\"absenceRevision\"`" + `
+	AbsenceObservedAtUnixNano    int64 ` + "`json:\"absenceObservedAtUnixNano\"`" + `
+	FinalizeTargetRevision       uint64 ` + "`json:\"finalizeTargetRevision\"`" + `
 	HostBootID                   string ` + "`json:\"hostBootId\"`" + `
 	SeedCorrelationDigest        string ` + "`json:\"seedCorrelationDigest\"`" + `
 	SupervisorGeneration         string ` + "`json:\"supervisorGeneration\"`" + `

--- a/cmd/l8_d6_runtime_owner_supervisor_contract_test.go
+++ b/cmd/l8_d6_runtime_owner_supervisor_contract_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"path/filepath"
 	"strings"
@@ -15,6 +18,7 @@ const l8D6RuntimeOwnerSupervisorProtocolDocBlock = `const (
 	l8RuntimeOwnerPacketLimit = 512
 	l8RuntimeOwnerHandshakeTimeout = 5 * time.Second
 
+	l8RuntimeOwnerOpcodeReject uint16 = 0
 	l8RuntimeOwnerOpcodeBootstrapStart uint16 = 1
 	l8RuntimeOwnerOpcodeBootstrapPublished uint16 = 2
 	l8RuntimeOwnerOpcodeChildArmed uint16 = 3
@@ -60,6 +64,8 @@ func validateL8D6RuntimeOwnerSupervisorContract(doc string) error {
 		"The default-off owner executable is exactly `hal-firecracker-runtime-owner`", "`supervise` and `child-gate`",
 		"bootstrap `SOCK_SEQPACKET` socket as fd 3", "owner directory as fd 4",
 		"configuration memfd as fd 5", "fd 6 then fd 7 in kernel-then-rootfs order",
+		"Fd 8 is an already-open read-only handle to the stable owner-root",
+		"`O_RDONLY|O_CLOEXEC|O_NOFOLLOW`", "read exactly 32 bytes by `pread`",
 		"user-namespace, network-namespace, kernel, and rootfs order",
 		"`[resolved-binary-path, \"supervise\"]`", "`[resolved-binary-path, \"child-gate\"]`",
 		"user, network, kernel, and rootfs sources from fds 5, 6, 7, and 8",
@@ -73,7 +79,9 @@ func validateL8D6RuntimeOwnerSupervisorContract(doc string) error {
 		"byte-identical body plus fresh duplicates", "current one-use secret in that order",
 		"`SO_PEERCRED`", "direct-child `Wait`", "double-`/proc` absence",
 		"No packet transports an absence proof", "Finalize is accepted only",
+		"atomically persists `finalizing`", "only then persists `finalized`",
 		"Commit is accepted only for `finalized`", "Controller Close is distinct",
+		"requires its observed parent PID to be exactly one",
 		"stable owner-root HMAC key is not a per-runtime artifact",
 		"Non-Linux builds return exit code 127 before reading an inherited descriptor",
 	} {
@@ -106,9 +114,14 @@ func TestL8D6RuntimeOwnerSupervisorContractMutationGuards(t *testing.T) {
 }
 
 func TestL8D6RuntimeOwnerSupervisorExecutableIsIsolated(t *testing.T) {
-	want := filepath.ToSlash(filepath.Join("hal-firecracker-runtime-owner", "main.go"))
+	allowed := map[string]bool{
+		filepath.ToSlash(filepath.Join("cmd", "hal-firecracker-runtime-owner", "main.go")):                                            true,
+		filepath.ToSlash(filepath.Join("internal", "sandboxruntime", "microvm", "firecrackerhost", "l8_runtime_owner_executable.go")): true,
+	}
 	uses := 0
-	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+	declarations := 0
+	calls := 0
+	err := filepath.WalkDir("..", func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -116,10 +129,45 @@ func TestL8D6RuntimeOwnerSupervisorExecutableIsIsolated(t *testing.T) {
 			return nil
 		}
 		source := readL8CredentialDeliveryFile(t, path)
+		parsed, parseErr := parser.ParseFile(token.NewFileSet(), path, source, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		relative, relErr := filepath.Rel("..", path)
+		if relErr != nil {
+			return relErr
+		}
+		relative = filepath.ToSlash(relative)
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			switch value := node.(type) {
+			case *ast.FuncDecl:
+				if value.Name.Name == "RunPrivateL8RuntimeOwnerExecutable" {
+					declarations++
+					if relative != filepath.ToSlash(filepath.Join("internal", "sandboxruntime", "microvm", "firecrackerhost", "l8_runtime_owner_executable.go")) {
+						t.Errorf("private owner executable declaration in %s", relative)
+					}
+				}
+			case *ast.CallExpr:
+				name := ""
+				switch called := value.Fun.(type) {
+				case *ast.Ident:
+					name = called.Name
+				case *ast.SelectorExpr:
+					name = called.Sel.Name
+				}
+				if name == "RunPrivateL8RuntimeOwnerExecutable" {
+					calls++
+					if relative != filepath.ToSlash(filepath.Join("cmd", "hal-firecracker-runtime-owner", "main.go")) {
+						t.Errorf("private owner executable called from %s", relative)
+					}
+				}
+			}
+			return true
+		})
 		if strings.Contains(source, "RunPrivateL8RuntimeOwnerExecutable") {
 			uses++
-			if filepath.ToSlash(path) != want {
-				t.Errorf("private owner executable wired from %s", filepath.ToSlash(path))
+			if !allowed[relative] {
+				t.Errorf("private owner executable wired from %s", relative)
 			}
 		}
 		return nil
@@ -127,7 +175,10 @@ func TestL8D6RuntimeOwnerSupervisorExecutableIsIsolated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uses != 1 {
-		t.Fatalf("private owner executable entrypoint uses = %d, want 1", uses)
+	if uses != 2 {
+		t.Fatalf("private owner executable production references = %d, want 2", uses)
+	}
+	if declarations != 1 || calls != 1 {
+		t.Fatalf("private owner executable AST declarations/calls = %d/%d, want 1/1", declarations, calls)
 	}
 }

--- a/cmd/l8_d6_runtime_owner_supervisor_contract_test.go
+++ b/cmd/l8_d6_runtime_owner_supervisor_contract_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const l8D6RuntimeOwnerSupervisorProtocolDocBlock = `const (
+	l8RuntimeOwnerProtocolMagic = "HL8OWNR1"
+	l8RuntimeOwnerProtocolVersion uint16 = 1
+	l8RuntimeOwnerPacketHeaderSize = 24
+	l8RuntimeOwnerPacketLimit = 512
+	l8RuntimeOwnerHandshakeTimeout = 5 * time.Second
+
+	l8RuntimeOwnerOpcodeBootstrapStart uint16 = 1
+	l8RuntimeOwnerOpcodeBootstrapPublished uint16 = 2
+	l8RuntimeOwnerOpcodeChildArmed uint16 = 3
+	l8RuntimeOwnerOpcodeChildRelease uint16 = 4
+	l8RuntimeOwnerOpcodeHandshake uint16 = 5
+	l8RuntimeOwnerOpcodeAbortStart uint16 = 6
+	l8RuntimeOwnerOpcodeInspect uint16 = 7
+	l8RuntimeOwnerOpcodeStopReap uint16 = 8
+	l8RuntimeOwnerOpcodeAcquireNamespaces uint16 = 9
+	l8RuntimeOwnerOpcodeFinalize uint16 = 10
+	l8RuntimeOwnerOpcodeCommit uint16 = 11
+	l8RuntimeOwnerOpcodeClose uint16 = 12
+
+	l8RuntimeOwnerStatusOK uint16 = 0
+	l8RuntimeOwnerStatusRejected uint16 = 1
+	l8RuntimeOwnerStatusInvalidState uint16 = 2
+	l8RuntimeOwnerStatusUncertain uint16 = 3
+	l8RuntimeOwnerStatusUnsupported uint16 = 4
+)
+
+type l8RuntimeOwnerPacketHeaderV1 struct {
+	Magic [8]byte
+	Version uint16
+	Opcode uint16
+	Status uint16
+	BodyLength uint16
+	Sequence uint64
+}`
+
+func TestL8D6RuntimeOwnerSupervisorContractIsExact(t *testing.T) {
+	doc := readL8CredentialDeliveryFile(t, filepath.Join("..", "docs", "design", l8CredentialArchitectureDoc))
+	if err := validateL8D6RuntimeOwnerSupervisorContract(doc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateL8D6RuntimeOwnerSupervisorContract(doc string) error {
+	if strings.Count(doc, "```go\n"+l8D6RuntimeOwnerSupervisorProtocolDocBlock+"\n```") != 1 {
+		return fmt.Errorf("L8 D6 runtime-owner supervisor protocol block is not exact")
+	}
+	normalized := strings.Join(strings.Fields(doc), " ")
+	for _, marker := range []string{
+		"The default-off owner executable is exactly `hal-firecracker-runtime-owner`", "`supervise` and `child-gate`",
+		"bootstrap `SOCK_SEQPACKET` socket as fd 3", "owner directory as fd 4",
+		"configuration memfd as fd 5", "fd 6 then fd 7 in kernel-then-rootfs order",
+		"user-namespace, network-namespace, kernel, and rootfs order",
+		"`[resolved-binary-path, \"supervise\"]`", "`[resolved-binary-path, \"child-gate\"]`",
+		"user, network, kernel, and rootfs sources from fds 5, 6, 7, and 8",
+		"collision-free private `F_DUPFD_CLOEXEC` temporaries at fd 9 or higher",
+		"maps those temporaries to fds 3, 4, 5, and 6 with `dup3`",
+		"exact namespace wrapper through `execve`",
+		"`F_SEAL_SEAL|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_WRITE`",
+		"regular anonymous zero-link descriptors with `FD_CLOEXEC`",
+		"exactly two `SCM_RIGHTS` descriptors in user-then-network order",
+		"`NSFS_MAGIC`", "sets `FD_CLOEXEC`", "sequence starts at one",
+		"byte-identical body plus fresh duplicates", "current one-use secret in that order",
+		"`SO_PEERCRED`", "direct-child `Wait`", "double-`/proc` absence",
+		"No packet transports an absence proof", "Finalize is accepted only",
+		"Commit is accepted only for `finalized`", "Controller Close is distinct",
+		"stable owner-root HMAC key is not a per-runtime artifact",
+		"Non-Linux builds return exit code 127 before reading an inherited descriptor",
+	} {
+		if !strings.Contains(normalized, marker) {
+			return fmt.Errorf("L8 D6 supervisor contract omits %q", marker)
+		}
+	}
+	return nil
+}
+
+func TestL8D6RuntimeOwnerSupervisorContractMutationGuards(t *testing.T) {
+	doc := readL8CredentialDeliveryFile(t, filepath.Join("..", "docs", "design", l8CredentialArchitectureDoc))
+	for _, mutation := range []struct{ name, before, after string }{
+		{"stream socket", "daemon bootstrap\n`SOCK_SEQPACKET` socket as fd 3", "daemon bootstrap stream socket as fd 3"},
+		{"namespace order", "user-then-network order", "network-then-user order"},
+		{"reusable secret", "current one-use secret in\nthat order", "current reusable secret in that order"},
+		{"proof packet", "No packet transports an absence proof", "A packet may transport an absence proof"},
+		{"close implies finalization", "Controller Close is distinct", "Controller Close finalizes the runtime"},
+		{"default command", "The default-off owner executable is exactly", "The default-wired owner executable is exactly"},
+	} {
+		t.Run(mutation.name, func(t *testing.T) {
+			if strings.Count(doc, mutation.before) == 0 {
+				t.Fatalf("missing mutation source %q", mutation.before)
+			}
+			if err := validateL8D6RuntimeOwnerSupervisorContract(strings.ReplaceAll(doc, mutation.before, mutation.after)); err == nil {
+				t.Fatal("weakened supervisor contract passed")
+			}
+		})
+	}
+}
+
+func TestL8D6RuntimeOwnerSupervisorExecutableIsIsolated(t *testing.T) {
+	want := filepath.ToSlash(filepath.Join("hal-firecracker-runtime-owner", "main.go"))
+	uses := 0
+	err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		source := readL8CredentialDeliveryFile(t, path)
+		if strings.Contains(source, "RunPrivateL8RuntimeOwnerExecutable") {
+			uses++
+			if filepath.ToSlash(path) != want {
+				t.Errorf("private owner executable wired from %s", filepath.ToSlash(path))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uses != 1 {
+		t.Fatalf("private owner executable entrypoint uses = %d, want 1", uses)
+	}
+}

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -240,17 +240,18 @@ finalized revision rather than trusting a caller-supplied expected token.
 
 ## R2 supervisor/bootstrap/reconnect prerequisite
 
-The R2 RED contract freezes only the explicit default-off `hal-firecracker-runtime-owner`
-executable, its strict sealed configuration and inherited-fd ABI, the bounded
-private `SOCK_SEQPACKET` codec, namespace-fd retention/transfer, the durable
-owner transition/CAS machinery, and direct-parent plus replacement-owner
-containment primitives. It does not construct the executable from a default
-runtime, publish an absence proof, implement the neutral recovery provider,
-perform L7 recovery/finalization, persist a worker receipt, or wire command,
-worker, sandboxd, factory, or profile selection.
+R2 implements the explicit default-off `hal-firecracker-runtime-owner`
+executable over its strict sealed configuration and inherited-fd ABI, the
+bounded private `SOCK_SEQPACKET` codec, namespace-fd retention/transfer, the
+durable owner transition/CAS machinery, and direct-parent containment. The
+Linux executable callbacks construct the private record store and reconnect
+listener, execute the frozen bootstrap/controller FSM, and use the child gate
+to arm parent-death containment before the namespace-wrapper `execve`. No
+default runtime constructs this executable. R2 does not publish an absence
+proof, implement the neutral recovery provider, perform L7 recovery, persist a
+worker receipt, or wire worker, sandboxd, factory, or profile selection.
 
-The causal RED selector is expected to fail until the reviewed GREEN
-implementation exists; the command guard is expected to pass:
+The causal and command selectors pass on the reviewed GREEN implementation:
 
 ```bash
 go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner'

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -240,7 +240,7 @@ finalized revision rather than trusting a caller-supplied expected token.
 
 ## R2 supervisor/bootstrap/reconnect prerequisite
 
-R2 adds only the explicit default-off `hal-firecracker-runtime-owner`
+The R2 RED contract freezes only the explicit default-off `hal-firecracker-runtime-owner`
 executable, its strict sealed configuration and inherited-fd ABI, the bounded
 private `SOCK_SEQPACKET` codec, namespace-fd retention/transfer, the durable
 owner transition/CAS machinery, and direct-parent plus replacement-owner
@@ -249,13 +249,14 @@ runtime, publish an absence proof, implement the neutral recovery provider,
 perform L7 recovery/finalization, persist a worker receipt, or wire command,
 worker, sandboxd, factory, or profile selection.
 
-Focused fake-safe verification is:
+The causal RED selector is expected to fail until the reviewed GREEN
+implementation exists; the command guard is expected to pass:
 
 ```bash
-go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner(Protocol|Transition|CommitUncertain|Containment|SupervisorConfig|Seqpacket|NamespaceTransfer|Executable|Process|Replacement)'
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner'
 go test ./cmd -run '^TestL8D6RuntimeOwnerSupervisor'
-go test -count=20 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner(Protocol|Transition|CommitUncertain|Containment|SupervisorConfig|Seqpacket|NamespaceTransfer|Executable|Process|Replacement)'
-go test -race -count=5 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner(Protocol|Transition|CommitUncertain|Containment|SupervisorConfig|Seqpacket|NamespaceTransfer|Executable|Process|Replacement)'
+go test -count=20 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner'
+go test -race -count=5 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner'
 ```
 
 The standalone executable is compiled on Linux and cross-compiled on a

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -237,3 +237,30 @@ PID. A zero observation owns no file descriptor. The HMAC fixed vector locks
 raw key-generation and seed-digest bytes after the two length-prefixed strings,
 and commit validation recomputes that HMAC from the stable key, full seed, and
 finalized revision rather than trusting a caller-supplied expected token.
+
+## R2 supervisor/bootstrap/reconnect prerequisite
+
+R2 adds only the explicit default-off `hal-firecracker-runtime-owner`
+executable, its strict sealed configuration and inherited-fd ABI, the bounded
+private `SOCK_SEQPACKET` codec, namespace-fd retention/transfer, the durable
+owner transition/CAS machinery, and direct-parent plus replacement-owner
+containment primitives. It does not construct the executable from a default
+runtime, publish an absence proof, implement the neutral recovery provider,
+perform L7 recovery/finalization, persist a worker receipt, or wire command,
+worker, sandboxd, factory, or profile selection.
+
+Focused fake-safe verification is:
+
+```bash
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner(Protocol|Transition|CommitUncertain|Containment|SupervisorConfig|Seqpacket|NamespaceTransfer|Executable|Process|Replacement)'
+go test ./cmd -run '^TestL8D6RuntimeOwnerSupervisor'
+go test -count=20 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner(Protocol|Transition|CommitUncertain|Containment|SupervisorConfig|Seqpacket|NamespaceTransfer|Executable|Process|Replacement)'
+go test -race -count=5 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner(Protocol|Transition|CommitUncertain|Containment|SupervisorConfig|Seqpacket|NamespaceTransfer|Executable|Process|Replacement)'
+```
+
+The standalone executable is compiled on Linux and cross-compiled on a
+non-Linux target. Linux tests use only local socketpairs, sealed memfds,
+namespace descriptor duplication, and direct child processes; they require no
+KVM, Firecracker binary, network access, cloud account, guest image, worker, or
+daemon. The production absence-proof constructor call count remains zero until
+the later provider/L7 integration slice.

--- a/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
+++ b/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
@@ -924,7 +924,7 @@ and rejects any mismatch; the safe L7 subset alone is never sufficient
 authority.
 `AbsenceKind`, `AbsenceRevision`, and `AbsenceObservedAtUnixNano` are zero in
 `starting`, `running`, and `stopping`. An `absent`, `finalizing`, or `finalized`
-record carries exactly `direct_wait` or `replacement_proc_absence`, binds
+record carries exactly `direct_wait` or `replacement_proc`, binds
 `AbsenceRevision` to the revision at which that fresh observation was
 persisted, and carries a positive signed Unix-nanosecond observation no earlier
 than the seed. Repeated StopReap against `absent` must reobserve exact absence
@@ -1219,8 +1219,9 @@ Its request body is the 43-byte controller-session generation, the eight-byte
 absence record revision, and the signed eight-byte Unix-nanosecond observation
 that must equal the supervisor's private fresh absence observation. It is sent
 only after the daemon-side binding has validated the neutral absence proof and
-completed correlated same-boot L7 cleanup. The supervisor closes both retained
-namespace originals, persists `finalized` with the HMAC commit ID, and returns
+completed correlated same-boot L7 cleanup. The supervisor first persists
+`finalizing` with the HMAC commit ID and exact target revision, closes both
+retained namespace originals, then persists `finalized`, and returns
 exactly that 43-byte commit ID plus the eight-byte finalized revision. Failure
 to close either namespace descriptor or persist the record returns uncertain
 and retains the record; it never reports finalized.

--- a/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
+++ b/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
@@ -1008,6 +1008,164 @@ state and control boundary.
 
 ### Reconnect and replay state machine
 
+The default-off owner executable is exactly
+`hal-firecracker-runtime-owner`. It accepts no flags or environment-derived
+configuration and has exactly two private modes: `supervise` and `child-gate`.
+The complete argv is exactly `[resolved-binary-path, "supervise"]` or
+`[resolved-binary-path, "child-gate"]`; empty, extra, repeated, or alternate
+arguments fail closed.
+The supervisor mode receives an already-connected daemon bootstrap
+`SOCK_SEQPACKET` socket as fd 3, the pinned mode-`0700` owner directory as fd
+4, a sealed bounded supervisor configuration memfd as fd 5, and exactly two
+sealed launch-asset descriptors as fd 6 then fd 7 in kernel-then-rootfs order.
+The supervisor owns those descriptors before acknowledging bootstrap and
+retains them until it has either transferred duplicates into the child or
+completed bounded abort containment. The child-gate
+mode receives its supervisor gate `SOCK_SEQPACKET` socket as fd 3, the same
+sealed configuration memfd as fd 4, and the exact Firecracker inherited
+descriptors starting at fd 5 in user-namespace, network-namespace, kernel, and
+rootfs order. Every other inherited
+descriptor is closed before entering either mode. The supervisor configuration
+is at most 32 KiB, strictly decoded, contains the complete validated seed plus
+the clean absolute namespace-wrapper and Firecracker executable paths, exact
+arguments, and the fixed inherited-descriptor count of two, and is
+never durable or projected. The executable path is clean and absolute, the
+environment is exactly empty, and the helper replaces itself with the exact
+namespace wrapper through `execve` only after the release gate. Its argv is
+exactly `nsenter --preserve-credentials --keep-caps --user=/proc/self/fd/3
+--net=/proc/self/fd/4 -- firecracker` followed by the validated Firecracker
+arguments. The child first duplicates its inherited user, network, kernel, and
+rootfs sources from fds 5, 6, 7, and 8 to four collision-free private
+`F_DUPFD_CLOEXEC` temporaries at fd 9 or higher. It then maps those temporaries
+to fds 3, 4, 5, and 6 with `dup3`, closes the temporaries plus the old gate,
+configuration, and source descriptors, clears close-on-exec only on 3 through
+6, and closes every descriptor above 6 before `execve`. It never overwrites fd
+3 or fd 4 before the gate/config reads complete and never maps in-place across
+an as-yet-unduplicated source. Non-Linux builds return exit code
+127 before reading an inherited descriptor. Configuration and asset memfds are
+regular anonymous zero-link descriptors with `FD_CLOEXEC`; the configuration memfd
+requires exactly `F_SEAL_SEAL|F_SEAL_SHRINK|F_SEAL_GROW|F_SEAL_WRITE`. Kernel
+and rootfs asset descriptors require those four seals, read-only access,
+distinct device/inode identity, and exact identity/digest correlation supplied
+by the validated live launch lease. A wrong type, seal, access mode,
+descriptor identity, order, count, or correlation closes every accepted
+duplicate and fails before revision-zero publication.
+
+The private wire ABI is big-endian and exact:
+
+```go
+const (
+	l8RuntimeOwnerProtocolMagic = "HL8OWNR1"
+	l8RuntimeOwnerProtocolVersion uint16 = 1
+	l8RuntimeOwnerPacketHeaderSize = 24
+	l8RuntimeOwnerPacketLimit = 512
+	l8RuntimeOwnerHandshakeTimeout = 5 * time.Second
+
+	l8RuntimeOwnerOpcodeBootstrapStart uint16 = 1
+	l8RuntimeOwnerOpcodeBootstrapPublished uint16 = 2
+	l8RuntimeOwnerOpcodeChildArmed uint16 = 3
+	l8RuntimeOwnerOpcodeChildRelease uint16 = 4
+	l8RuntimeOwnerOpcodeHandshake uint16 = 5
+	l8RuntimeOwnerOpcodeAbortStart uint16 = 6
+	l8RuntimeOwnerOpcodeInspect uint16 = 7
+	l8RuntimeOwnerOpcodeStopReap uint16 = 8
+	l8RuntimeOwnerOpcodeAcquireNamespaces uint16 = 9
+	l8RuntimeOwnerOpcodeFinalize uint16 = 10
+	l8RuntimeOwnerOpcodeCommit uint16 = 11
+	l8RuntimeOwnerOpcodeClose uint16 = 12
+
+	l8RuntimeOwnerStatusOK uint16 = 0
+	l8RuntimeOwnerStatusRejected uint16 = 1
+	l8RuntimeOwnerStatusInvalidState uint16 = 2
+	l8RuntimeOwnerStatusUncertain uint16 = 3
+	l8RuntimeOwnerStatusUnsupported uint16 = 4
+)
+
+type l8RuntimeOwnerPacketHeaderV1 struct {
+	Magic [8]byte
+	Version uint16
+	Opcode uint16
+	Status uint16
+	BodyLength uint16
+	Sequence uint64
+}
+```
+
+Every packet is one complete `SOCK_SEQPACKET` datagram. Truncation,
+`MSG_TRUNC`, `MSG_CTRUNC`, a packet longer than 512 bytes, a noncanonical
+header, an unknown opcode/status, a nonzero request status, an unexpected
+sequence, or a body whose exact length does not match its opcode is rejected.
+The 24-byte header is the eight ASCII magic bytes, version, opcode, status,
+body length, and sequence in that order. There are no padding or reserved
+bytes. A rejected authentication or malformed packet receives the same empty
+body with `StatusRejected`; field-specific diagnostics never cross the socket.
+
+The bootstrap-start packet has sequence zero and a 32-byte body of four
+big-endian uint64 values: user-namespace device, user-namespace inode,
+network-namespace device, and network-namespace inode. It carries exactly two
+`SCM_RIGHTS` descriptors in user-then-network order. The supervisor requires
+both descriptors to be `NSFS_MAGIC` namespace files and to match the supplied
+device/inode correlation, sets `FD_CLOEXEC`, and retains them before it forks
+the child. Missing, duplicate, extra, reordered, non-namespace, or mismatched
+descriptors close every received descriptor and fail publication. The
+bootstrap-published reply has sequence zero and exactly an eight-byte durable
+record revision. Child-armed and child-release packets have sequence zero,
+empty bodies, and no rights.
+
+The handshake packet has sequence zero. Its body is the exact 43-byte
+supervisor generation, a two-byte runtime-generation length followed by one to
+128 validated safe-ID bytes, an eight-byte record revision, and the exact
+43-byte reconnect secret. The successful response body is the new 43-byte
+controller-session generation followed by the new eight-byte controlled
+record revision. `AbortStart` is accepted only before ordinary controller
+admission and otherwise uses the request shape below.
+
+Every authenticated controller request body is exactly its 43-byte
+controller-session generation. Its header sequence starts at one. Successful
+inspect, abort-start, stop/reap, and close responses have an exact 24-byte body:
+one owner-state byte, one absence-kind byte, six zero bytes, the record
+revision, and a signed Unix-nanosecond observation encoded in an eight-byte
+two's-complement field. Observation and absence kind are nonzero only for an
+exact `absent` stop/reap result. Acquire-namespaces has the same 24-byte body
+with zero observation fields and carries exactly two freshly duplicated
+`SCM_RIGHTS` descriptors in user-then-network order. Its immediate replay
+returns the byte-identical body plus fresh duplicates of the same retained
+handles; this is an idempotent read, not a transfer of ownership from the
+supervisor. Send failure closes only the duplicates. The supervisor retains
+the originals through daemon restart, Firecracker absence, and same-boot
+Finalize; supervisor loss makes namespace recovery uncertain. All receive,
+validation, replay, controller-loss, and rejection paths close unaccepted or
+created descriptors exactly once.
+
+The exact state-byte mapping is `starting=1`, `unclaimed=2`, `controlled=3`,
+`stopping=4`, `absent=5`, `finalized=6`, and `uncertain=7`. Absence kind is
+zero for none, one for direct-child `Wait`, and two for replacement-owner
+double-`/proc` absence. No packet transports an absence proof.
+
+Finalize and commit remain protocol-complete even before their L7 caller is
+wired. Finalize is accepted only on the authenticated controller after an
+Acquire-namespaces response and only while the exact durable state is `absent`.
+Its request body is the 43-byte controller-session generation, the eight-byte
+absence record revision, and the signed eight-byte Unix-nanosecond observation
+that must equal the supervisor's private fresh absence observation. It is sent
+only after the daemon-side binding has validated the neutral absence proof and
+completed correlated same-boot L7 cleanup. The supervisor closes both retained
+namespace originals, persists `finalized` with the HMAC commit ID, and returns
+exactly that 43-byte commit ID plus the eight-byte finalized revision. Failure
+to close either namespace descriptor or persist the record returns uncertain
+and retains the record; it never reports finalized.
+
+Commit is accepted only for `finalized`. Its request body is the 43-byte
+controller-session generation, the exact 43-byte commit ID, and the eight-byte
+finalized revision. The supervisor verifies the owner-root HMAC, atomically
+retires the per-runtime owner record, closes and removes its reconnect socket,
+acknowledges success, and exits. The stable owner-root HMAC key is not a
+per-runtime artifact and is not removed by this request. A response-loss replay
+with record absent is authenticated by that stable key and is idempotent.
+Controller Close is distinct: it has only the 43-byte session body, rotates to
+`unclaimed`, and never closes namespace originals, retires owner state, or
+implies process/L7 absence.
+
 The reconnect transport is a private Linux Unix `SOCK_SEQPACKET` listener. The
 supervisor first obtains peer credentials and requires the exact daemon service
 UID through same-UID `SO_PEERCRED`; request fields cannot supply or override the

--- a/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
+++ b/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
@@ -874,6 +874,11 @@ type firecrackerRuntimeOwnerRecordV1 struct {
 	ContractVersion              string `json:"contractVersion"`
 	Revision                     uint64 `json:"revision"`
 	State                        string `json:"state"`
+	ControllerState              string `json:"controllerState"`
+	AbsenceKind                  string `json:"absenceKind"`
+	AbsenceRevision              uint64 `json:"absenceRevision"`
+	AbsenceObservedAtUnixNano    int64 `json:"absenceObservedAtUnixNano"`
+	FinalizeTargetRevision       uint64 `json:"finalizeTargetRevision"`
 	HostBootID                   string `json:"hostBootId"`
 	SeedCorrelationDigest        string `json:"seedCorrelationDigest"`
 	SupervisorGeneration         string `json:"supervisorGeneration"`
@@ -902,18 +907,41 @@ type firecrackerRuntimeOwnerRecordV1 struct {
 }
 ```
 
-`ContractVersion` is exactly `firecracker-runtime-owner-private-v1`. `State` is
-exactly one of `starting`, `unclaimed`, `controlled`, `stopping`, `absent`,
-`finalized`, or `uncertain`. `HostBootID` is the exact lowercase canonical UUID read from
+`ContractVersion` is exactly `firecracker-runtime-owner-private-v1`. Lifecycle
+`State` is exactly one of `starting`, `running`, `stopping`, `absent`,
+`finalizing`, `finalized`, or `uncertain`. `ControllerState` is independently
+exactly one of `none`, `unclaimed`, or `controlled`. Revision-zero and
+revision-one `starting` use `none`; publication changes lifecycle to `running`
+and controller state to `unclaimed`. Handshake, EOF, and Close rotate only
+`ControllerState` plus the one-use secret and preserve lifecycle `State`,
+including while `stopping`, `absent`, `uncertain`, `finalizing`, or `finalized`.
+A controller claim is never process-liveness authority. `HostBootID` is the exact lowercase canonical UUID read from
 `/proc/sys/kernel/random/boot_id` through a bounded no-symlink Linux reader.
 `SeedCorrelationDigest` is the exact private lowercase-hex digest defined for
 the absence token. Before binding, reconnect, signal, absence inspection, or
 cleanup, the owner recomputes it from every `JobCredentialIdentitySeed` field
 and rejects any mismatch; the safe L7 subset alone is never sufficient
 authority.
-`FinalizedCommitID` is empty in every state except `finalized`. The transition
-to `finalized` computes it from the exact target revision and persists the
-state, target revision, and commit ID atomically before returning the same
+`AbsenceKind`, `AbsenceRevision`, and `AbsenceObservedAtUnixNano` are zero in
+`starting`, `running`, and `stopping`. An `absent`, `finalizing`, or `finalized`
+record carries exactly `direct_wait` or `replacement_proc_absence`, binds
+`AbsenceRevision` to the revision at which that fresh observation was
+persisted, and carries a positive signed Unix-nanosecond observation no earlier
+than the seed. Repeated StopReap against `absent` must reobserve exact absence
+and persist a new `absent` revision/time before reissuing it; it never returns a
+cached stale observation. `uncertain` may retain the last complete absence
+tuple only as non-authoritative history and may move to `absent` only after a
+new exact direct Wait or double-`/proc` observation.
+
+`FinalizedCommitID` and `FinalizeTargetRevision` are empty/zero outside
+`finalizing` and `finalized`. After correlated L7 cleanup, Finalize computes the
+commit ID for the exact target revision, atomically persists `finalizing` with
+that ID and target first, then closes the retained namespace originals, and
+only then persists `finalized` at the exact target revision. Restart from
+`finalizing` verifies the HMAC and completed L7-cleanup intent, treats lost
+supervisor-owned namespace descriptors as closed, and retries only the final
+transition; it never returns a receipt from the intent record. The transition
+to `finalized` persists the state, target revision, and commit ID before returning the same
 `CommitID` and `FinalizedRevision` in the worker receipt. A finalized record
 with an empty, malformed, or recomputation-mismatched commit ID is uncertain.
 Supervisor PID/start identity is always nonzero. Firecracker PID and start time
@@ -984,7 +1012,8 @@ revision-one `starting` record, and only then releases the child's pre-exec gate
 and sends the publication acknowledgement. The revision-one `starting` record is durable before Firecracker publication or acknowledgement.
 No backend handle, readiness bridge,
 worker reference, or status is published before that acknowledgement. The
-supervisor atomically changes the record to `unclaimed` before admitting the
+supervisor atomically changes lifecycle to `running` and controller state to
+`unclaimed` before admitting the
 ordinary reconnect controller.
 
 Bootstrap pipe, daemon controller, supervisor, child-armed acknowledgement, record-write, child-gate, or
@@ -992,15 +1021,21 @@ acknowledgement loss before durable publication requires the supervisor to
 TERM/KILL and `Wait` the child under the shared bounded containment path, write
 `absent` if possible, close the bootstrap channel, and exit. It cannot leave an
 unrecorded surviving supervisor or child. `AbortStart` is the only recovery
-command accepted for a `starting` record: an exact live supervisor proves it
-never forked the child or kills and waits that child before replying. A new
-owner encountering revision-zero `starting` verifies the exact supervisor and
-either commands `AbortStart` or, after proving that supervisor absent, accepts
-only the start-gate/Pdeathsig proof that no Firecracker exec could survive. A
-revision-one `starting` record additionally requires exact recorded-child pidfd
-absence or successful supervisor abort. It never launches, publishes, adopts,
-or replaces a runtime from `starting`. Any uncertain gate, supervisor, child,
-or record observation retains the record and quarantine.
+command accepted for a `starting` record. For revision zero, the exact live
+supervisor must prove from its serialized bootstrap FSM that it has not forked
+the child and that the start-gate packet was not consumed; while holding the
+owner lock it then closes retained namespace/assets, unlinks the exact genesis
+record, syncs the directory, acknowledges retirement, and exits. Directory
+sync uncertainty receives no acknowledgement and retains quarantine. A new
+owner may request this causal retirement from that exact supervisor, but an
+absent supervisor plus revision zero is not enough: no unrecorded PID is
+available to inspect, so replacement retains the record rather than fabricating
+never-launched absence. For revision one, AbortStart first persists `stopping`
+at revision two, then TERM/KILL/Waits the exact child and persists `absent` with
+fresh direct-Wait evidence at revision three before replying. It never jumps
+revision-one `starting` directly to `absent`, launches, publishes, adopts, or
+replaces a runtime from `starting`. Any uncertain gate, supervisor, child,
+record-unlink, or record observation retains quarantine.
 
 No PID, start time, host boot ID, listener identity, secret, record pathname,
 live descriptor, bootstrap capability, or raw capability leaves this owner-only
@@ -1018,13 +1053,24 @@ The supervisor mode receives an already-connected daemon bootstrap
 `SOCK_SEQPACKET` socket as fd 3, the pinned mode-`0700` owner directory as fd
 4, a sealed bounded supervisor configuration memfd as fd 5, and exactly two
 sealed launch-asset descriptors as fd 6 then fd 7 in kernel-then-rootfs order.
+Fd 8 is an already-open read-only handle to the stable owner-root
+`receipt-hmac.key`. Before supervisor launch the daemon opens the pinned owner
+root component-by-component with `openat` plus `O_NOFOLLOW`, then opens that
+exact basename relative to the pinned root with
+`O_RDONLY|O_CLOEXEC|O_NOFOLLOW`. Both daemon and supervisor require a regular
+mode-`0600`, current-service-UID, single-link file, read exactly 32 bytes by
+`pread`, and reject size change, replacement, wrong inode identity, or any
+read/close uncertainty. The key is never named in argv/config, sent through a
+packet, or inherited by child-gate/Firecracker. Missing or invalid fd 8 fails
+before revision-zero creation; the supervisor never creates or replaces the
+stable key.
 The supervisor owns those descriptors before acknowledging bootstrap and
 retains them until it has either transferred duplicates into the child or
 completed bounded abort containment. The child-gate
 mode receives its supervisor gate `SOCK_SEQPACKET` socket as fd 3, the same
 sealed configuration memfd as fd 4, and the exact Firecracker inherited
 descriptors starting at fd 5 in user-namespace, network-namespace, kernel, and
-rootfs order. Every other inherited
+rootfs order. Child-gate has no key descriptor. Every other inherited
 descriptor is closed before entering either mode. The supervisor configuration
 is at most 32 KiB, strictly decoded, contains the complete validated seed plus
 the clean absolute namespace-wrapper and Firecracker executable paths, exact
@@ -1061,6 +1107,7 @@ const (
 	l8RuntimeOwnerPacketLimit = 512
 	l8RuntimeOwnerHandshakeTimeout = 5 * time.Second
 
+	l8RuntimeOwnerOpcodeReject uint16 = 0
 	l8RuntimeOwnerOpcodeBootstrapStart uint16 = 1
 	l8RuntimeOwnerOpcodeBootstrapPublished uint16 = 2
 	l8RuntimeOwnerOpcodeChildArmed uint16 = 3
@@ -1099,6 +1146,28 @@ The 24-byte header is the eight ASCII magic bytes, version, opcode, status,
 body length, and sequence in that order. There are no padding or reserved
 bytes. A rejected authentication or malformed packet receives the same empty
 body with `StatusRejected`; field-specific diagnostics never cross the socket.
+Opcode zero is response-only generic Reject: status rejected, sequence zero,
+empty body, and no rights. For a structurally valid authenticated request, an
+invalid-state, uncertain, or unsupported response echoes its opcode and
+sequence, carries the corresponding nonzero status, and has empty body/no
+rights. No request may carry nonzero status and no successful response may use
+an unlisted body or rights role.
+
+The complete role matrix is exact: BootstrapStart request `(seq=0,body=32,rights=2)`;
+BootstrapPublished response `(seq=0,body=8,rights=0)`; ChildArmed request and
+ChildRelease response `(seq=0,body=0,rights=0)`; Handshake request
+`(seq=0,body=97..224,rights=0)` and response `(seq=0,body=51,rights=0)`;
+AbortStart, Inspect, StopReap, AcquireNamespaces, and Close requests
+`(seq>=1,body=43,rights=0)`; AbortStart, Inspect, StopReap, and Close successful
+responses `(same seq,body=24,rights=0)`; AcquireNamespaces successful response
+`(same seq,body=24,rights=2)`; Finalize request `(seq>=1,body=59,rights=0)` and
+response `(same seq,body=51,rights=0)`; Commit request
+`(seq>=1,body=94,rights=0)` and response `(same seq,body=8,rights=0)`. The role
+validator is applied before body decoding or descriptor adoption. Rights on
+any other role, missing rights on a rights-bearing role, multiple control
+messages, non-`SCM_RIGHTS` control data, and any received descriptor count
+other than the exact role count are rejected and all received descriptors are
+closed.
 
 The bootstrap-start packet has sequence zero and a 32-byte body of four
 big-endian uint64 values: user-namespace device, user-namespace inode,
@@ -1116,7 +1185,7 @@ The handshake packet has sequence zero. Its body is the exact 43-byte
 supervisor generation, a two-byte runtime-generation length followed by one to
 128 validated safe-ID bytes, an eight-byte record revision, and the exact
 43-byte reconnect secret. The successful response body is the new 43-byte
-controller-session generation followed by the new eight-byte controlled
+controller-session generation followed by the new eight-byte controller-claim
 record revision. `AbortStart` is accepted only before ordinary controller
 admission and otherwise uses the request shape below.
 
@@ -1137,8 +1206,9 @@ Finalize; supervisor loss makes namespace recovery uncertain. All receive,
 validation, replay, controller-loss, and rejection paths close unaccepted or
 created descriptors exactly once.
 
-The exact state-byte mapping is `starting=1`, `unclaimed=2`, `controlled=3`,
-`stopping=4`, `absent=5`, `finalized=6`, and `uncertain=7`. Absence kind is
+The exact lifecycle state-byte mapping is `starting=1`, `running=2`,
+`stopping=3`, `absent=4`, `finalizing=5`, `finalized=6`, and `uncertain=7`.
+Controller state is not encoded in the 24-byte lifecycle response. Absence kind is
 zero for none, one for direct-child `Wait`, and two for replacement-owner
 double-`/proc` absence. No packet transports an absence proof.
 
@@ -1162,8 +1232,8 @@ retires the per-runtime owner record, closes and removes its reconnect socket,
 acknowledges success, and exits. The stable owner-root HMAC key is not a
 per-runtime artifact and is not removed by this request. A response-loss replay
 with record absent is authenticated by that stable key and is idempotent.
-Controller Close is distinct: it has only the 43-byte session body, rotates to
-`unclaimed`, and never closes namespace originals, retires owner state, or
+Controller Close is distinct: it has only the 43-byte session body, rotates
+controller state to `unclaimed` without changing lifecycle, and never closes namespace originals, retires owner state, or
 implies process/L7 absence.
 
 The reconnect transport is a private Linux Unix `SOCK_SEQPACKET` listener. The
@@ -1178,14 +1248,15 @@ does not disclose which field failed.
 
 At most one handshake and exactly one live controller are admitted. Before
 acknowledging a successful handshake, the supervisor generates a new one-use
-secret, atomically persists the next `controlled` revision, invalidates the old
+secret, atomically persists the next lifecycle-preserving controller
+`controlled` revision, invalidates the old
 secret, and binds a new random controller-session generation to that
 connection. If persistence fails, it sends no success and the prior record
 is reconciled under the commit-uncertain rule above. If success persistence completed but the acknowledgement is
 lost, the daemon must reread the record and reconnect with the replacement
 secret; replaying the consumed secret always fails. EOF or authenticated
-controller close changes `controlled` to `unclaimed` with another atomic secret
-rotation while leaving the Firecracker child owned and running.
+controller close changes only controller state from `controlled` to `unclaimed`
+with another atomic secret rotation while leaving lifecycle unchanged.
 
 Controller requests carry the controller-session generation and an unsigned
 64-bit sequence starting at one. Exactly one request may be outstanding. The
@@ -1194,9 +1265,11 @@ returns the byte-identical cached sanitized response without repeating its
 side effect; older, skipped, wrapped, cross-session, or concurrently outstanding
 sequences fail closed. A lost connection never transfers a response cache to a
 new session. New-session inspection and stop/reap are idempotent against the
-durable owner FSM, so recovery resumes from `unclaimed`, `stopping`, `absent`,
-or `uncertain` without replaying an unproved transition. No request can move
-`uncertain` back to running or `absent` back to live.
+durable owner FSM, so recovery resumes from lifecycle `running`, `stopping`,
+`absent`, `uncertain`, `finalizing`, or `finalized` without replaying an
+unproved transition. Admission never changes lifecycle. No request can move
+`uncertain` to `absent` without a new exact absence observation or move
+`absent` back to live.
 
 ### Stop, reap, supervisor loss, and L7 cleanup
 
@@ -1235,7 +1308,10 @@ supervisor and Firecracker PIDs, compares each pinned process's exact proc start
 time with the record, and reinspects after every signal or poll. An exact
 surviving supervisor is reconnected, never replaced. If the recorded supervisor
 is absent and the exact recorded Firecracker incarnation remains, the
-replacement sends SIGKILL through that pidfd and waits for pidfd terminal
+replacement additionally requires its observed parent PID to be exactly one.
+This slice does not assume or authorize an unrecorded subreaper; any other
+parent after exact supervisor absence is a replacement/mismatch and remains
+uncertain without signalling. The replacement sends SIGKILL through that pidfd and waits for pidfd terminal
 readiness. Readiness alone, including a zombie, never proves reap. Replacement
 may record externally reaped absence only after the exact `/proc/<pid>` entry
 is absent in two inspections separated by the acquisition barrier; it does not

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
@@ -94,7 +94,8 @@ func encodeL8RuntimeOwnerSupervisorConfig(config l8RuntimeOwnerSupervisorConfigV
 }
 
 func decodeL8RuntimeOwnerSupervisorConfig(payload []byte) (l8RuntimeOwnerSupervisorConfigV1, error) {
-	if len(payload) == 0 || len(payload) > l8RuntimeOwnerSupervisorConfigLimit || !l8RuntimeOwnerJSONNoDuplicateKeys(payload) {
+	if len(payload) == 0 || len(payload) > l8RuntimeOwnerSupervisorConfigLimit || !l8RuntimeOwnerJSONNoDuplicateKeys(payload) ||
+		!l8RuntimeOwnerSupervisorConfigJSONExact(payload) {
 		return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
 	}
 	decoder := json.NewDecoder(bytes.NewReader(payload))
@@ -104,6 +105,38 @@ func decodeL8RuntimeOwnerSupervisorConfig(payload []byte) (l8RuntimeOwnerSupervi
 		return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
 	}
 	return config, nil
+}
+
+func l8RuntimeOwnerSupervisorConfigJSONExact(payload []byte) bool {
+	var object map[string]json.RawMessage
+	if json.Unmarshal(payload, &object) != nil || len(object) != 9 {
+		return false
+	}
+	stringFields := []string{"contractVersion", "namespaceWrapperExecutable", "firecrackerExecutable"}
+	for _, name := range stringFields {
+		var value string
+		if raw, ok := object[name]; !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) || json.Unmarshal(raw, &value) != nil {
+			return false
+		}
+	}
+	var daemonUID uint32
+	if raw, ok := object["daemonUid"]; !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) || json.Unmarshal(raw, &daemonUID) != nil {
+		return false
+	}
+	var inherited uint16
+	if raw, ok := object["inheritedDescriptorCount"]; !ok || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) || json.Unmarshal(raw, &inherited) != nil {
+		return false
+	}
+	for _, name := range []string{"seed", "kernel", "rootfs"} {
+		raw, ok := object[name]
+		trimmed := bytes.TrimSpace(raw)
+		if !ok || len(trimmed) < 2 || trimmed[0] != '{' || trimmed[len(trimmed)-1] != '}' {
+			return false
+		}
+	}
+	raw, ok := object["firecrackerArguments"]
+	trimmed := bytes.TrimSpace(raw)
+	return ok && len(trimmed) >= 2 && trimmed[0] == '[' && trimmed[len(trimmed)-1] == ']'
 }
 
 func runPrivateL8RuntimeOwnerExecutableWithOps(arguments []string, ops l8RuntimeOwnerExecutableOps) int {
@@ -172,11 +205,32 @@ func remapAndExecL8RuntimeOwnerChild(config l8RuntimeOwnerSupervisorConfigV1, so
 	if err := validateL8RuntimeOwnerSupervisorConfig(config); err != nil {
 		return errL8RuntimeOwnerInvalid
 	}
-	var temps [4]int
+	temps := [4]int{-1, -1, -1, -1}
+	defer func() {
+		for _, temporary := range temps {
+			if temporary >= 0 {
+				_ = ops.Close(temporary)
+			}
+		}
+	}()
 	for index, source := range sources {
 		temporary, err := ops.DuplicateAtLeast(source, 9)
-		if err != nil {
+		if err != nil || temporary < 9 {
+			if temporary >= 0 {
+				alreadyOwned := false
+				for prior := 0; prior < index; prior++ {
+					alreadyOwned = alreadyOwned || temps[prior] == temporary
+				}
+				if !alreadyOwned {
+					_ = ops.Close(temporary)
+				}
+			}
 			return errL8RuntimeOwnerInvalid
+		}
+		for prior := 0; prior < index; prior++ {
+			if temps[prior] == temporary {
+				return errL8RuntimeOwnerInvalid
+			}
 		}
 		temps[index] = temporary
 	}
@@ -185,8 +239,11 @@ func remapAndExecL8RuntimeOwnerChild(config l8RuntimeOwnerSupervisorConfigV1, so
 			return errL8RuntimeOwnerInvalid
 		}
 	}
-	for _, temporary := range temps {
-		_ = ops.Close(temporary)
+	for index, temporary := range temps {
+		temps[index] = -1
+		if err := ops.Close(temporary); err != nil {
+			return errL8RuntimeOwnerInvalid
+		}
 	}
 	if err := ops.CloseFrom(7); err != nil {
 		return errL8RuntimeOwnerInvalid
@@ -320,10 +377,11 @@ func l8RuntimeOwnerJSONNoDuplicateValue(decoder *json.Decoder) bool {
 		for decoder.More() {
 			key, err := decoder.Token()
 			name, ok := key.(string)
-			if err != nil || !ok || seen[name] {
+			canonicalName := strings.ToLower(name)
+			if err != nil || !ok || seen[canonicalName] {
 				return false
 			}
-			seen[name] = true
+			seen[canonicalName] = true
 			if !l8RuntimeOwnerJSONNoDuplicateValue(decoder) {
 				return false
 			}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
@@ -1,7 +1,12 @@
 package firecrackerhost
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/jywlabs/hal/internal/sandboxruntime"
 )
@@ -77,32 +82,265 @@ type l8RuntimeOwnerKeyFDOps struct {
 	Close func(int) error
 }
 
-func encodeL8RuntimeOwnerSupervisorConfig(l8RuntimeOwnerSupervisorConfigV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerInvalid
+func encodeL8RuntimeOwnerSupervisorConfig(config l8RuntimeOwnerSupervisorConfigV1) ([]byte, error) {
+	if err := validateL8RuntimeOwnerSupervisorConfig(config); err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	payload, err := json.Marshal(config)
+	if err != nil || len(payload) == 0 || len(payload) > l8RuntimeOwnerSupervisorConfigLimit {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	return payload, nil
 }
 
-func decodeL8RuntimeOwnerSupervisorConfig([]byte) (l8RuntimeOwnerSupervisorConfigV1, error) {
-	return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+func decodeL8RuntimeOwnerSupervisorConfig(payload []byte) (l8RuntimeOwnerSupervisorConfigV1, error) {
+	if len(payload) == 0 || len(payload) > l8RuntimeOwnerSupervisorConfigLimit || !l8RuntimeOwnerJSONNoDuplicateKeys(payload) {
+		return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	var config l8RuntimeOwnerSupervisorConfigV1
+	if decoder.Decode(&config) != nil || decoder.Decode(&struct{}{}) != io.EOF || validateL8RuntimeOwnerSupervisorConfig(config) != nil {
+		return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+	}
+	return config, nil
 }
 
-func runPrivateL8RuntimeOwnerExecutableWithOps([]string, l8RuntimeOwnerExecutableOps) int {
-	return 127
+func runPrivateL8RuntimeOwnerExecutableWithOps(arguments []string, ops l8RuntimeOwnerExecutableOps) int {
+	if len(arguments) != 1 || (arguments[0] != l8RuntimeOwnerExecutableSupervise && arguments[0] != l8RuntimeOwnerExecutableChildGate) {
+		return 127
+	}
+	if ops.OpenFD == nil || ops.CloseFD == nil {
+		return 127
+	}
+	roles := []string{"control-socket", "owner-directory", "supervisor-config", "kernel-asset", "rootfs-asset", "owner-root-key"}
+	opened := make([]int, 0, 6)
+	for index := 0; index < 6; index++ {
+		fd, err := ops.OpenFD(uintptr(index+3), roles[index])
+		if err != nil {
+			for i := len(opened) - 1; i >= 0; i-- {
+				_ = ops.CloseFD(opened[i])
+			}
+			return 127
+		}
+		opened = append(opened, fd)
+	}
+	var fds [6]int
+	copy(fds[:], opened)
+	var runErr error
+	if arguments[0] == l8RuntimeOwnerExecutableSupervise {
+		if ops.RunSupervisor == nil {
+			runErr = errL8RuntimeOwnerInvalid
+		} else {
+			runErr = ops.RunSupervisor(fds)
+		}
+	} else {
+		if ops.RunChildGate == nil {
+			runErr = errL8RuntimeOwnerInvalid
+		} else {
+			runErr = ops.RunChildGate(fds)
+		}
+	}
+	for i := len(opened) - 1; i >= 0; i-- {
+		_ = ops.CloseFD(opened[i])
+	}
+	if runErr != nil {
+		return 127
+	}
+	return 0
 }
 
-func launchL8RuntimeOwnerChildOnRetainedThread(l8RuntimeOwnerChildLaunchOps) error {
-	return errL8RuntimeOwnerInvalid
+func launchL8RuntimeOwnerChildOnRetainedThread(ops l8RuntimeOwnerChildLaunchOps) error {
+	if ops.LockOSThread == nil || ops.UnlockOSThread == nil || ops.Start == nil || ops.Wait == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	ops.LockOSThread()
+	defer ops.UnlockOSThread()
+	if err := ops.Start(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := ops.Wait(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
 }
 
-func remapAndExecL8RuntimeOwnerChild(l8RuntimeOwnerSupervisorConfigV1, [4]int, l8RuntimeOwnerFDRemapOps) error {
-	return errL8RuntimeOwnerInvalid
+func remapAndExecL8RuntimeOwnerChild(config l8RuntimeOwnerSupervisorConfigV1, sources [4]int, ops l8RuntimeOwnerFDRemapOps) error {
+	if ops.DuplicateAtLeast == nil || ops.Dup3 == nil || ops.Close == nil || ops.CloseFrom == nil || ops.Exec == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := validateL8RuntimeOwnerSupervisorConfig(config); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	var temps [4]int
+	for index, source := range sources {
+		temporary, err := ops.DuplicateAtLeast(source, 9)
+		if err != nil {
+			return errL8RuntimeOwnerInvalid
+		}
+		temps[index] = temporary
+	}
+	for index, temporary := range temps {
+		if err := ops.Dup3(temporary, 3+index, 0); err != nil {
+			return errL8RuntimeOwnerInvalid
+		}
+	}
+	for _, temporary := range temps {
+		_ = ops.Close(temporary)
+	}
+	if err := ops.CloseFrom(7); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	argv := []string{
+		config.NamespaceWrapperExecutable,
+		"--preserve-credentials",
+		"--keep-caps",
+		"--user=/proc/self/fd/3",
+		"--net=/proc/self/fd/4",
+		"--",
+		config.FirecrackerExecutable,
+	}
+	argv = append(argv, config.FirecrackerArguments...)
+	if err := ops.Exec(config.NamespaceWrapperExecutable, argv, []string{}); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
 }
 
-func runL8RuntimeOwnerChildGate(l8RuntimeOwnerChildGateOps) error {
-	return errL8RuntimeOwnerInvalid
+func runL8RuntimeOwnerChildGate(ops l8RuntimeOwnerChildGateOps) error {
+	if ops.ArmPdeathsigAndVerifyParent == nil || ops.SendArmed == nil || ops.AwaitRelease == nil || ops.RemapAndExec == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := ops.ArmPdeathsigAndVerifyParent(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := ops.SendArmed(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := ops.AwaitRelease(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := ops.RemapAndExec(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
 }
 
-func loadL8RuntimeOwnerStableKeyFD(int, uint32, l8RuntimeOwnerKeyFDOps) ([]byte, error) {
-	return nil, errL8RuntimeOwnerInvalid
+func loadL8RuntimeOwnerStableKeyFD(fd int, uid uint32, ops l8RuntimeOwnerKeyFDOps) (key []byte, err error) {
+	if ops.Stat == nil || ops.Pread == nil || ops.Close == nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	defer func() {
+		if ops.Close(fd) != nil {
+			key = nil
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	first, statErr := ops.Stat(fd)
+	if statErr != nil || !validL8RuntimeOwnerKeyIdentity(first, uid) {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	buf := make([]byte, 32)
+	read, readErr := ops.Pread(fd, buf, 0)
+	if readErr != nil || read != 32 {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	second, statErr := ops.Stat(fd)
+	if statErr != nil || second != first {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	return buf, nil
+}
+
+func validL8RuntimeOwnerKeyIdentity(identity l8RuntimeOwnerKeyIdentity, uid uint32) bool {
+	return identity.Regular && identity.Mode == 0o600 && identity.UID == uid && identity.Links == 1 && identity.Size == 32
+}
+
+func validateL8RuntimeOwnerSupervisorConfig(config l8RuntimeOwnerSupervisorConfigV1) error {
+	if config.ContractVersion != l8RuntimeOwnerSupervisorConfigVersion ||
+		sandboxruntime.ValidateJobCredentialIdentitySeed(config.Seed) != nil ||
+		!l8RuntimeOwnerAbsolutePath(config.NamespaceWrapperExecutable) ||
+		!l8RuntimeOwnerAbsolutePath(config.FirecrackerExecutable) ||
+		config.InheritedDescriptorCount != 2 {
+		return errL8RuntimeOwnerInvalid
+	}
+	if config.Kernel.Kind != "kernel" || config.Rootfs.Kind != "rootfs" ||
+		!validL8RuntimeOwnerAssetDigest(config.Kernel.Digest) || !validL8RuntimeOwnerAssetDigest(config.Rootfs.Digest) ||
+		(config.Kernel.Device == config.Rootfs.Device && config.Kernel.Inode == config.Rootfs.Inode) {
+		return errL8RuntimeOwnerInvalid
+	}
+	for _, argument := range config.FirecrackerArguments {
+		if argument == "" || strings.ContainsAny(argument, "\x00\r\n") {
+			return errL8RuntimeOwnerInvalid
+		}
+	}
+	return nil
+}
+
+func l8RuntimeOwnerAbsolutePath(value string) bool {
+	return value != "" && filepath.IsAbs(value) && filepath.Clean(value) == value && !strings.ContainsAny(value, "\x00\r\n")
+}
+
+func validL8RuntimeOwnerAssetDigest(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, character := range value {
+		if character >= '0' && character <= '9' || character >= 'a' && character <= 'f' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func l8RuntimeOwnerJSONNoDuplicateKeys(payload []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	if !l8RuntimeOwnerJSONNoDuplicateValue(decoder) {
+		return false
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return false
+	}
+	return true
+}
+
+func l8RuntimeOwnerJSONNoDuplicateValue(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return token != nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]bool)
+		for decoder.More() {
+			key, err := decoder.Token()
+			name, ok := key.(string)
+			if err != nil || !ok || seen[name] {
+				return false
+			}
+			seen[name] = true
+			if !l8RuntimeOwnerJSONNoDuplicateValue(decoder) {
+				return false
+			}
+		}
+		end, err := decoder.Token()
+		return err == nil && end == json.Delim('}')
+	case '[':
+		for decoder.More() {
+			if !l8RuntimeOwnerJSONNoDuplicateValue(decoder) {
+				return false
+			}
+		}
+		end, err := decoder.Token()
+		return err == nil && end == json.Delim(']')
+	default:
+		return false
+	}
 }
 
 // RunPrivateL8RuntimeOwnerExecutable is the single internal entry point for

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
@@ -1,0 +1,47 @@
+package firecrackerhost
+
+import (
+	"os"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+const (
+	l8RuntimeOwnerExecutableSupervise     = "supervise"
+	l8RuntimeOwnerExecutableChildGate     = "child-gate"
+	l8RuntimeOwnerSupervisorConfigVersion = "firecracker-runtime-owner-supervisor-config-v1"
+	l8RuntimeOwnerSupervisorConfigLimit   = 32 << 10
+)
+
+type l8RuntimeOwnerDescriptorIdentityV1 struct {
+	Kind   string `json:"kind"`
+	Device uint64 `json:"device"`
+	Inode  uint64 `json:"inode"`
+	Digest string `json:"digest"`
+}
+
+type l8RuntimeOwnerSupervisorConfigV1 struct {
+	ContractVersion            string                                   `json:"contractVersion"`
+	Seed                       sandboxruntime.JobCredentialIdentitySeed `json:"seed"`
+	DaemonUID                  uint32                                   `json:"daemonUid"`
+	NamespaceWrapperExecutable string                                   `json:"namespaceWrapperExecutable"`
+	FirecrackerExecutable      string                                   `json:"firecrackerExecutable"`
+	FirecrackerArguments       []string                                 `json:"firecrackerArguments"`
+	Kernel                     l8RuntimeOwnerDescriptorIdentityV1       `json:"kernel"`
+	Rootfs                     l8RuntimeOwnerDescriptorIdentityV1       `json:"rootfs"`
+	InheritedDescriptorCount   uint16                                   `json:"inheritedDescriptorCount"`
+}
+
+func encodeL8RuntimeOwnerSupervisorConfig(l8RuntimeOwnerSupervisorConfigV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerInvalid
+}
+
+func decodeL8RuntimeOwnerSupervisorConfig([]byte) (l8RuntimeOwnerSupervisorConfigV1, error) {
+	return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+}
+
+// RunPrivateL8RuntimeOwnerExecutable is the single internal entry point for
+// the isolated runtime-owner executable. It is not a default runtime factory.
+func RunPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, string) *os.File) int {
+	return runPrivateL8RuntimeOwnerExecutable(arguments, file)
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable.go
@@ -32,12 +32,77 @@ type l8RuntimeOwnerSupervisorConfigV1 struct {
 	InheritedDescriptorCount   uint16                                   `json:"inheritedDescriptorCount"`
 }
 
+type l8RuntimeOwnerExecutableOps struct {
+	OpenFD        func(uintptr, string) (int, error)
+	CloseFD       func(int) error
+	RunSupervisor func([6]int) error
+	RunChildGate  func([6]int) error
+}
+
+type l8RuntimeOwnerChildLaunchOps struct {
+	LockOSThread   func()
+	UnlockOSThread func()
+	Start          func() error
+	Wait           func() error
+}
+
+type l8RuntimeOwnerFDRemapOps struct {
+	DuplicateAtLeast func(int, int) (int, error)
+	Dup3             func(int, int, int) error
+	Close            func(int) error
+	CloseFrom        func(int) error
+	Exec             func(string, []string, []string) error
+}
+
+type l8RuntimeOwnerChildGateOps struct {
+	ArmPdeathsigAndVerifyParent func() error
+	SendArmed                   func() error
+	AwaitRelease                func() error
+	RemapAndExec                func() error
+}
+
+type l8RuntimeOwnerKeyIdentity struct {
+	Regular bool
+	Mode    uint32
+	UID     uint32
+	Links   uint64
+	Size    int64
+	Device  uint64
+	Inode   uint64
+}
+
+type l8RuntimeOwnerKeyFDOps struct {
+	Stat  func(int) (l8RuntimeOwnerKeyIdentity, error)
+	Pread func(int, []byte, int64) (int, error)
+	Close func(int) error
+}
+
 func encodeL8RuntimeOwnerSupervisorConfig(l8RuntimeOwnerSupervisorConfigV1) ([]byte, error) {
 	return nil, errL8RuntimeOwnerInvalid
 }
 
 func decodeL8RuntimeOwnerSupervisorConfig([]byte) (l8RuntimeOwnerSupervisorConfigV1, error) {
 	return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+}
+
+func runPrivateL8RuntimeOwnerExecutableWithOps([]string, l8RuntimeOwnerExecutableOps) int {
+	return 127
+}
+
+func launchL8RuntimeOwnerChildOnRetainedThread(l8RuntimeOwnerChildLaunchOps) error {
+	return errL8RuntimeOwnerInvalid
+}
+
+func remapAndExecL8RuntimeOwnerChild(l8RuntimeOwnerSupervisorConfigV1, [4]int, l8RuntimeOwnerFDRemapOps) error {
+	return errL8RuntimeOwnerInvalid
+}
+
+func runL8RuntimeOwnerChildGate(l8RuntimeOwnerChildGateOps) error {
+	return errL8RuntimeOwnerInvalid
+}
+
+func loadL8RuntimeOwnerStableKeyFD(int, uint32, l8RuntimeOwnerKeyFDOps) ([]byte, error) {
+	return nil, errL8RuntimeOwnerInvalid
 }
 
 // RunPrivateL8RuntimeOwnerExecutable is the single internal entry point for

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package firecrackerhost
+
+import "os"
+
+func runPrivateL8RuntimeOwnerExecutable([]string, func(uintptr, string) *os.File) int {
+	return 127
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
@@ -3,11 +3,28 @@
 package firecrackerhost
 
 import (
+	"context"
+	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
+
+type l8RuntimeOwnerLinuxChild struct {
+	mu          sync.Mutex
+	command     *exec.Cmd
+	gate        *os.File
+	observation l8RuntimeOwnerProcessObservation
+	waitDone    chan struct{}
+	waitErr     error
+	released    bool
+	closed      bool
+}
 
 func runPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, string) *os.File) int {
 	_ = launchPrivateL8RuntimeOwnerLinuxChild
@@ -26,6 +43,10 @@ func runPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, s
 				_ = opened.Close()
 				return -1, errL8RuntimeOwnerInvalid
 			}
+			if _, err := unix.FcntlInt(opened.Fd(), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+				_ = opened.Close()
+				return -1, errL8RuntimeOwnerInvalid
+			}
 			openedFiles[openedFD] = opened
 			return openedFD, nil
 		},
@@ -40,12 +61,8 @@ func runPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, s
 			}
 			return nil
 		},
-		RunSupervisor: func([6]int) error {
-			return errL8RuntimeOwnerInvalid
-		},
-		RunChildGate: func([6]int) error {
-			return errL8RuntimeOwnerInvalid
-		},
+		RunSupervisor: runL8RuntimeOwnerSupervisorLinux,
+		RunChildGate:  runL8RuntimeOwnerChildGateLinux,
 	})
 }
 
@@ -64,6 +81,180 @@ func launchPrivateL8RuntimeOwnerLinuxChild(command *exec.Cmd) error {
 	}
 	runtime.UnlockOSThread()
 	if startErr != nil || waitErr != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func startL8RuntimeOwnerLinuxChild(configFD int, namespaces [2]*os.File, assetFDs [2]int) (*l8RuntimeOwnerLinuxChild, error) {
+	sockets, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	parentGate := os.NewFile(uintptr(sockets[0]), "runtime-owner-parent-gate")
+	childGate := os.NewFile(uintptr(sockets[1]), "runtime-owner-child-gate")
+	if parentGate == nil || childGate == nil {
+		if parentGate != nil {
+			_ = parentGate.Close()
+		} else {
+			_ = unix.Close(sockets[0])
+		}
+		if childGate != nil {
+			_ = childGate.Close()
+		} else {
+			_ = unix.Close(sockets[1])
+		}
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	extra := []*os.File{childGate}
+	failed := true
+	defer func() {
+		for _, file := range extra {
+			if file != nil {
+				_ = file.Close()
+			}
+		}
+		if failed {
+			_ = parentGate.Close()
+		}
+	}()
+	for _, source := range []int{configFD, int(namespaces[0].Fd()), int(namespaces[1].Fd()), assetFDs[0], assetFDs[1]} {
+		fd, err := unix.FcntlInt(uintptr(source), unix.F_DUPFD_CLOEXEC, 9)
+		if err != nil {
+			return nil, errL8RuntimeOwnerInvalid
+		}
+		file := os.NewFile(uintptr(fd), "runtime-owner-child-input")
+		if file == nil {
+			_ = unix.Close(fd)
+			return nil, errL8RuntimeOwnerInvalid
+		}
+		extra = append(extra, file)
+	}
+	executable, err := os.Executable()
+	if err != nil || !filepath.IsAbs(executable) || filepath.Clean(executable) != executable {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	command := exec.Command(executable, l8RuntimeOwnerExecutableChildGate)
+	command.Env = []string{}
+	command.ExtraFiles = extra
+	command.SysProcAttr = &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+	child := &l8RuntimeOwnerLinuxChild{command: command, gate: parentGate, waitDone: make(chan struct{})}
+	started := make(chan error, 1)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		startErr := command.Start()
+		started <- startErr
+		if startErr != nil {
+			child.mu.Lock()
+			child.waitErr = startErr
+			child.mu.Unlock()
+			close(child.waitDone)
+			return
+		}
+		waitErr := command.Wait()
+		child.mu.Lock()
+		child.waitErr = waitErr
+		child.mu.Unlock()
+		close(child.waitDone)
+	}()
+	if err := <-started; err != nil || command.Process == nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	for index, file := range extra {
+		_ = file.Close()
+		extra[index] = nil
+	}
+	observation, err := inspectL8RuntimeOwnerProcess(uint32(command.Process.Pid))
+	if err != nil || observation.ParentPID != uint32(os.Getpid()) {
+		_ = observation.Close()
+		_ = child.abort()
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	child.observation = observation
+	if setL8RuntimeOwnerSocketTimeout(int(parentGate.Fd()), l8RuntimeOwnerHandshakeTimeout) != nil {
+		_ = child.abort()
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	armed, err := receiveL8RuntimeOwnerSeqpacket(int(parentGate.Fd()))
+	if err != nil {
+		_ = child.abort()
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	closeL8RuntimeOwnerFiles(armed.Files)
+	if validateL8RuntimeOwnerPacketRole(armed.Packet, false, len(armed.Files)) != nil || armed.Packet.Opcode != l8RuntimeOwnerOpcodeChildArmed {
+		_ = child.abort()
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	failed = false
+	return child, nil
+}
+
+func (child *l8RuntimeOwnerLinuxChild) release() error {
+	child.mu.Lock()
+	defer child.mu.Unlock()
+	if child.closed || child.released || child.gate == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := sendL8RuntimeOwnerSeqpacket(int(child.gate.Fd()), l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeChildRelease}, nil); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	child.released = true
+	return nil
+}
+
+func (child *l8RuntimeOwnerLinuxChild) signal(signal os.Signal) error {
+	child.mu.Lock()
+	defer child.mu.Unlock()
+	if child.command == nil || child.command.Process == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := child.command.Process.Signal(signal); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func (child *l8RuntimeOwnerLinuxChild) wait(ctx context.Context) (bool, error) {
+	if child == nil || child.waitDone == nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	select {
+	case <-child.waitDone:
+		return true, nil
+	case <-ctx.Done():
+		return false, nil
+	}
+}
+
+func (child *l8RuntimeOwnerLinuxChild) abort() error {
+	if child == nil {
+		return nil
+	}
+	_ = child.signal(syscall.SIGKILL)
+	ctx, cancel := context.WithTimeout(context.Background(), l8RuntimeOwnerContainmentBudget)
+	defer cancel()
+	reaped, err := child.wait(ctx)
+	if err != nil || !reaped {
+		return errL8RuntimeOwnerInvalid
+	}
+	return child.close()
+}
+
+func (child *l8RuntimeOwnerLinuxChild) close() error {
+	child.mu.Lock()
+	defer child.mu.Unlock()
+	if child.closed {
+		return nil
+	}
+	child.closed = true
+	var failed bool
+	if child.gate != nil {
+		failed = child.gate.Close() != nil
+		child.gate = nil
+	}
+	failed = child.observation.Close() != nil || failed
+	if failed {
 		return errL8RuntimeOwnerInvalid
 	}
 	return nil

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
@@ -7,12 +7,11 @@ import (
 	"os/exec"
 	"runtime"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
 func runPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, string) *os.File) int {
 	_ = launchPrivateL8RuntimeOwnerLinuxChild
+	openedFiles := make(map[int]*os.File)
 	return runPrivateL8RuntimeOwnerExecutableWithOps(arguments, l8RuntimeOwnerExecutableOps{
 		OpenFD: func(fd uintptr, role string) (int, error) {
 			if file == nil {
@@ -22,13 +21,21 @@ func runPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, s
 			if opened == nil {
 				return -1, errL8RuntimeOwnerInvalid
 			}
-			return int(opened.Fd()), nil
+			openedFD := int(opened.Fd())
+			if openedFD < 0 {
+				_ = opened.Close()
+				return -1, errL8RuntimeOwnerInvalid
+			}
+			openedFiles[openedFD] = opened
+			return openedFD, nil
 		},
 		CloseFD: func(fd int) error {
 			if fd < 0 {
 				return nil
 			}
-			if err := unix.Close(fd); err != nil {
+			opened := openedFiles[fd]
+			delete(openedFiles, fd)
+			if opened == nil || opened.Close() != nil {
 				return errL8RuntimeOwnerInvalid
 			}
 			return nil

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_linux.go
@@ -2,8 +2,62 @@
 
 package firecrackerhost
 
-import "os"
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"syscall"
 
-func runPrivateL8RuntimeOwnerExecutable([]string, func(uintptr, string) *os.File) int {
-	return 127
+	"golang.org/x/sys/unix"
+)
+
+func runPrivateL8RuntimeOwnerExecutable(arguments []string, file func(uintptr, string) *os.File) int {
+	_ = launchPrivateL8RuntimeOwnerLinuxChild
+	return runPrivateL8RuntimeOwnerExecutableWithOps(arguments, l8RuntimeOwnerExecutableOps{
+		OpenFD: func(fd uintptr, role string) (int, error) {
+			if file == nil {
+				return -1, errL8RuntimeOwnerInvalid
+			}
+			opened := file(fd, role)
+			if opened == nil {
+				return -1, errL8RuntimeOwnerInvalid
+			}
+			return int(opened.Fd()), nil
+		},
+		CloseFD: func(fd int) error {
+			if fd < 0 {
+				return nil
+			}
+			if err := unix.Close(fd); err != nil {
+				return errL8RuntimeOwnerInvalid
+			}
+			return nil
+		},
+		RunSupervisor: func([6]int) error {
+			return errL8RuntimeOwnerInvalid
+		},
+		RunChildGate: func([6]int) error {
+			return errL8RuntimeOwnerInvalid
+		},
+	})
+}
+
+func launchPrivateL8RuntimeOwnerLinuxChild(command *exec.Cmd) error {
+	if command == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	runtime.LockOSThread()
+	command.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+	startErr := command.Start()
+	var waitErr error
+	if startErr == nil {
+		waitErr = command.Wait()
+	}
+	runtime.UnlockOSThread()
+	if startErr != nil || waitErr != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_other.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package firecrackerhost
+
+import "os"
+
+func runPrivateL8RuntimeOwnerExecutable([]string, func(uintptr, string) *os.File) int {
+	return 127
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
@@ -3,9 +3,267 @@ package firecrackerhost
 import (
 	"bytes"
 	"errors"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestL8RuntimeOwnerLinuxLaunchSourceRetainsPdeathsigCreatingThread(t *testing.T) {
+	source, err := os.ReadFile("l8_runtime_owner_executable_linux.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	markers := []string{"runtime.LockOSThread", "SysProcAttr", "Pdeathsig:", "syscall.SIGKILL", ".Start()", ".Wait()", "runtime.UnlockOSThread"}
+	previous := -1
+	for _, marker := range markers {
+		index := strings.Index(text, marker)
+		if index < 0 {
+			t.Fatalf("linux launch omits %q", marker)
+		}
+		if index <= previous {
+			t.Fatalf("linux launch order for %q", marker)
+		}
+		previous = index
+	}
+}
+
+func TestL8RuntimeOwnerExecutableModesAndDescriptorABI(t *testing.T) {
+	for _, scenario := range []struct {
+		name    string
+		argv    []string
+		wantRun string
+		wantFDs []uintptr
+	}{
+		{name: "supervise", argv: []string{"supervise"}, wantRun: "supervise", wantFDs: []uintptr{3, 4, 5, 6, 7, 8}},
+		{name: "child gate", argv: []string{"child-gate"}, wantRun: "child-gate", wantFDs: []uintptr{3, 4, 5, 6, 7, 8}},
+		{name: "missing mode"},
+		{name: "extra argument", argv: []string{"supervise", "extra"}},
+		{name: "unknown mode", argv: []string{"unknown"}},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			var opened []uintptr
+			var closed []int
+			var run string
+			ops := l8RuntimeOwnerExecutableOps{
+				OpenFD: func(fd uintptr, role string) (int, error) {
+					if strings.TrimSpace(role) == "" {
+						t.Fatal("empty descriptor role")
+					}
+					opened = append(opened, fd)
+					return int(fd), nil
+				},
+				CloseFD: func(fd int) error { closed = append(closed, fd); return nil },
+				RunSupervisor: func(fds [6]int) error {
+					run = "supervise"
+					if fds != [6]int{3, 4, 5, 6, 7, 8} {
+						t.Fatalf("supervisor fds = %v", fds)
+					}
+					return nil
+				},
+				RunChildGate: func(fds [6]int) error {
+					run = "child-gate"
+					if fds != [6]int{3, 4, 5, 6, 7, 8} {
+						t.Fatalf("child fds = %v", fds)
+					}
+					return nil
+				},
+			}
+			got := runPrivateL8RuntimeOwnerExecutableWithOps(scenario.argv, ops)
+			if scenario.wantRun == "" {
+				if got != 127 || len(opened) != 0 || run != "" {
+					t.Fatalf("invalid mode = exit %d opened %v run %q", got, opened, run)
+				}
+				return
+			}
+			if got != 0 || run != scenario.wantRun || !reflect.DeepEqual(opened, scenario.wantFDs) || !reflect.DeepEqual(closed, []int{8, 7, 6, 5, 4, 3}) {
+				t.Fatalf("mode result = exit %d opened %v closed %v run %q", got, opened, closed, run)
+			}
+		})
+	}
+
+	for failedAt := uintptr(3); failedAt <= 8; failedAt++ {
+		t.Run("open failure", func(t *testing.T) {
+			var closed []int
+			got := runPrivateL8RuntimeOwnerExecutableWithOps([]string{"supervise"}, l8RuntimeOwnerExecutableOps{
+				OpenFD: func(fd uintptr, _ string) (int, error) {
+					if fd == failedAt {
+						return -1, errors.New("private path")
+					}
+					return int(fd), nil
+				},
+				CloseFD:       func(fd int) error { closed = append(closed, fd); return nil },
+				RunSupervisor: func([6]int) error { t.Fatal("ran after open failure"); return nil },
+			})
+			if got != 127 || len(closed) != int(failedAt-3) {
+				t.Fatalf("failure cleanup = exit %d closed %v", got, closed)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerChildLaunchRetainsCreatingThreadThroughWait(t *testing.T) {
+	var events []string
+	ops := l8RuntimeOwnerChildLaunchOps{
+		LockOSThread:   func() { events = append(events, "lock") },
+		UnlockOSThread: func() { events = append(events, "unlock") },
+		Start:          func() error { events = append(events, "start"); return nil },
+		Wait:           func() error { events = append(events, "wait"); return nil },
+	}
+	if err := launchL8RuntimeOwnerChildOnRetainedThread(ops); err != nil || !reflect.DeepEqual(events, []string{"lock", "start", "wait", "unlock"}) {
+		t.Fatalf("launch = %v, %v", events, err)
+	}
+	events = nil
+	ops.Start = func() error { events = append(events, "start"); return errors.New("private start") }
+	if err := launchL8RuntimeOwnerChildOnRetainedThread(ops); !errors.Is(err, errL8RuntimeOwnerInvalid) || !reflect.DeepEqual(events, []string{"lock", "start", "unlock"}) {
+		t.Fatalf("start failure = %v, %v", events, err)
+	}
+}
+
+func TestL8RuntimeOwnerChildGateRemapsCollisionFreeAndExecsNamespaceWrapper(t *testing.T) {
+	config := l8RuntimeOwnerTestSupervisorConfig()
+	var events []string
+	next := 9
+	ops := l8RuntimeOwnerFDRemapOps{
+		DuplicateAtLeast: func(fd, minimum int) (int, error) {
+			events = append(events, "dup-temp")
+			if minimum != 9 {
+				t.Fatalf("minimum = %d", minimum)
+			}
+			value := next
+			next++
+			return value, nil
+		},
+		Dup3: func(from, to, flags int) error {
+			events = append(events, "dup3")
+			if from < 9 || to < 3 || to > 6 || flags != 0 {
+				t.Fatalf("dup3 = %d %d %d", from, to, flags)
+			}
+			return nil
+		},
+		Close: func(int) error { events = append(events, "close"); return nil },
+		CloseFrom: func(first int) error {
+			events = append(events, "closefrom")
+			if first != 7 {
+				t.Fatalf("closefrom = %d", first)
+			}
+			return nil
+		},
+		Exec: func(path string, argv, env []string) error {
+			events = append(events, "exec")
+			want := []string{config.NamespaceWrapperExecutable, "--preserve-credentials", "--keep-caps", "--user=/proc/self/fd/3", "--net=/proc/self/fd/4", "--", config.FirecrackerExecutable, "--api-sock", "/private/runtime/firecracker.sock"}
+			if path != config.NamespaceWrapperExecutable || !reflect.DeepEqual(argv, want) || len(env) != 0 {
+				t.Fatalf("exec = %q %#v %#v", path, argv, env)
+			}
+			return nil
+		},
+	}
+	if err := remapAndExecL8RuntimeOwnerChild(config, [4]int{5, 6, 7, 8}, ops); err != nil {
+		t.Fatal(err)
+	}
+	if countString(events, "dup-temp") != 4 || countString(events, "dup3") != 4 || events[len(events)-2] != "closefrom" || events[len(events)-1] != "exec" {
+		t.Fatalf("remap events = %v", events)
+	}
+}
+
+func TestL8RuntimeOwnerChildGateArmsBeforeAcknowledgementAndRelease(t *testing.T) {
+	for _, scenario := range []struct{ name, fail string }{
+		{name: "success"}, {name: "arm", fail: "arm"}, {name: "armed ack", fail: "armed"}, {name: "gate eof", fail: "release"}, {name: "exec", fail: "exec"},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			var events []string
+			step := func(name string) error {
+				events = append(events, name)
+				if scenario.fail == name {
+					return errors.New("private child gate")
+				}
+				return nil
+			}
+			err := runL8RuntimeOwnerChildGate(l8RuntimeOwnerChildGateOps{
+				ArmPdeathsigAndVerifyParent: func() error { return step("arm") },
+				SendArmed:                   func() error { return step("armed") },
+				AwaitRelease:                func() error { return step("release") },
+				RemapAndExec:                func() error { return step("exec") },
+			})
+			want := []string{"arm", "armed", "release", "exec"}
+			if scenario.fail != "" {
+				for index, value := range want {
+					if value == scenario.fail {
+						want = want[:index+1]
+						break
+					}
+				}
+			}
+			if !reflect.DeepEqual(events, want) {
+				t.Fatalf("gate events = %v want %v", events, want)
+			}
+			if scenario.fail == "" && err != nil {
+				t.Fatal(err)
+			}
+			if scenario.fail != "" && (!errors.Is(err, errL8RuntimeOwnerInvalid) || err.Error() != errL8RuntimeOwnerInvalid.Error()) {
+				t.Fatalf("failure = %v", err)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerStableKeyFDIsExactAndReplacementSafe(t *testing.T) {
+	wantIdentity := l8RuntimeOwnerKeyIdentity{Regular: true, Mode: 0600, UID: 1000, Links: 1, Size: 32, Device: 7, Inode: 9}
+	for _, scenario := range []struct {
+		name              string
+		first, second     l8RuntimeOwnerKeyIdentity
+		read              int
+		readErr, closeErr error
+		ok                bool
+	}{
+		{name: "valid", first: wantIdentity, second: wantIdentity, read: 32, ok: true},
+		{name: "short", first: wantIdentity, second: wantIdentity, read: 31},
+		{name: "wrong mode", first: func() l8RuntimeOwnerKeyIdentity { v := wantIdentity; v.Mode = 0640; return v }(), second: wantIdentity, read: 32},
+		{name: "wrong uid", first: func() l8RuntimeOwnerKeyIdentity { v := wantIdentity; v.UID = 1001; return v }(), second: wantIdentity, read: 32},
+		{name: "hardlink", first: func() l8RuntimeOwnerKeyIdentity { v := wantIdentity; v.Links = 2; return v }(), second: wantIdentity, read: 32},
+		{name: "replacement", first: wantIdentity, second: func() l8RuntimeOwnerKeyIdentity { v := wantIdentity; v.Inode++; return v }(), read: 32},
+		{name: "read error", first: wantIdentity, second: wantIdentity, readErr: errors.New("private key path")},
+		{name: "close uncertainty", first: wantIdentity, second: wantIdentity, read: 32, closeErr: errors.New("private close")},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			stats := 0
+			closes := 0
+			key, err := loadL8RuntimeOwnerStableKeyFD(8, 1000, l8RuntimeOwnerKeyFDOps{
+				Stat: func(fd int) (l8RuntimeOwnerKeyIdentity, error) {
+					if fd != 8 {
+						t.Fatalf("fd = %d", fd)
+					}
+					stats++
+					if stats == 1 {
+						return scenario.first, nil
+					}
+					return scenario.second, nil
+				},
+				Pread: func(fd int, destination []byte, offset int64) (int, error) {
+					if fd != 8 || len(destination) != 32 || offset != 0 {
+						t.Fatalf("pread = %d %d %d", fd, len(destination), offset)
+					}
+					for i := range destination {
+						destination[i] = byte(i)
+					}
+					return scenario.read, scenario.readErr
+				},
+				Close: func(fd int) error { closes++; return scenario.closeErr },
+			})
+			if closes != 1 {
+				t.Fatalf("close count = %d", closes)
+			}
+			if scenario.ok {
+				if err != nil || len(key) != 32 || stats != 2 {
+					t.Fatalf("key = %d stats %d err %v", len(key), stats, err)
+				}
+			} else if len(key) != 0 || !errors.Is(err, errL8RuntimeOwnerInvalid) || err.Error() != errL8RuntimeOwnerInvalid.Error() {
+				t.Fatalf("invalid key = %x, %v", key, err)
+			}
+		})
+	}
+}
 
 func TestL8RuntimeOwnerSupervisorConfigIsStrictBoundedAndComplete(t *testing.T) {
 	config := l8RuntimeOwnerTestSupervisorConfig()

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
@@ -29,6 +29,30 @@ func TestL8RuntimeOwnerLinuxLaunchSourceRetainsPdeathsigCreatingThread(t *testin
 	}
 }
 
+func TestL8RuntimeOwnerLinuxExecutableWiresProductionModes(t *testing.T) {
+	source, err := os.ReadFile("l8_runtime_owner_executable_linux.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	for _, marker := range []string{
+		"RunSupervisor: runL8RuntimeOwnerSupervisorLinux",
+		"RunChildGate:  runL8RuntimeOwnerChildGateLinux",
+	} {
+		if strings.Count(text, marker) != 1 {
+			t.Fatalf("linux executable wiring count for %q = %d", marker, strings.Count(text, marker))
+		}
+	}
+	for _, forbidden := range []string{
+		"RunSupervisor: func([6]int) error",
+		"RunChildGate: func([6]int) error",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("linux executable retains failure callback %q", forbidden)
+		}
+	}
+}
+
 func TestL8RuntimeOwnerExecutableModesAndDescriptorABI(t *testing.T) {
 	for _, scenario := range []struct {
 		name    string

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
@@ -1,0 +1,82 @@
+package firecrackerhost
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestL8RuntimeOwnerSupervisorConfigIsStrictBoundedAndComplete(t *testing.T) {
+	config := l8RuntimeOwnerTestSupervisorConfig()
+	payload, err := encodeL8RuntimeOwnerSupervisorConfig(config)
+	if err != nil || len(payload) == 0 || len(payload) > l8RuntimeOwnerSupervisorConfigLimit {
+		t.Fatalf("encode config = %d bytes, %v", len(payload), err)
+	}
+	decoded, err := decodeL8RuntimeOwnerSupervisorConfig(payload)
+	if err != nil || !l8RuntimeOwnerSupervisorConfigsEqual(decoded, config) {
+		t.Fatalf("decode config = %#v, %v", decoded, err)
+	}
+	for name, candidate := range map[string][]byte{
+		"null":      []byte("null\n"),
+		"unknown":   bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"unknown\":1,\"daemonUid\":"), 1),
+		"duplicate": bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"daemonUid\":1,\"daemonUid\":"), 1),
+		"trailing":  append(append([]byte(nil), payload...), 'x'),
+		"oversize":  make([]byte, l8RuntimeOwnerSupervisorConfigLimit+1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeL8RuntimeOwnerSupervisorConfig(candidate); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("decode mutation = %v", err)
+			}
+		})
+	}
+	mutations := map[string]func(*l8RuntimeOwnerSupervisorConfigV1){
+		"version":                func(value *l8RuntimeOwnerSupervisorConfigV1) { value.ContractVersion = "v2" },
+		"invalid seed":           func(value *l8RuntimeOwnerSupervisorConfigV1) { value.Seed.RuntimeGeneration = "" },
+		"relative wrapper":       func(value *l8RuntimeOwnerSupervisorConfigV1) { value.NamespaceWrapperExecutable = "nsenter" },
+		"relative firecracker":   func(value *l8RuntimeOwnerSupervisorConfigV1) { value.FirecrackerExecutable = "firecracker" },
+		"wrong descriptor count": func(value *l8RuntimeOwnerSupervisorConfigV1) { value.InheritedDescriptorCount = 3 },
+		"asset alias":            func(value *l8RuntimeOwnerSupervisorConfigV1) { value.Rootfs = value.Kernel },
+		"asset kind":             func(value *l8RuntimeOwnerSupervisorConfigV1) { value.Kernel.Kind = "rootfs" },
+		"asset digest":           func(value *l8RuntimeOwnerSupervisorConfigV1) { value.Kernel.Digest = "private path" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			candidate := config
+			candidate.FirecrackerArguments = append([]string(nil), config.FirecrackerArguments...)
+			mutate(&candidate)
+			if _, err := encodeL8RuntimeOwnerSupervisorConfig(candidate); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("encode mutation = %v", err)
+			}
+		})
+	}
+}
+
+func l8RuntimeOwnerTestSupervisorConfig() l8RuntimeOwnerSupervisorConfigV1 {
+	return l8RuntimeOwnerSupervisorConfigV1{
+		ContractVersion:            l8RuntimeOwnerSupervisorConfigVersion,
+		Seed:                       l8RuntimeOwnerTestSeed(),
+		DaemonUID:                  1000,
+		NamespaceWrapperExecutable: "/usr/bin/nsenter",
+		FirecrackerExecutable:      "/usr/bin/firecracker",
+		FirecrackerArguments:       []string{"--api-sock", "/private/runtime/firecracker.sock"},
+		Kernel:                     l8RuntimeOwnerDescriptorIdentityV1{Kind: "kernel", Device: 1, Inode: 2, Digest: string(bytes.Repeat([]byte("a"), 64))},
+		Rootfs:                     l8RuntimeOwnerDescriptorIdentityV1{Kind: "rootfs", Device: 1, Inode: 3, Digest: string(bytes.Repeat([]byte("b"), 64))},
+		InheritedDescriptorCount:   2,
+	}
+}
+
+func l8RuntimeOwnerSupervisorConfigsEqual(left, right l8RuntimeOwnerSupervisorConfigV1) bool {
+	if left.ContractVersion != right.ContractVersion || left.DaemonUID != right.DaemonUID ||
+		left.NamespaceWrapperExecutable != right.NamespaceWrapperExecutable || left.FirecrackerExecutable != right.FirecrackerExecutable ||
+		left.Kernel != right.Kernel || left.Rootfs != right.Rootfs || left.InheritedDescriptorCount != right.InheritedDescriptorCount ||
+		len(left.FirecrackerArguments) != len(right.FirecrackerArguments) {
+		return false
+	}
+	for index := range left.FirecrackerArguments {
+		if left.FirecrackerArguments[index] != right.FirecrackerArguments[index] {
+			return false
+		}
+	}
+	return reflect.DeepEqual(left.Seed, right.Seed)
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
@@ -38,6 +38,7 @@ func TestL8RuntimeOwnerLinuxExecutableWiresProductionModes(t *testing.T) {
 	for _, marker := range []string{
 		"RunSupervisor: runL8RuntimeOwnerSupervisorLinux",
 		"RunChildGate:  runL8RuntimeOwnerChildGateLinux",
+		"observation.ParentPID != uint32(os.Getpid())",
 	} {
 		if strings.Count(text, marker) != 1 {
 			t.Fatalf("linux executable wiring count for %q = %d", marker, strings.Count(text, marker))

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
@@ -167,6 +167,62 @@ func TestL8RuntimeOwnerChildGateRemapsCollisionFreeAndExecsNamespaceWrapper(t *t
 	}
 }
 
+func TestL8RuntimeOwnerChildGateClosesEveryTemporaryOnFailure(t *testing.T) {
+	config := l8RuntimeOwnerTestSupervisorConfig()
+	for _, scenario := range []struct {
+		name        string
+		failDupAt   int
+		failMapAt   int
+		failCloseAt int
+	}{
+		{name: "duplicate", failDupAt: 2},
+		{name: "map", failMapAt: 2},
+		{name: "close", failCloseAt: 2},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			next := 9
+			duplicateCalls := 0
+			mapCalls := 0
+			closeCalls := make(map[int]int)
+			err := remapAndExecL8RuntimeOwnerChild(config, [4]int{5, 6, 7, 8}, l8RuntimeOwnerFDRemapOps{
+				DuplicateAtLeast: func(int, int) (int, error) {
+					duplicateCalls++
+					if duplicateCalls == scenario.failDupAt {
+						return -1, errors.New("private duplicate")
+					}
+					fd := next
+					next++
+					return fd, nil
+				},
+				Dup3: func(int, int, int) error {
+					mapCalls++
+					if mapCalls == scenario.failMapAt {
+						return errors.New("private map")
+					}
+					return nil
+				},
+				Close: func(fd int) error {
+					closeCalls[fd]++
+					if fd == 10 && scenario.failCloseAt != 0 {
+						return errors.New("private close")
+					}
+					return nil
+				},
+				CloseFrom: func(int) error { return nil },
+				Exec:      func(string, []string, []string) error { return nil },
+			})
+			if !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("failure = %v", err)
+			}
+			for fd := 9; fd < next; fd++ {
+				if closeCalls[fd] != 1 {
+					t.Fatalf("temporary %d close count = %d", fd, closeCalls[fd])
+				}
+			}
+		})
+	}
+}
+
 func TestL8RuntimeOwnerChildGateArmsBeforeAcknowledgementAndRelease(t *testing.T) {
 	for _, scenario := range []struct{ name, fail string }{
 		{name: "success"}, {name: "arm", fail: "arm"}, {name: "armed ack", fail: "armed"}, {name: "gate eof", fail: "release"}, {name: "exec", fail: "exec"},

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_executable_test.go
@@ -276,11 +276,13 @@ func TestL8RuntimeOwnerSupervisorConfigIsStrictBoundedAndComplete(t *testing.T) 
 		t.Fatalf("decode config = %#v, %v", decoded, err)
 	}
 	for name, candidate := range map[string][]byte{
-		"null":      []byte("null\n"),
-		"unknown":   bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"unknown\":1,\"daemonUid\":"), 1),
-		"duplicate": bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"daemonUid\":1,\"daemonUid\":"), 1),
-		"trailing":  append(append([]byte(nil), payload...), 'x'),
-		"oversize":  make([]byte, l8RuntimeOwnerSupervisorConfigLimit+1),
+		"null":           []byte("null\n"),
+		"unknown":        bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"unknown\":1,\"daemonUid\":"), 1),
+		"duplicate":      bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"daemonUid\":1,\"daemonUid\":"), 1),
+		"case duplicate": bytes.Replace(payload, []byte("\"daemonUid\":"), []byte("\"DaemonUid\":1,\"daemonUid\":"), 1),
+		"null uid":       bytes.Replace(payload, []byte("\"daemonUid\":1000"), []byte("\"daemonUid\":null"), 1),
+		"trailing":       append(append([]byte(nil), payload...), 'x'),
+		"oversize":       make([]byte, l8RuntimeOwnerSupervisorConfigLimit+1),
 	} {
 		t.Run(name, func(t *testing.T) {
 			if _, err := decodeL8RuntimeOwnerSupervisorConfig(candidate); !errors.Is(err, errL8RuntimeOwnerInvalid) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_process_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_process_linux_test.go
@@ -5,12 +5,15 @@ package firecrackerhost
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestL8RuntimeOwnerProcessIdentityIncludesExactParentAndStart(t *testing.T) {
@@ -33,6 +36,40 @@ func TestL8RuntimeOwnerProcessIdentityIncludesExactParentAndStart(t *testing.T) 
 			t.Fatalf("malformed process identity = %v", err)
 		}
 	}
+}
+
+func TestL8RuntimeOwnerReplacementClosesEveryOwnedPidfdOnFailure(t *testing.T) {
+	seed := l8RuntimeOwnerTestSeed()
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "running", "unclaimed", 2
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Close()
+	fd := int(reader.Fd())
+	observation := l8RuntimeOwnerProcessObservation{PID: record.FirecrackerPID, ParentPID: 1, StartTime: record.FirecrackerStartTime, state: 'S', pidfd: fd, pidfdOwned: true}
+	_, gotErr := containL8RuntimeOwnerReplacement(record, l8RuntimeOwnerReplacementOps{
+		CurrentBootID: func() (string, error) { return record.HostBootID, nil },
+		InspectSupervisor: func(uint32) (l8RuntimeOwnerProcessObservation, bool, error) {
+			return l8RuntimeOwnerProcessObservation{}, false, nil
+		},
+		InspectChild:       func(uint32) (l8RuntimeOwnerProcessObservation, bool, error) { return observation, true, nil },
+		SignalKill:         func(l8RuntimeOwnerProcessObservation) error { return errors.New("private signal path") },
+		WaitTerminal:       func(context.Context, l8RuntimeOwnerProcessObservation) error { return errors.New("private wait path") },
+		ProcessAbsent:      func(uint32) (bool, error) { return false, nil },
+		AcquisitionBarrier: func() error { return nil },
+		RecordAbsent:       func(l8RuntimeOwnerAbsenceObservation) (uint64, error) { return 0, errors.New("must not record absent") },
+		RecordUncertain:    func() (uint64, error) { return 3, nil },
+		Now:                func() time.Time { return time.Unix(1, 0) },
+	})
+	if !errors.Is(gotErr, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("replacement = %v", gotErr)
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); !errors.Is(err, unix.EBADF) {
+		t.Fatalf("pidfd still open: %v", err)
+	}
+	_ = reader.Close()
 }
 
 func TestL8RuntimeOwnerPidfdSignalTerminalAndProcAbsenceAreDistinct(t *testing.T) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_process_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_process_linux_test.go
@@ -1,0 +1,80 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestL8RuntimeOwnerProcessIdentityIncludesExactParentAndStart(t *testing.T) {
+	fields := []string{"S", "77"}
+	for index := 0; index < 17; index++ {
+		fields = append(fields, strconv.Itoa(index+1))
+	}
+	fields = append(fields, "424242")
+	payload := []byte("123 (firecracker ) helper) " + strings.Join(fields, " ") + "\n")
+	parent, start, state, err := parseL8RuntimeOwnerProcIdentity(payload, 123)
+	if err != nil || parent != 77 || start != 424242 || state != 'S' {
+		t.Fatalf("process identity = parent %d start %d state %q, %v", parent, start, state, err)
+	}
+	for _, malformed := range [][]byte{
+		[]byte("123 (firecracker) S 0 1 2\n"),
+		[]byte("123 (firecracker) S bad " + strings.Repeat("1 ", 20)),
+		[]byte("124 (firecracker) " + strings.Join(fields, " ") + "\n"),
+	} {
+		if _, _, _, err := parseL8RuntimeOwnerProcIdentity(malformed, 123); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+			t.Fatalf("malformed process identity = %v", err)
+		}
+	}
+}
+
+func TestL8RuntimeOwnerPidfdSignalTerminalAndProcAbsenceAreDistinct(t *testing.T) {
+	path, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep executable unavailable")
+	}
+	command := exec.Command(path, "30")
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	reaped := false
+	defer func() {
+		if !reaped {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	}()
+	observation, err := inspectL8RuntimeOwnerProcess(uint32(command.Process.Pid))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer observation.Close()
+	if observation.ParentPID != uint32(syscall.Getpid()) || observation.state == 'Z' {
+		t.Fatalf("child observation = %#v", observation)
+	}
+	if err := signalL8RuntimeOwnerProcess(observation, syscall.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitL8RuntimeOwnerProcessTerminal(ctx, observation); err != nil {
+		t.Fatal(err)
+	}
+	if absent, err := inspectL8RuntimeOwnerProcessAbsent(observation.PID); err != nil || absent {
+		t.Fatalf("unreaped child absence = %t, %v", absent, err)
+	}
+	if err := command.Wait(); err == nil {
+		t.Fatal("SIGKILL child unexpectedly exited successfully")
+	}
+	reaped = true
+	if absent, err := inspectL8RuntimeOwnerProcessAbsent(observation.PID); err != nil || !absent {
+		t.Fatalf("reaped child absence = %t, %v", absent, err)
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_process_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_process_linux_test.go
@@ -38,6 +38,45 @@ func TestL8RuntimeOwnerProcessIdentityIncludesExactParentAndStart(t *testing.T) 
 	}
 }
 
+func TestL8RuntimeOwnerProcessLivenessRetriesInterruptedPoll(t *testing.T) {
+	calls := 0
+	alive := l8RuntimeOwnerProcessAliveWithPoll(17, func(fds []unix.PollFd, timeout int) (int, error) {
+		calls++
+		if len(fds) != 1 || fds[0].Fd != 17 || fds[0].Events != unix.POLLIN || timeout != 0 {
+			t.Fatalf("poll input = %#v timeout %d", fds, timeout)
+		}
+		if calls == 1 {
+			return -1, unix.EINTR
+		}
+		return 0, nil
+	})
+	if !alive || calls != 2 {
+		t.Fatalf("interrupted liveness = %v calls %d", alive, calls)
+	}
+}
+
+func TestL8RuntimeOwnerProcessIdentityAllowsSchedulerStateChanges(t *testing.T) {
+	if !sameL8RuntimeOwnerProcessIdentity(10, 20, 'R', 10, 20, 'S') {
+		t.Fatal("scheduler state change rejected stable process identity")
+	}
+	for _, scenario := range []struct {
+		beforeParent uint32
+		beforeStart  uint64
+		beforeState  byte
+		afterParent  uint32
+		afterStart   uint64
+		afterState   byte
+	}{
+		{beforeParent: 10, beforeStart: 20, beforeState: 'R', afterParent: 11, afterStart: 20, afterState: 'S'},
+		{beforeParent: 10, beforeStart: 20, beforeState: 'R', afterParent: 10, afterStart: 21, afterState: 'S'},
+		{beforeParent: 10, beforeStart: 20, beforeState: 'Z', afterParent: 10, afterStart: 20, afterState: 'Z'},
+	} {
+		if sameL8RuntimeOwnerProcessIdentity(scenario.beforeParent, scenario.beforeStart, scenario.beforeState, scenario.afterParent, scenario.afterStart, scenario.afterState) {
+			t.Fatalf("unstable process identity accepted: %#v", scenario)
+		}
+	}
+}
+
 func TestL8RuntimeOwnerReplacementClosesEveryOwnedPidfdOnFailure(t *testing.T) {
 	seed := l8RuntimeOwnerTestSeed()
 	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -213,6 +213,12 @@ func validateFirecrackerRuntimeOwnerRecordV1(record firecrackerRuntimeOwnerRecor
 	} else if record.FinalizedCommitID != "" {
 		return errL8RuntimeOwnerInvalid
 	}
+	switch record.State {
+	case "starting", "running", "stopping":
+		if record.AbsenceKind != "" || record.AbsenceRevision != 0 || record.AbsenceObservedAtUnixNano != 0 {
+			return errL8RuntimeOwnerInvalid
+		}
+	}
 	return nil
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -195,10 +195,17 @@ func validateFirecrackerRuntimeOwnerRecordV1(record firecrackerRuntimeOwnerRecor
 		record.RuleGenerationID != seed.RuleGenerationID {
 		return errL8RuntimeOwnerInvalid
 	}
-	if !validL8RuntimeOwnerState(record.State) {
+	if !validL8RuntimeOwnerState(record.State) || !validL8RuntimeOwnerControllerState(record.ControllerState) {
 		return errL8RuntimeOwnerInvalid
 	}
 	prelaunch := record.State == "starting" && record.Revision == 0
+	if record.State == "starting" {
+		if record.ControllerState != "none" || record.Revision > 1 {
+			return errL8RuntimeOwnerInvalid
+		}
+	} else if record.Revision < 2 {
+		return errL8RuntimeOwnerInvalid
+	}
 	if prelaunch {
 		if record.FirecrackerPID != 0 || record.FirecrackerStartTime != 0 {
 			return errL8RuntimeOwnerInvalid
@@ -206,11 +213,17 @@ func validateFirecrackerRuntimeOwnerRecordV1(record firecrackerRuntimeOwnerRecor
 	} else if record.Revision == 0 || record.FirecrackerPID == 0 || record.FirecrackerStartTime == 0 {
 		return errL8RuntimeOwnerInvalid
 	}
-	if record.State == "finalized" {
-		if !validL8RuntimeOwnerToken(record.FinalizedCommitID) {
+	if record.State == "finalizing" || record.State == "finalized" {
+		if !validL8RuntimeOwnerToken(record.FinalizedCommitID) || record.FinalizeTargetRevision == 0 {
 			return errL8RuntimeOwnerInvalid
 		}
-	} else if record.FinalizedCommitID != "" {
+		if record.State == "finalizing" && (record.ControllerState == "none" || record.Revision == ^uint64(0) || record.FinalizeTargetRevision != record.Revision+1) {
+			return errL8RuntimeOwnerInvalid
+		}
+		if record.State == "finalized" && (record.ControllerState == "none" || record.FinalizeTargetRevision > record.Revision) {
+			return errL8RuntimeOwnerInvalid
+		}
+	} else if record.FinalizedCommitID != "" || record.FinalizeTargetRevision != 0 {
 		return errL8RuntimeOwnerInvalid
 	}
 	switch record.State {
@@ -218,8 +231,25 @@ func validateFirecrackerRuntimeOwnerRecordV1(record firecrackerRuntimeOwnerRecor
 		if record.AbsenceKind != "" || record.AbsenceRevision != 0 || record.AbsenceObservedAtUnixNano != 0 {
 			return errL8RuntimeOwnerInvalid
 		}
+	case "absent", "finalizing", "finalized":
+		if !validL8RuntimeOwnerAbsence(record, seed) {
+			return errL8RuntimeOwnerInvalid
+		}
+	case "uncertain":
+		absentHistory := record.AbsenceKind != "" || record.AbsenceRevision != 0 || record.AbsenceObservedAtUnixNano != 0
+		if absentHistory && !validL8RuntimeOwnerAbsence(record, seed) {
+			return errL8RuntimeOwnerInvalid
+		}
 	}
 	return nil
+}
+
+func validL8RuntimeOwnerAbsence(record firecrackerRuntimeOwnerRecordV1, seed sandboxruntime.JobCredentialIdentitySeed) bool {
+	if record.AbsenceKind != "direct_wait" && record.AbsenceKind != "replacement_proc" {
+		return false
+	}
+	return record.AbsenceRevision > 0 && record.AbsenceRevision <= record.Revision &&
+		record.AbsenceObservedAtUnixNano >= seed.IssuedAt.UnixNano()
 }
 
 func encodeFirecrackerRuntimeOwnerRecordV1(record firecrackerRuntimeOwnerRecordV1, seed sandboxruntime.JobCredentialIdentitySeed, currentBootID string) ([]byte, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -35,6 +35,11 @@ type firecrackerRuntimeOwnerRecordV1 struct {
 	ContractVersion              string `json:"contractVersion"`
 	Revision                     uint64 `json:"revision"`
 	State                        string `json:"state"`
+	ControllerState              string `json:"controllerState"`
+	AbsenceKind                  string `json:"absenceKind"`
+	AbsenceRevision              uint64 `json:"absenceRevision"`
+	AbsenceObservedAtUnixNano    int64  `json:"absenceObservedAtUnixNano"`
+	FinalizeTargetRevision       uint64 `json:"finalizeTargetRevision"`
 	HostBootID                   string `json:"hostBootId"`
 	SeedCorrelationDigest        string `json:"seedCorrelationDigest"`
 	SupervisorGeneration         string `json:"supervisorGeneration"`
@@ -238,7 +243,9 @@ func decodeFirecrackerRuntimeOwnerRecordV1(payload []byte, seed sandboxruntime.J
 
 func l8RuntimeOwnerUniqueJSONObject(payload []byte) bool {
 	allowed := map[string]bool{
-		"contractVersion": true, "revision": true, "state": true, "hostBootId": true,
+		"contractVersion": true, "revision": true, "state": true, "controllerState": true,
+		"absenceKind": true, "absenceRevision": true, "absenceObservedAtUnixNano": true,
+		"finalizeTargetRevision": true, "hostBootId": true,
 		"seedCorrelationDigest": true, "supervisorGeneration": true, "supervisorPid": true,
 		"supervisorStartTime": true, "firecrackerPid": true, "firecrackerStartTime": true,
 		"finalizedCommitId": true, "sandboxId": true, "executionId": true, "workerId": true,
@@ -275,8 +282,11 @@ func l8RuntimeOwnerJSONFieldTypeValid(name string, payload json.RawMessage) bool
 		return false
 	}
 	switch name {
-	case "revision", "supervisorStartTime", "firecrackerStartTime":
+	case "revision", "absenceRevision", "finalizeTargetRevision", "supervisorStartTime", "firecrackerStartTime":
 		var value uint64
+		return json.Unmarshal(payload, &value) == nil
+	case "absenceObservedAtUnixNano":
+		var value int64
 		return json.Unmarshal(payload, &value) == nil
 	case "supervisorPid", "firecrackerPid":
 		var value uint32
@@ -289,7 +299,16 @@ func l8RuntimeOwnerJSONFieldTypeValid(name string, payload json.RawMessage) bool
 
 func validL8RuntimeOwnerState(state string) bool {
 	switch state {
-	case "starting", "unclaimed", "controlled", "stopping", "absent", "finalized", "uncertain":
+	case "starting", "running", "stopping", "absent", "finalizing", "finalized", "uncertain":
+		return true
+	default:
+		return false
+	}
+}
+
+func validL8RuntimeOwnerControllerState(state string) bool {
+	switch state {
+	case "none", "unclaimed", "controlled":
 		return true
 	default:
 		return false

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -71,6 +71,7 @@ type l8RuntimeOwnerRecoveryBinding struct {
 
 type l8RuntimeOwnerProcessObservation struct {
 	PID        uint32
+	ParentPID  uint32
 	StartTime  uint64
 	state      byte
 	pidfd      int

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_linux.go
@@ -73,20 +73,37 @@ func inspectL8RuntimeOwnerProcess(pid uint32) (l8RuntimeOwnerProcessObservation,
 		return l8RuntimeOwnerProcessObservation{}, errL8RuntimeOwnerInvalid
 	}
 	afterParent, afterStart, afterState, err := readL8RuntimeOwnerProcStat(processfd, pid)
-	if err != nil || afterParent != beforeParent || afterStart != beforeStart || afterState != beforeState || !l8RuntimeOwnerProcessAlive(pidfd) {
+	if err != nil || !sameL8RuntimeOwnerProcessIdentity(beforeParent, beforeStart, beforeState, afterParent, afterStart, afterState) ||
+		!l8RuntimeOwnerProcessAlive(pidfd) {
 		return l8RuntimeOwnerProcessObservation{}, errL8RuntimeOwnerInvalid
 	}
 	failed = false
 	return l8RuntimeOwnerProcessObservation{PID: pid, ParentPID: afterParent, StartTime: afterStart, state: afterState, pidfd: pidfd, pidfdOwned: true}, nil
 }
 
+func sameL8RuntimeOwnerProcessIdentity(beforeParent uint32, beforeStart uint64, beforeState byte, afterParent uint32, afterStart uint64, afterState byte) bool {
+	return beforeParent == afterParent && beforeStart == afterStart && beforeState != 'Z' && afterState != 'Z'
+}
+
 func l8RuntimeOwnerProcessAlive(pidfd int) bool {
+	return l8RuntimeOwnerProcessAliveWithPoll(pidfd, unix.Poll)
+}
+
+func l8RuntimeOwnerProcessAliveWithPoll(pidfd int, poll func([]unix.PollFd, int) (int, error)) bool {
 	if pidfd < 0 || uint64(pidfd) > uint64(^uint32(0)>>1) {
 		return false
 	}
-	poll := []unix.PollFd{{Fd: int32(pidfd), Events: unix.POLLIN}}
-	ready, err := unix.Poll(poll, 0)
-	return err == nil && ready == 0 && poll[0].Revents == 0
+	if poll == nil {
+		return false
+	}
+	for {
+		fds := []unix.PollFd{{Fd: int32(pidfd), Events: unix.POLLIN}}
+		ready, err := poll(fds, 0)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err == nil && ready == 0 && fds[0].Revents == 0
+	}
 }
 
 func readL8RuntimeOwnerProcStat(processfd int, pid uint32) (uint32, uint64, byte, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_linux.go
@@ -68,16 +68,16 @@ func inspectL8RuntimeOwnerProcess(pid uint32) (l8RuntimeOwnerProcessObservation,
 		return l8RuntimeOwnerProcessObservation{}, errL8RuntimeOwnerInvalid
 	}
 	defer unix.Close(processfd)
-	beforeStart, beforeState, err := readL8RuntimeOwnerProcStat(processfd, pid)
+	beforeParent, beforeStart, beforeState, err := readL8RuntimeOwnerProcStat(processfd, pid)
 	if err != nil || !l8RuntimeOwnerProcessAlive(pidfd) {
 		return l8RuntimeOwnerProcessObservation{}, errL8RuntimeOwnerInvalid
 	}
-	afterStart, afterState, err := readL8RuntimeOwnerProcStat(processfd, pid)
-	if err != nil || afterStart != beforeStart || afterState != beforeState || !l8RuntimeOwnerProcessAlive(pidfd) {
+	afterParent, afterStart, afterState, err := readL8RuntimeOwnerProcStat(processfd, pid)
+	if err != nil || afterParent != beforeParent || afterStart != beforeStart || afterState != beforeState || !l8RuntimeOwnerProcessAlive(pidfd) {
 		return l8RuntimeOwnerProcessObservation{}, errL8RuntimeOwnerInvalid
 	}
 	failed = false
-	return l8RuntimeOwnerProcessObservation{PID: pid, StartTime: afterStart, state: afterState, pidfd: pidfd, pidfdOwned: true}, nil
+	return l8RuntimeOwnerProcessObservation{PID: pid, ParentPID: afterParent, StartTime: afterStart, state: afterState, pidfd: pidfd, pidfdOwned: true}, nil
 }
 
 func l8RuntimeOwnerProcessAlive(pidfd int) bool {
@@ -89,42 +89,28 @@ func l8RuntimeOwnerProcessAlive(pidfd int) bool {
 	return err == nil && ready == 0 && poll[0].Revents == 0
 }
 
-func readL8RuntimeOwnerProcStat(processfd int, pid uint32) (uint64, byte, error) {
+func readL8RuntimeOwnerProcStat(processfd int, pid uint32) (uint32, uint64, byte, error) {
 	statfd, err := unix.Openat(processfd, "stat", unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
 	if err != nil {
-		return 0, 0, errL8RuntimeOwnerInvalid
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
 	}
 	statFile := os.NewFile(uintptr(statfd), "process-stat")
 	if statFile == nil {
 		_ = unix.Close(statfd)
-		return 0, 0, errL8RuntimeOwnerInvalid
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
 	}
 	payload, readErr := io.ReadAll(io.LimitReader(statFile, 4097))
 	closeErr := statFile.Close()
-	startTime, state, parseErr := parseL8RuntimeOwnerProcStat(payload, pid)
+	parent, startTime, state, parseErr := parseL8RuntimeOwnerProcIdentity(payload, pid)
 	if readErr != nil || closeErr != nil || len(payload) > 4096 || parseErr != nil {
-		return 0, 0, errL8RuntimeOwnerInvalid
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
 	}
-	return startTime, state, nil
+	return parent, startTime, state, nil
 }
 
 func parseL8RuntimeOwnerProcStat(payload []byte, expectedPID uint32) (uint64, byte, error) {
-	value := strings.TrimSuffix(string(payload), "\n")
-	open := strings.IndexByte(value, '(')
-	close := strings.LastIndexByte(value, ')')
-	if open <= 0 || close <= open || strings.TrimSpace(value[close+1:]) == "" {
-		return 0, 0, errL8RuntimeOwnerInvalid
-	}
-	parsedPID, err := strconv.ParseUint(strings.TrimSpace(value[:open]), 10, 32)
-	fields := strings.Fields(value[close+1:])
-	if err != nil || uint32(parsedPID) != expectedPID || len(fields) < 20 || len(fields[0]) != 1 {
-		return 0, 0, errL8RuntimeOwnerInvalid
-	}
-	startTime, err := strconv.ParseUint(fields[19], 10, 64)
-	if err != nil || startTime == 0 {
-		return 0, 0, errL8RuntimeOwnerInvalid
-	}
-	return startTime, fields[0][0], nil
+	_, startTime, state, err := parseL8RuntimeOwnerProcIdentity(payload, expectedPID)
+	return startTime, state, err
 }
 
 func writeL8RuntimeOwnerRecord(directory string, record firecrackerRuntimeOwnerRecordV1, seed sandboxruntime.JobCredentialIdentitySeed, currentBootID string) error {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_linux_test.go
@@ -66,6 +66,8 @@ func TestL8RuntimeOwnerStoreRejectsDirectoryModeAndHardlinks(t *testing.T) {
 	}
 	next := record
 	next.Revision = 1
+	next.State, next.ControllerState = "starting", "none"
+	next.AbsenceKind, next.AbsenceRevision, next.AbsenceObservedAtUnixNano = "", 0, 0
 	if err := writeL8RuntimeOwnerRecord(directory, next, seed, bootID); err != nil {
 		t.Fatalf("next revision write: %v", err)
 	}
@@ -74,6 +76,7 @@ func TestL8RuntimeOwnerStoreRejectsDirectoryModeAndHardlinks(t *testing.T) {
 	}
 	nextAgain := next
 	nextAgain.Revision = 2
+	nextAgain.State, nextAgain.ControllerState = "running", "unclaimed"
 	if err := writeL8RuntimeOwnerRecord(directory, nextAgain, seed, bootID); err != nil {
 		t.Fatalf("second revision write: %v", err)
 	}
@@ -120,9 +123,7 @@ func TestL8RuntimeOwnerStoreRequiresGenesisAndExclusiveCAS(t *testing.T) {
 		t.Fatalf("missing-record non-genesis write = %v", err)
 	}
 
-	genesis := nonGenesis
-	genesis.Revision, genesis.State = 0, "starting"
-	genesis.FirecrackerPID, genesis.FirecrackerStartTime = 0, 0
+	genesis := l8RuntimeOwnerTestGenesis(nonGenesis)
 	directoryFD, err := unix.Open(directory, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -153,6 +154,7 @@ func TestL8RuntimeOwnerStoreRequiresGenesisAndExclusiveCAS(t *testing.T) {
 			<-start
 			next := genesis
 			next.Revision = 1
+			next.State, next.ControllerState = "starting", "none"
 			next.FirecrackerPID, next.FirecrackerStartTime = 303, 404
 			next.ReconnectSecret = l8RuntimeOwnerTestToken(byte(index + 10))
 			results <- writeL8RuntimeOwnerRecord(directory, next, seed, bootID)

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
@@ -125,8 +125,8 @@ func TestL8RuntimeOwnerRecordValidationRejectsSubstitutionAndPIDReuse(t *testing
 	if err := validateFirecrackerRuntimeOwnerRecordV1(record, seed, bootID); err != nil {
 		t.Fatalf("valid record: %v", err)
 	}
-	supervisor := l8RuntimeOwnerProcessObservation{PID: record.SupervisorPID, StartTime: record.SupervisorStartTime, state: 'S', pidfd: 10, pidfdOwned: true}
-	firecracker := l8RuntimeOwnerProcessObservation{PID: record.FirecrackerPID, StartTime: record.FirecrackerStartTime, state: 'S', pidfd: 11, pidfdOwned: true}
+	supervisor := l8RuntimeOwnerProcessObservation{PID: record.SupervisorPID, ParentPID: 1, StartTime: record.SupervisorStartTime, state: 'S', pidfd: 10, pidfdOwned: true}
+	firecracker := l8RuntimeOwnerProcessObservation{PID: record.FirecrackerPID, ParentPID: record.SupervisorPID, StartTime: record.FirecrackerStartTime, state: 'S', pidfd: 11, pidfdOwned: true}
 	if err := validateL8RuntimeOwnerProcessCorrelation(record, supervisor, firecracker); err != nil {
 		t.Fatalf("valid process correlation: %v", err)
 	}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
@@ -101,7 +101,8 @@ func TestL8RuntimeOwnerCommitVerifierRecomputesSeedBoundHMAC(t *testing.T) {
 func TestL8RuntimeOwnerRecordSchemaIsExact(t *testing.T) {
 	typeOf := reflect.TypeOf(firecrackerRuntimeOwnerRecordV1{})
 	want := []string{
-		"ContractVersion", "Revision", "State", "HostBootID", "SeedCorrelationDigest", "SupervisorGeneration",
+		"ContractVersion", "Revision", "State", "ControllerState", "AbsenceKind", "AbsenceRevision", "AbsenceObservedAtUnixNano", "FinalizeTargetRevision",
+		"HostBootID", "SeedCorrelationDigest", "SupervisorGeneration",
 		"SupervisorPID", "SupervisorStartTime", "FirecrackerPID", "FirecrackerStartTime", "FinalizedCommitID",
 		"SandboxID", "ExecutionID", "WorkerID", "HostID", "RuntimeDriver", "RuntimeID", "RuntimeGeneration",
 		"FirecrackerProcessGeneration", "VsockGeneration", "NetworkPlanID", "PolicySnapshotID", "ProxySessionID",
@@ -164,8 +165,7 @@ func TestL8RuntimeOwnerRecordValidationRejectsSubstitutionAndPIDReuse(t *testing
 			}
 		})
 	}
-	starting := record
-	starting.Revision, starting.State, starting.FirecrackerPID, starting.FirecrackerStartTime = 0, "starting", 0, 0
+	starting := l8RuntimeOwnerTestGenesis(record)
 	if err := validateFirecrackerRuntimeOwnerRecordV1(starting, seed, bootID); err != nil {
 		t.Fatalf("revision-zero starting: %v", err)
 	}
@@ -321,7 +321,8 @@ func l8RuntimeOwnerTestRecord(t *testing.T, seed sandboxruntime.JobCredentialIde
 		t.Fatal(err)
 	}
 	return firecrackerRuntimeOwnerRecordV1{
-		ContractVersion: "firecracker-runtime-owner-private-v1", Revision: 8, State: "absent", HostBootID: bootID,
+		ContractVersion: "firecracker-runtime-owner-private-v1", Revision: 8, State: "absent", ControllerState: "unclaimed",
+		AbsenceKind: "direct_wait", AbsenceRevision: 8, AbsenceObservedAtUnixNano: seed.IssuedAt.Add(time.Second).UnixNano(), HostBootID: bootID,
 		SeedCorrelationDigest: hex.EncodeToString(digest[:]), SupervisorGeneration: l8RuntimeOwnerTestToken(1),
 		SupervisorPID: 101, SupervisorStartTime: 202, FirecrackerPID: 303, FirecrackerStartTime: 404,
 		SandboxID: seed.SandboxID, ExecutionID: seed.ExecutionID, WorkerID: seed.WorkerID, HostID: seed.HostID,
@@ -336,6 +337,11 @@ func l8RuntimeOwnerTestRecord(t *testing.T, seed sandboxruntime.JobCredentialIde
 func l8RuntimeOwnerTestGenesis(record firecrackerRuntimeOwnerRecordV1) firecrackerRuntimeOwnerRecordV1 {
 	record.Revision = 0
 	record.State = "starting"
+	record.ControllerState = "none"
+	record.AbsenceKind = ""
+	record.AbsenceRevision = 0
+	record.AbsenceObservedAtUnixNano = 0
+	record.FinalizeTargetRevision = 0
 	record.FirecrackerPID = 0
 	record.FirecrackerStartTime = 0
 	return record

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
@@ -315,8 +315,10 @@ func TestL8RuntimeOwnerLinuxStoreAndProcessInspectionArePrivate(t *testing.T) {
 	if err := writeL8RuntimeOwnerRecord(directory, genesis, seed, bootID); err != nil {
 		t.Fatalf("write owner genesis: %v", err)
 	}
-	stored := record
+	stored := genesis
 	stored.Revision = 1
+	stored.FirecrackerPID = record.FirecrackerPID
+	stored.FirecrackerStartTime = record.FirecrackerStartTime
 	if err := writeL8RuntimeOwnerRecord(directory, stored, seed, bootID); err != nil {
 		t.Fatalf("write owner record: %v", err)
 	}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
@@ -154,7 +154,18 @@ func TestL8RuntimeOwnerRecordValidationRejectsSubstitutionAndPIDReuse(t *testing
 		"partial child identity": func(value *firecrackerRuntimeOwnerRecordV1) { value.FirecrackerStartTime = 0 },
 		"bad state":              func(value *firecrackerRuntimeOwnerRecordV1) { value.State = "running" },
 		"finalized ID in absent": func(value *firecrackerRuntimeOwnerRecordV1) { value.FinalizedCommitID = l8RuntimeOwnerTestToken(9) },
-		"safe field mismatch":    func(value *firecrackerRuntimeOwnerRecordV1) { value.RuntimeID = "runtime-neighbor" },
+		"invalid controller":     func(value *firecrackerRuntimeOwnerRecordV1) { value.ControllerState = "claimable" },
+		"missing absence kind":   func(value *firecrackerRuntimeOwnerRecordV1) { value.AbsenceKind = "" },
+		"wrong absence kind":     func(value *firecrackerRuntimeOwnerRecordV1) { value.AbsenceKind = "replacement_proc_absence" },
+		"future absence revision": func(value *firecrackerRuntimeOwnerRecordV1) {
+			value.AbsenceRevision = value.Revision + 1
+		},
+		"zero absence time": func(value *firecrackerRuntimeOwnerRecordV1) { value.AbsenceObservedAtUnixNano = 0 },
+		"pre-seed absence time": func(value *firecrackerRuntimeOwnerRecordV1) {
+			value.AbsenceObservedAtUnixNano = seed.IssuedAt.Add(-time.Nanosecond).UnixNano()
+		},
+		"finalize target in absent": func(value *firecrackerRuntimeOwnerRecordV1) { value.FinalizeTargetRevision = value.Revision + 1 },
+		"safe field mismatch":       func(value *firecrackerRuntimeOwnerRecordV1) { value.RuntimeID = "runtime-neighbor" },
 	}
 	for name, mutate := range mutations {
 		t.Run(name, func(t *testing.T) {
@@ -168,6 +179,63 @@ func TestL8RuntimeOwnerRecordValidationRejectsSubstitutionAndPIDReuse(t *testing
 	starting := l8RuntimeOwnerTestGenesis(record)
 	if err := validateFirecrackerRuntimeOwnerRecordV1(starting, seed, bootID); err != nil {
 		t.Fatalf("revision-zero starting: %v", err)
+	}
+	revisionOne := starting
+	revisionOne.Revision, revisionOne.FirecrackerPID, revisionOne.FirecrackerStartTime = 1, record.FirecrackerPID, record.FirecrackerStartTime
+	if err := validateFirecrackerRuntimeOwnerRecordV1(revisionOne, seed, bootID); err != nil {
+		t.Fatalf("revision-one starting: %v", err)
+	}
+	for name, candidate := range map[string]firecrackerRuntimeOwnerRecordV1{
+		"starting revision two": func() firecrackerRuntimeOwnerRecordV1 { value := revisionOne; value.Revision = 2; return value }(),
+		"starting claimed": func() firecrackerRuntimeOwnerRecordV1 {
+			value := starting
+			value.ControllerState = "unclaimed"
+			return value
+		}(),
+		"running revision one": func() firecrackerRuntimeOwnerRecordV1 {
+			value := revisionOne
+			value.State = "running"
+			value.ControllerState = "unclaimed"
+			return value
+		}(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateFirecrackerRuntimeOwnerRecordV1(candidate, seed, bootID); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("validation = %v", err)
+			}
+		})
+	}
+
+	finalizing := record
+	finalizing.State = "finalizing"
+	finalizing.Revision++
+	finalizing.FinalizeTargetRevision = finalizing.Revision + 1
+	finalizing.FinalizedCommitID = l8RuntimeOwnerTestToken(10)
+	if err := validateFirecrackerRuntimeOwnerRecordV1(finalizing, seed, bootID); err != nil {
+		t.Fatalf("valid finalizing: %v", err)
+	}
+	finalized := finalizing
+	finalized.State = "finalized"
+	finalized.Revision = finalizing.FinalizeTargetRevision
+	if err := validateFirecrackerRuntimeOwnerRecordV1(finalized, seed, bootID); err != nil {
+		t.Fatalf("valid finalized: %v", err)
+	}
+	for name, mutate := range map[string]func(*firecrackerRuntimeOwnerRecordV1){
+		"finalizing wrong target": func(value *firecrackerRuntimeOwnerRecordV1) { value.FinalizeTargetRevision++ },
+		"finalizing missing ID":   func(value *firecrackerRuntimeOwnerRecordV1) { value.FinalizedCommitID = "" },
+		"finalized future target": func(value *firecrackerRuntimeOwnerRecordV1) { value.FinalizeTargetRevision = value.Revision + 1 },
+		"finalized malformed ID":  func(value *firecrackerRuntimeOwnerRecordV1) { value.FinalizedCommitID = "not-a-token" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := finalizing
+			if strings.HasPrefix(name, "finalized") {
+				candidate = finalized
+			}
+			mutate(&candidate)
+			if err := validateFirecrackerRuntimeOwnerRecordV1(candidate, seed, bootID); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("validation = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux.go
@@ -1,0 +1,779 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	l8RuntimeOwnerReconnectPrefix = ".runtime-owner-"
+	l8RuntimeOwnerReconnectSuffix = ".sock"
+	l8RuntimeOwnerRequiredSeals   = unix.F_SEAL_SEAL | unix.F_SEAL_SHRINK | unix.F_SEAL_GROW | unix.F_SEAL_WRITE
+)
+
+type l8RuntimeOwnerLinuxRuntime struct {
+	config      l8RuntimeOwnerSupervisorConfigV1
+	store       *l8RuntimeOwnerLinuxRecordStore
+	genesis     firecrackerRuntimeOwnerRecordV1
+	commitKey   []byte
+	listenerFD  int
+	listenerKey string
+	configFD    int
+	assetFDs    [2]int
+
+	mu         sync.Mutex
+	namespaces [2]*os.File
+	child      *l8RuntimeOwnerLinuxChild
+	contain    l8RuntimeOwnerContainmentController
+}
+
+type l8RuntimeOwnerLinuxRecordStore struct {
+	directoryFD int
+	seed        sandboxruntime.JobCredentialIdentitySeed
+	bootID      string
+}
+
+func runL8RuntimeOwnerSupervisorLinux(fds [6]int) error {
+	owned, err := newL8RuntimeOwnerLinuxRuntime(fds)
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	defer owned.close()
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store:               owned.store,
+		GenesisRecord:       owned.genesis,
+		ExpectedUID:         owned.config.DaemonUID,
+		RandomToken:         randomL8RuntimeOwnerToken,
+		StartChild:          owned.startChild,
+		ContainChild:        owned.containChild,
+		ReinspectAbsence:    owned.reinspectAbsence,
+		DuplicateNamespaces: owned.duplicateNamespaces,
+		CloseNamespaces:     owned.closeNamespaces,
+		AbortStartingZero:   owned.closeNamespaces,
+		CommitKey:           owned.commitKey,
+	})
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	defer clear(owner.opts.CommitKey)
+	if err := owned.serveBootstrap(owner, fds[0]); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := owned.serveControllers(owner); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func runL8RuntimeOwnerChildGateLinux(fds [6]int) error {
+	if validateL8RuntimeOwnerSeqpacketFD(fds[0]) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	config, err := readL8RuntimeOwnerSupervisorConfigFD(fds[1])
+	if err != nil || validateL8RuntimeOwnerNamespacePair(fds[2], fds[3]) != nil ||
+		validateL8RuntimeOwnerAssetFD(fds[4], config.Kernel) != nil || validateL8RuntimeOwnerAssetFD(fds[5], config.Rootfs) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	parentPID := os.Getppid()
+	if parentPID <= 1 {
+		return errL8RuntimeOwnerInvalid
+	}
+	return runL8RuntimeOwnerChildGate(l8RuntimeOwnerChildGateOps{
+		ArmPdeathsigAndVerifyParent: func() error {
+			if unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0) != nil || os.Getppid() != parentPID {
+				return errL8RuntimeOwnerInvalid
+			}
+			return nil
+		},
+		SendArmed: func() error {
+			return sendL8RuntimeOwnerSeqpacket(fds[0], l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeChildArmed}, nil)
+		},
+		AwaitRelease: func() error {
+			if setL8RuntimeOwnerSocketTimeout(fds[0], l8RuntimeOwnerHandshakeTimeout) != nil {
+				return errL8RuntimeOwnerInvalid
+			}
+			received, err := receiveL8RuntimeOwnerSeqpacket(fds[0])
+			if err != nil {
+				return errL8RuntimeOwnerInvalid
+			}
+			defer closeL8RuntimeOwnerFiles(received.Files)
+			if validateL8RuntimeOwnerPacketRole(received.Packet, true, len(received.Files)) != nil || received.Packet.Opcode != l8RuntimeOwnerOpcodeChildRelease {
+				return errL8RuntimeOwnerInvalid
+			}
+			return nil
+		},
+		RemapAndExec: func() error {
+			return remapAndExecL8RuntimeOwnerChild(config, [4]int{fds[2], fds[3], fds[4], fds[5]}, l8RuntimeOwnerFDRemapOps{
+				DuplicateAtLeast: func(fd, minimum int) (int, error) {
+					return unix.FcntlInt(uintptr(fd), unix.F_DUPFD_CLOEXEC, minimum)
+				},
+				Dup3:      unix.Dup3,
+				Close:     unix.Close,
+				CloseFrom: func(first int) error { return unix.CloseRange(uint(first), ^uint(0), 0) },
+				Exec:      unix.Exec,
+			})
+		},
+	})
+}
+
+func newL8RuntimeOwnerLinuxRuntime(fds [6]int) (*l8RuntimeOwnerLinuxRuntime, error) {
+	if validateL8RuntimeOwnerSeqpacketFD(fds[0]) != nil || validateL8RuntimeOwnerDirectoryFD(fds[1]) != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	config, err := readL8RuntimeOwnerSupervisorConfigFD(fds[2])
+	if err != nil || config.DaemonUID != uint32(os.Geteuid()) ||
+		validateL8RuntimeOwnerAssetFD(fds[3], config.Kernel) != nil || validateL8RuntimeOwnerAssetFD(fds[4], config.Rootfs) != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	keyFD, err := unix.FcntlInt(uintptr(fds[5]), unix.F_DUPFD_CLOEXEC, 9)
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	key, err := loadL8RuntimeOwnerStableKeyFD(keyFD, config.DaemonUID, realL8RuntimeOwnerKeyFDOps())
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	keepKey := false
+	defer func() {
+		if !keepKey {
+			clear(key)
+		}
+	}()
+	bootID, err := readL8RuntimeOwnerHostBootID()
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	supervisor, err := inspectL8RuntimeOwnerProcess(uint32(os.Getpid()))
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	defer supervisor.Close()
+	supervisorGeneration, err := randomL8RuntimeOwnerToken()
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	listenerIdentity, err := randomL8RuntimeOwnerToken()
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	reconnectSecret, err := randomL8RuntimeOwnerToken()
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	listenerFD, listenerKey, err := openL8RuntimeOwnerReconnectListener(fds[1], listenerIdentity)
+	if err != nil {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	seedDigest, err := l8RuntimeOwnerSeedDigest(config.Seed)
+	if err != nil {
+		_ = unix.Close(listenerFD)
+		_ = unix.Unlinkat(fds[1], listenerKey, 0)
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	owned := &l8RuntimeOwnerLinuxRuntime{
+		config:      config,
+		store:       &l8RuntimeOwnerLinuxRecordStore{directoryFD: fds[1], seed: config.Seed, bootID: bootID},
+		commitKey:   key,
+		listenerFD:  listenerFD,
+		listenerKey: listenerKey,
+		configFD:    fds[2],
+		assetFDs:    [2]int{fds[3], fds[4]},
+	}
+	owned.genesis = l8RuntimeOwnerGenesisRecord(config.Seed, bootID, supervisorGeneration, listenerIdentity, reconnectSecret, supervisor, seedDigest)
+	keepKey = true
+	return owned, nil
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) close() {
+	if owned == nil {
+		return
+	}
+	owned.mu.Lock()
+	child := owned.child
+	owned.mu.Unlock()
+	if child != nil {
+		_ = child.abort()
+		_ = child.close()
+	}
+	_ = owned.closeNamespaces()
+	if owned.listenerFD >= 0 {
+		_ = unix.Close(owned.listenerFD)
+		owned.listenerFD = -1
+	}
+	if owned.listenerKey != "" && owned.store != nil {
+		_ = unix.Unlinkat(owned.store.directoryFD, owned.listenerKey, 0)
+	}
+	for index := range owned.commitKey {
+		owned.commitKey[index] = 0
+	}
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) serveBootstrap(owner *l8RuntimeOwnerSupervisor, fd int) error {
+	if owner == nil || setL8RuntimeOwnerSocketTimeout(fd, l8RuntimeOwnerHandshakeTimeout) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	uid, err := l8RuntimeOwnerPeerUID(fd)
+	if err != nil || uid != owned.config.DaemonUID {
+		return errL8RuntimeOwnerInvalid
+	}
+	received, err := receiveL8RuntimeOwnerSeqpacket(fd)
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	transferred := false
+	defer func() {
+		if !transferred {
+			closeL8RuntimeOwnerFiles(received.Files)
+		}
+	}()
+	if validateL8RuntimeOwnerPacketRole(received.Packet, false, len(received.Files)) != nil || received.Packet.Opcode != l8RuntimeOwnerOpcodeBootstrapStart {
+		return errL8RuntimeOwnerInvalid
+	}
+	correlation, err := decodeL8RuntimeOwnerNamespaceCorrelation(received.Packet.Body)
+	if err != nil || validateL8RuntimeOwnerNamespaceFiles(received.Files, correlation) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	owned.mu.Lock()
+	if owned.namespaces[0] != nil || owned.namespaces[1] != nil {
+		owned.mu.Unlock()
+		return errL8RuntimeOwnerInvalid
+	}
+	copy(owned.namespaces[:], received.Files)
+	owned.mu.Unlock()
+	transferred = true
+	result, err := owner.HandleBootstrap(context.Background(), uid, received)
+	if err != nil || sendL8RuntimeOwnerControlResult(fd, result) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) serveControllers(owner *l8RuntimeOwnerSupervisor) error {
+	for {
+		fd, _, err := unix.Accept4(owned.listenerFD, unix.SOCK_CLOEXEC)
+		if err != nil {
+			return errL8RuntimeOwnerInvalid
+		}
+		exit, controllerErr := owned.serveController(owner, fd)
+		_ = unix.Close(fd)
+		if controllerErr != nil {
+			continue
+		}
+		if exit {
+			return nil
+		}
+	}
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) serveController(owner *l8RuntimeOwnerSupervisor, fd int) (bool, error) {
+	if owner == nil || setL8RuntimeOwnerSocketTimeout(fd, l8RuntimeOwnerHandshakeTimeout) != nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	uid, err := l8RuntimeOwnerPeerUID(fd)
+	if err != nil || uid != owned.config.DaemonUID {
+		_ = sendL8RuntimeOwnerReject(fd)
+		return false, errL8RuntimeOwnerInvalid
+	}
+	received, err := receiveL8RuntimeOwnerSeqpacket(fd)
+	if err != nil {
+		_ = sendL8RuntimeOwnerReject(fd)
+		return false, errL8RuntimeOwnerInvalid
+	}
+	defer closeL8RuntimeOwnerFiles(received.Files)
+	if validateL8RuntimeOwnerPacketRole(received.Packet, false, len(received.Files)) != nil || received.Packet.Opcode != l8RuntimeOwnerOpcodeHandshake {
+		_ = sendL8RuntimeOwnerReject(fd)
+		return false, errL8RuntimeOwnerInvalid
+	}
+	result, err := owner.AdmitController(context.Background(), uid, received)
+	if err != nil {
+		_ = sendL8RuntimeOwnerReject(fd)
+		return false, errL8RuntimeOwnerInvalid
+	}
+	if sendL8RuntimeOwnerControlResult(fd, result) != nil || setL8RuntimeOwnerSocketTimeout(fd, 0) != nil {
+		_ = owner.ControllerLost(context.Background())
+		return false, errL8RuntimeOwnerInvalid
+	}
+	for {
+		request, err := receiveL8RuntimeOwnerSeqpacket(fd)
+		if err != nil {
+			_ = owner.ControllerLost(context.Background())
+			return false, errL8RuntimeOwnerInvalid
+		}
+		if validateL8RuntimeOwnerPacketRole(request.Packet, false, len(request.Files)) != nil {
+			closeL8RuntimeOwnerFiles(request.Files)
+			_ = sendL8RuntimeOwnerReject(fd)
+			_ = owner.ControllerLost(context.Background())
+			return false, errL8RuntimeOwnerInvalid
+		}
+		response, handleErr := owner.HandleController(context.Background(), request)
+		closeL8RuntimeOwnerFiles(request.Files)
+		if handleErr != nil || sendL8RuntimeOwnerControlResult(fd, response) != nil {
+			_ = sendL8RuntimeOwnerReject(fd)
+			_ = owner.ControllerLost(context.Background())
+			return false, errL8RuntimeOwnerInvalid
+		}
+		if request.Packet.Opcode == l8RuntimeOwnerOpcodeClose {
+			return false, nil
+		}
+		if response.Exit {
+			return true, nil
+		}
+	}
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) startChild() (l8RuntimeOwnerStartedChild, error) {
+	owned.mu.Lock()
+	defer owned.mu.Unlock()
+	if owned.child != nil || owned.namespaces[0] == nil || owned.namespaces[1] == nil {
+		return l8RuntimeOwnerStartedChild{}, errL8RuntimeOwnerInvalid
+	}
+	child, err := startL8RuntimeOwnerLinuxChild(owned.configFD, owned.namespaces, owned.assetFDs)
+	if err != nil {
+		return l8RuntimeOwnerStartedChild{}, errL8RuntimeOwnerInvalid
+	}
+	owned.child = child
+	return l8RuntimeOwnerStartedChild{
+		Observation: child.observation,
+		Release:     child.release,
+		Abort:       child.abort,
+	}, nil
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) containChild() (l8RuntimeOwnerAbsenceObservation, error) {
+	owned.mu.Lock()
+	child := owned.child
+	owned.mu.Unlock()
+	if child == nil {
+		return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+	}
+	return owned.contain.Stop(l8RuntimeOwnerContainmentOps{
+		RecordStopping:  func() (uint64, error) { return 1, nil },
+		Terminate:       func() error { return child.signal(syscall.SIGTERM) },
+		Wait:            child.wait,
+		Kill:            func() error { return child.signal(syscall.SIGKILL) },
+		RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) (uint64, error) { return 1, nil },
+		RecordUncertain: func() (uint64, error) { return 1, nil },
+		Now:             time.Now,
+	})
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) reinspectAbsence() (l8RuntimeOwnerAbsenceObservation, error) {
+	owned.mu.Lock()
+	child := owned.child
+	owned.mu.Unlock()
+	if child == nil {
+		return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), l8RuntimeOwnerHandshakeTimeout)
+	defer cancel()
+	reaped, err := child.wait(ctx)
+	if err != nil || !reaped {
+		return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+	}
+	return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: time.Now()}, nil
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) duplicateNamespaces() ([]int, error) {
+	owned.mu.Lock()
+	defer owned.mu.Unlock()
+	result := make([]int, 0, 2)
+	for _, namespace := range owned.namespaces {
+		if namespace == nil {
+			for _, fd := range result {
+				_ = unix.Close(fd)
+			}
+			return nil, errL8RuntimeOwnerInvalid
+		}
+		fd, err := unix.FcntlInt(namespace.Fd(), unix.F_DUPFD_CLOEXEC, 3)
+		if err != nil {
+			for _, opened := range result {
+				_ = unix.Close(opened)
+			}
+			return nil, errL8RuntimeOwnerInvalid
+		}
+		result = append(result, fd)
+	}
+	return result, nil
+}
+
+func (owned *l8RuntimeOwnerLinuxRuntime) closeNamespaces() error {
+	owned.mu.Lock()
+	defer owned.mu.Unlock()
+	var failed bool
+	for index, namespace := range owned.namespaces {
+		if namespace != nil {
+			failed = namespace.Close() != nil || failed
+			owned.namespaces[index] = nil
+		}
+	}
+	if failed {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) Load(ctx context.Context) (firecrackerRuntimeOwnerRecordV1, error) {
+	record, present, err := store.withLock(ctx, unix.LOCK_SH, func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
+		return readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)
+	})
+	if err != nil || !present {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	return record, nil
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) CreateGenesis(ctx context.Context, next firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	record, _, err := store.withLock(ctx, unix.LOCK_EX, func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
+		_, present, readErr := readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)
+		if readErr != nil || present || next.Revision != 0 || next.State != "starting" || next.ControllerState != "none" {
+			return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+		}
+		if writeL8RuntimeOwnerRecordAt(store.directoryFD, next, store.seed, store.bootID) != nil {
+			return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+		}
+		return next, true, nil
+	})
+	return record, err
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) Transition(ctx context.Context, expected uint64, next firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	record, _, err := store.withLock(ctx, unix.LOCK_EX, func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
+		current, present, readErr := readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)
+		if readErr != nil || !present || current.Revision != expected || !validL8RuntimeOwnerTransition(current, next) {
+			return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+		}
+		if writeL8RuntimeOwnerRecordAt(store.directoryFD, next, store.seed, store.bootID) != nil {
+			observed, observedPresent, observedErr := readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)
+			if observedErr != nil || !observedPresent || observed != next {
+				return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+			}
+		}
+		return next, true, nil
+	})
+	return record, err
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) RetireStartingZero(ctx context.Context, expected uint64) error {
+	return store.retire(ctx, func(record firecrackerRuntimeOwnerRecordV1) bool {
+		return expected == 0 && record.Revision == 0 && record.State == "starting" && record.ControllerState == "none" && record.FirecrackerPID == 0
+	})
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) RetireFinalized(ctx context.Context, expected uint64, commitID string) error {
+	return store.retire(ctx, func(record firecrackerRuntimeOwnerRecordV1) bool {
+		return record.State == "finalized" && record.Revision == expected && record.FinalizedCommitID == commitID
+	})
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) retire(ctx context.Context, accept func(firecrackerRuntimeOwnerRecordV1) bool) error {
+	_, _, err := store.withLock(ctx, unix.LOCK_EX, func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
+		record, present, readErr := readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)
+		if readErr != nil || !present || accept == nil || !accept(record) || unix.Unlinkat(store.directoryFD, l8RuntimeOwnerRecordName, 0) != nil || unix.Fsync(store.directoryFD) != nil {
+			return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+		}
+		return record, false, nil
+	})
+	return err
+}
+
+func (store *l8RuntimeOwnerLinuxRecordStore) withLock(ctx context.Context, operation int, fn func() (firecrackerRuntimeOwnerRecordV1, bool, error)) (firecrackerRuntimeOwnerRecordV1, bool, error) {
+	if store == nil || store.directoryFD < 0 || fn == nil || ctx == nil {
+		return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+	}
+	for {
+		lockErr := unix.Flock(store.directoryFD, operation|unix.LOCK_NB)
+		if lockErr == nil {
+			break
+		}
+		if !errors.Is(lockErr, unix.EWOULDBLOCK) && !errors.Is(lockErr, unix.EAGAIN) {
+			return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+		}
+		select {
+		case <-ctx.Done():
+			return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	record, present, err := fn()
+	if unix.Flock(store.directoryFD, unix.LOCK_UN) != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+	}
+	return record, present, err
+}
+
+func writeL8RuntimeOwnerRecordAt(directoryFD int, record firecrackerRuntimeOwnerRecordV1, seed sandboxruntime.JobCredentialIdentitySeed, bootID string) error {
+	payload, err := encodeFirecrackerRuntimeOwnerRecordV1(record, seed, bootID)
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	var random [16]byte
+	if _, err := io.ReadFull(rand.Reader, random[:]); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	temporary := ".runtime-owner-" + hex.EncodeToString(random[:]) + ".tmp"
+	fd, err := unix.Openat(directoryFD, temporary, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	remove := true
+	defer func() {
+		if fd >= 0 {
+			_ = unix.Close(fd)
+		}
+		if remove {
+			_ = unix.Unlinkat(directoryFD, temporary, 0)
+		}
+	}()
+	if unix.Fchmod(fd, 0o600) != nil || writeL8RuntimeOwnerRecordPayload(fd, payload) != nil || unix.Fsync(fd) != nil || unix.Close(fd) != nil {
+		fd = -1
+		return errL8RuntimeOwnerInvalid
+	}
+	fd = -1
+	if unix.Renameat(directoryFD, temporary, directoryFD, l8RuntimeOwnerRecordName) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	remove = false
+	if unix.Fsync(directoryFD) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func l8RuntimeOwnerGenesisRecord(seed sandboxruntime.JobCredentialIdentitySeed, bootID, supervisorGeneration, listenerIdentity, reconnectSecret string, supervisor l8RuntimeOwnerProcessObservation, seedDigest [32]byte) firecrackerRuntimeOwnerRecordV1 {
+	return firecrackerRuntimeOwnerRecordV1{
+		ContractVersion:              l8RuntimeOwnerContractVersion,
+		State:                        "starting",
+		ControllerState:              "none",
+		HostBootID:                   bootID,
+		SeedCorrelationDigest:        hex.EncodeToString(seedDigest[:]),
+		SupervisorGeneration:         supervisorGeneration,
+		SupervisorPID:                supervisor.PID,
+		SupervisorStartTime:          supervisor.StartTime,
+		SandboxID:                    seed.SandboxID,
+		ExecutionID:                  seed.ExecutionID,
+		WorkerID:                     seed.WorkerID,
+		HostID:                       seed.HostID,
+		RuntimeDriver:                seed.RuntimeDriver,
+		RuntimeID:                    seed.RuntimeID,
+		RuntimeGeneration:            seed.RuntimeGeneration,
+		FirecrackerProcessGeneration: seed.FirecrackerProcessGeneration,
+		VsockGeneration:              seed.VsockGeneration,
+		NetworkPlanID:                seed.NetworkPlanID,
+		PolicySnapshotID:             seed.PolicySnapshotID,
+		ProxySessionID:               seed.ProxySessionID,
+		ProxyGenerationID:            seed.ProxyGenerationID,
+		TopologyGenerationID:         seed.TopologyGenerationID,
+		RuleGenerationID:             seed.RuleGenerationID,
+		ReconnectListenerIdentity:    listenerIdentity,
+		ReconnectSecret:              reconnectSecret,
+	}
+}
+
+func randomL8RuntimeOwnerToken() (string, error) {
+	var value [32]byte
+	if _, err := io.ReadFull(rand.Reader, value[:]); err != nil {
+		return "", errL8RuntimeOwnerInvalid
+	}
+	return base64.RawURLEncoding.EncodeToString(value[:]), nil
+}
+
+func readL8RuntimeOwnerSupervisorConfigFD(fd int) (l8RuntimeOwnerSupervisorConfigV1, error) {
+	identity, err := validateL8RuntimeOwnerSealedRegularFD(fd, l8RuntimeOwnerSupervisorConfigLimit)
+	if err != nil || identity.Size <= 0 {
+		return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+	}
+	payload := make([]byte, identity.Size)
+	read, err := unix.Pread(fd, payload, 0)
+	if err != nil || read != len(payload) {
+		return l8RuntimeOwnerSupervisorConfigV1{}, errL8RuntimeOwnerInvalid
+	}
+	return decodeL8RuntimeOwnerSupervisorConfig(payload)
+}
+
+func validateL8RuntimeOwnerAssetFD(fd int, expected l8RuntimeOwnerDescriptorIdentityV1) error {
+	identity, err := validateL8RuntimeOwnerSealedRegularFD(fd, 0)
+	if err != nil || identity.Size <= 0 || identity.Device != expected.Device || identity.Inode != expected.Inode {
+		return errL8RuntimeOwnerInvalid
+	}
+	digest := sha256.New()
+	buffer := make([]byte, 128<<10)
+	var offset int64
+	for offset < identity.Size {
+		limit := int64(len(buffer))
+		if remaining := identity.Size - offset; remaining < limit {
+			limit = remaining
+		}
+		read, err := unix.Pread(fd, buffer[:limit], offset)
+		if err != nil || read <= 0 {
+			return errL8RuntimeOwnerInvalid
+		}
+		_, _ = digest.Write(buffer[:read])
+		offset += int64(read)
+	}
+	if hex.EncodeToString(digest.Sum(nil)) != expected.Digest {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func validateL8RuntimeOwnerSealedRegularFD(fd int, sizeLimit int64) (l8RuntimeOwnerKeyIdentity, error) {
+	var stat unix.Stat_t
+	flags, flagErr := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	access, accessErr := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+	seals, sealErr := unix.FcntlInt(uintptr(fd), unix.F_GET_SEALS, 0)
+	if unix.Fstat(fd, &stat) != nil || flagErr != nil || accessErr != nil || sealErr != nil ||
+		stat.Mode&unix.S_IFMT != unix.S_IFREG || stat.Nlink != 0 || flags&unix.FD_CLOEXEC == 0 || access&unix.O_ACCMODE != unix.O_RDONLY ||
+		seals != l8RuntimeOwnerRequiredSeals || stat.Size < 0 || sizeLimit > 0 && stat.Size > sizeLimit {
+		return l8RuntimeOwnerKeyIdentity{}, errL8RuntimeOwnerInvalid
+	}
+	return l8RuntimeOwnerKeyIdentity{Regular: true, Size: stat.Size, Device: uint64(stat.Dev), Inode: stat.Ino}, nil
+}
+
+func validateL8RuntimeOwnerDirectoryFD(fd int) error {
+	var stat unix.Stat_t
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil || unix.Fstat(fd, &stat) != nil || stat.Mode&unix.S_IFMT != unix.S_IFDIR || stat.Mode&0o777 != 0o700 ||
+		stat.Uid != uint32(os.Geteuid()) || flags&unix.FD_CLOEXEC == 0 {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func validateL8RuntimeOwnerSeqpacketFD(fd int) error {
+	typeValue, err := unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_TYPE)
+	if err != nil || typeValue != unix.SOCK_SEQPACKET {
+		return errL8RuntimeOwnerInvalid
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func validateL8RuntimeOwnerNamespacePair(userFD, networkFD int) error {
+	userIdentity, userErr := l8RuntimeOwnerStatNamespaceFD(userFD)
+	networkIdentity, networkErr := l8RuntimeOwnerStatNamespaceFD(networkFD)
+	if userErr != nil || networkErr != nil || userIdentity == networkIdentity {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func l8RuntimeOwnerStatNamespaceFD(fd int) (l8RuntimeOwnerNSIdentity, error) {
+	var stat unix.Stat_t
+	var statfs unix.Statfs_t
+	if unix.Fstat(fd, &stat) != nil || unix.Fstatfs(fd, &statfs) != nil || statfs.Type != unix.NSFS_MAGIC {
+		return l8RuntimeOwnerNSIdentity{}, errL8RuntimeOwnerInvalid
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+		return l8RuntimeOwnerNSIdentity{}, errL8RuntimeOwnerInvalid
+	}
+	return l8RuntimeOwnerNSIdentity{device: uint64(stat.Dev), inode: stat.Ino}, nil
+}
+
+func realL8RuntimeOwnerKeyFDOps() l8RuntimeOwnerKeyFDOps {
+	return l8RuntimeOwnerKeyFDOps{
+		Stat: func(fd int) (l8RuntimeOwnerKeyIdentity, error) {
+			var stat unix.Stat_t
+			if unix.Fstat(fd, &stat) != nil {
+				return l8RuntimeOwnerKeyIdentity{}, errL8RuntimeOwnerInvalid
+			}
+			return l8RuntimeOwnerKeyIdentity{
+				Regular: stat.Mode&unix.S_IFMT == unix.S_IFREG,
+				Mode:    uint32(stat.Mode & 0o777),
+				UID:     stat.Uid,
+				Links:   uint64(stat.Nlink),
+				Size:    stat.Size,
+				Device:  uint64(stat.Dev),
+				Inode:   stat.Ino,
+			}, nil
+		},
+		Pread: unix.Pread,
+		Close: unix.Close,
+	}
+}
+
+func openL8RuntimeOwnerReconnectListener(directoryFD int, identity string) (int, string, error) {
+	if !validL8RuntimeOwnerToken(identity) {
+		return -1, "", errL8RuntimeOwnerInvalid
+	}
+	name := l8RuntimeOwnerReconnectPrefix + identity + l8RuntimeOwnerReconnectSuffix
+	path := "/proc/self/fd/" + strconv.Itoa(directoryFD) + "/" + name
+	if len(path) >= len(unix.RawSockaddrUnix{}.Path) {
+		return -1, "", errL8RuntimeOwnerInvalid
+	}
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return -1, "", errL8RuntimeOwnerInvalid
+	}
+	failed := true
+	defer func() {
+		if failed {
+			_ = unix.Close(fd)
+			_ = unix.Unlinkat(directoryFD, name, 0)
+		}
+	}()
+	if unix.Bind(fd, &unix.SockaddrUnix{Name: path}) != nil || unix.Fchmodat(directoryFD, name, 0o600, 0) != nil || unix.Listen(fd, 1) != nil {
+		return -1, "", errL8RuntimeOwnerInvalid
+	}
+	failed = false
+	return fd, name, nil
+}
+
+func sendL8RuntimeOwnerControlResult(fd int, result l8RuntimeOwnerControlResult) error {
+	if validateL8RuntimeOwnerPacketRole(result.Packet, true, len(result.Files)) != nil {
+		for _, opened := range result.Files {
+			_ = unix.Close(opened)
+		}
+		return errL8RuntimeOwnerInvalid
+	}
+	files := make([]*os.File, 0, len(result.Files))
+	for index, opened := range result.Files {
+		file := os.NewFile(uintptr(opened), "runtime-owner-response-right")
+		if file == nil {
+			for _, owned := range files {
+				_ = owned.Close()
+			}
+			for _, remaining := range result.Files[index:] {
+				_ = unix.Close(remaining)
+			}
+			return errL8RuntimeOwnerInvalid
+		}
+		files = append(files, file)
+	}
+	defer closeL8RuntimeOwnerFiles(files)
+	if sendL8RuntimeOwnerSeqpacket(fd, result.Packet, files) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func sendL8RuntimeOwnerReject(fd int) error {
+	return sendL8RuntimeOwnerSeqpacket(fd, l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeReject, Status: l8RuntimeOwnerStatusRejected}, nil)
+}
+
+func setL8RuntimeOwnerSocketTimeout(fd int, timeout time.Duration) error {
+	value := unix.NsecToTimeval(timeout.Nanoseconds())
+	if timeout == 0 {
+		value = unix.Timeval{}
+	}
+	if unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &value) != nil || unix.SetsockoptTimeval(fd, unix.SOL_SOCKET, unix.SO_SNDTIMEO, &value) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux_test.go
@@ -1,0 +1,231 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestL8RuntimeOwnerLinuxRecordStorePersistsExactFSM(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	directoryFD, err := unix.Open(directory, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(directoryFD)
+	seed := l8RuntimeOwnerTestSeed()
+	bootID := "01234567-89ab-cdef-0123-456789abcdef"
+	store := &l8RuntimeOwnerLinuxRecordStore{directoryFD: directoryFD, seed: seed, bootID: bootID}
+	genesis := l8RuntimeOwnerTestGenesis(l8RuntimeOwnerTestRecord(t, seed, bootID))
+	if created, err := store.CreateGenesis(context.Background(), genesis); err != nil || created != genesis {
+		t.Fatalf("create genesis = %#v, %v", created, err)
+	}
+	if _, err := store.CreateGenesis(context.Background(), genesis); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("duplicate genesis = %v", err)
+	}
+	revisionOne := genesis
+	revisionOne.Revision = 1
+	revisionOne.FirecrackerPID = 5001
+	revisionOne.FirecrackerStartTime = 7001
+	if updated, err := store.Transition(context.Background(), 0, revisionOne); err != nil || updated != revisionOne {
+		t.Fatalf("revision one = %#v, %v", updated, err)
+	}
+	running := revisionOne
+	running.Revision = 2
+	running.State = "running"
+	running.ControllerState = "unclaimed"
+	if updated, err := store.Transition(context.Background(), 1, running); err != nil || updated != running {
+		t.Fatalf("running = %#v, %v", updated, err)
+	}
+	if loaded, err := store.Load(context.Background()); err != nil || loaded != running {
+		t.Fatalf("load = %#v, %v", loaded, err)
+	}
+	if _, err := store.Transition(context.Background(), 1, running); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("stale transition = %v", err)
+	}
+}
+
+func TestL8RuntimeOwnerLinuxConfigAndAssetsRequireSealedReadOnlyDescriptors(t *testing.T) {
+	kernel := []byte("kernel-image")
+	rootfs := []byte("rootfs-image")
+	kernelFD := newL8RuntimeOwnerTestSealedFD(t, "kernel", kernel)
+	defer unix.Close(kernelFD)
+	rootfsFD := newL8RuntimeOwnerTestSealedFD(t, "rootfs", rootfs)
+	defer unix.Close(rootfsFD)
+	config := l8RuntimeOwnerTestSupervisorConfig()
+	config.Kernel = l8RuntimeOwnerTestAssetIdentity(t, "kernel", kernelFD, kernel)
+	config.Rootfs = l8RuntimeOwnerTestAssetIdentity(t, "rootfs", rootfsFD, rootfs)
+	payload, err := encodeL8RuntimeOwnerSupervisorConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configFD := newL8RuntimeOwnerTestSealedFD(t, "config", payload)
+	defer unix.Close(configFD)
+	decoded, err := readL8RuntimeOwnerSupervisorConfigFD(configFD)
+	if err != nil || !l8RuntimeOwnerSupervisorConfigsEqual(decoded, config) {
+		t.Fatalf("config = %#v, %v", decoded, err)
+	}
+	if err := validateL8RuntimeOwnerAssetFD(kernelFD, config.Kernel); err != nil {
+		t.Fatal(err)
+	}
+	mutated := config.Kernel
+	mutated.Digest = hex.EncodeToString(make([]byte, sha256.Size))
+	if err := validateL8RuntimeOwnerAssetFD(kernelFD, mutated); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("digest substitution = %v", err)
+	}
+}
+
+func TestL8RuntimeOwnerLinuxReconnectListenerIsPrivateAndSameUID(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	directoryFD, err := unix.Open(directory, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(directoryFD)
+	identity := l8RuntimeOwnerTestToken(17)
+	listenerFD, name, err := openL8RuntimeOwnerReconnectListener(directoryFD, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(listenerFD)
+	defer unix.Unlinkat(directoryFD, name, 0)
+	info, err := os.Lstat(filepath.Join(directory, name))
+	if err != nil || info.Mode().Perm() != 0o600 || info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("listener = %#v, %v", info, err)
+	}
+	clientFD, err := unix.Socket(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(clientFD)
+	if err := unix.Connect(clientFD, &unix.SockaddrUnix{Name: "/proc/self/fd/" + strconv.Itoa(directoryFD) + "/" + name}); err != nil {
+		t.Fatal(err)
+	}
+	acceptedFD, _, err := unix.Accept4(listenerFD, unix.SOCK_CLOEXEC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(acceptedFD)
+	uid, err := l8RuntimeOwnerPeerUID(acceptedFD)
+	if err != nil || uid != uint32(os.Geteuid()) {
+		t.Fatalf("peer uid = %d, %v", uid, err)
+	}
+}
+
+func TestL8RuntimeOwnerLinuxSupervisorProductionCompositionReachesTransport(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	directoryFD, err := unix.Open(directory, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(directoryFD)
+
+	kernel := []byte("kernel-image")
+	rootfs := []byte("rootfs-image")
+	kernelFD := newL8RuntimeOwnerTestSealedFD(t, "kernel", kernel)
+	defer unix.Close(kernelFD)
+	rootfsFD := newL8RuntimeOwnerTestSealedFD(t, "rootfs", rootfs)
+	defer unix.Close(rootfsFD)
+	config := l8RuntimeOwnerTestSupervisorConfig()
+	config.DaemonUID = uint32(os.Geteuid())
+	config.Kernel = l8RuntimeOwnerTestAssetIdentity(t, "kernel", kernelFD, kernel)
+	config.Rootfs = l8RuntimeOwnerTestAssetIdentity(t, "rootfs", rootfsFD, rootfs)
+	payload, err := encodeL8RuntimeOwnerSupervisorConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configFD := newL8RuntimeOwnerTestSealedFD(t, "config", payload)
+	defer unix.Close(configFD)
+
+	keyPath := filepath.Join(directory, "owner-key")
+	if err := os.WriteFile(keyPath, make([]byte, 32), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key, err := os.Open(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer key.Close()
+	if err := os.Chmod(keyPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	control, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(control[0])
+	defer unix.Close(control[1])
+
+	owned, err := newL8RuntimeOwnerLinuxRuntime([6]int{control[0], directoryFD, configFD, kernelFD, rootfsFD, int(key.Fd())})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer owned.close()
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, entry := range entries {
+		name := entry.Name()
+		if len(name) > len(l8RuntimeOwnerReconnectPrefix)+len(l8RuntimeOwnerReconnectSuffix) &&
+			name[:len(l8RuntimeOwnerReconnectPrefix)] == l8RuntimeOwnerReconnectPrefix &&
+			name[len(name)-len(l8RuntimeOwnerReconnectSuffix):] == l8RuntimeOwnerReconnectSuffix {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("production supervisor composition did not publish its reconnect transport")
+	}
+}
+
+func newL8RuntimeOwnerTestSealedFD(t *testing.T, name string, payload []byte) int {
+	t.Helper()
+	fd, err := unix.MemfdCreate(name, unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := unix.Write(fd, payload); err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_ADD_SEALS, l8RuntimeOwnerRequiredSeals); err != nil {
+		_ = unix.Close(fd)
+		t.Fatal(err)
+	}
+	readOnly, err := unix.Open("/proc/self/fd/"+strconv.Itoa(fd), unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	_ = unix.Close(fd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return readOnly
+}
+
+func l8RuntimeOwnerTestAssetIdentity(t *testing.T, kind string, fd int, payload []byte) l8RuntimeOwnerDescriptorIdentityV1 {
+	t.Helper()
+	var stat unix.Stat_t
+	if unix.Fstat(fd, &stat) != nil {
+		t.Fatal("stat asset")
+	}
+	digest := sha256.Sum256(payload)
+	return l8RuntimeOwnerDescriptorIdentityV1{Kind: kind, Device: uint64(stat.Dev), Inode: stat.Ino, Digest: hex.EncodeToString(digest[:])}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
@@ -1,6 +1,7 @@
 package firecrackerhost
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/binary"
@@ -168,6 +169,7 @@ type l8RuntimeOwnerSupervisor struct {
 	lastSequence      uint64
 	lastOpcode        uint16
 	lastPacket        l8RuntimeOwnerPacketV1
+	lastRequestBody   []byte
 	hasLast           bool
 }
 
@@ -731,14 +733,17 @@ func containL8RuntimeOwnerReplacement(record firecrackerRuntimeOwnerRecordV1, op
 	}
 	supervisor, supervisorExists, err := ops.InspectSupervisor(record.SupervisorPID)
 	if err != nil {
+		_ = supervisor.Close()
 		return fail()
 	}
 	if supervisorExists {
 		_ = supervisor.Close()
 		return fail()
 	}
+	_ = supervisor.Close()
 	child, childExists, err := ops.InspectChild(record.FirecrackerPID)
 	if err != nil {
+		_ = child.Close()
 		return fail()
 	}
 	if childExists {
@@ -752,6 +757,8 @@ func containL8RuntimeOwnerReplacement(record firecrackerRuntimeOwnerRecordV1, op
 		if ops.WaitTerminal != nil {
 			_ = l8RuntimeOwnerCall(func() error { return ops.WaitTerminal(context.Background(), child) })
 		}
+	} else {
+		_ = child.Close()
 	}
 	firstAbsent, err := ops.ProcessAbsent(record.FirecrackerPID)
 	if err != nil || !firstAbsent {
@@ -929,6 +936,9 @@ func (owner *l8RuntimeOwnerSupervisor) AdmitController(ctx context.Context, uid 
 	next.Revision = record.Revision + 1
 	next.ControllerState = "controlled"
 	next.ReconnectSecret = secret
+	if err := owner.refreshFinalizingIntent(&next); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
 	if _, err := owner.opts.Store.Transition(ctx, record.Revision, next); err != nil {
 		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
 	}
@@ -942,6 +952,7 @@ func (owner *l8RuntimeOwnerSupervisor) AdmitController(ctx context.Context, uid 
 	owner.sessionGeneration = session
 	owner.hasLast = false
 	owner.lastSequence = 0
+	owner.lastRequestBody = nil
 	return l8RuntimeOwnerControlResult{Packet: l8RuntimeOwnerPacketV1{
 		Opcode: l8RuntimeOwnerOpcodeHandshake,
 		Status: l8RuntimeOwnerStatusOK,
@@ -956,6 +967,9 @@ func (owner *l8RuntimeOwnerSupervisor) HandleController(ctx context.Context, rec
 	owner.mu.Lock()
 	defer owner.mu.Unlock()
 	if owner.hasLast && received.Packet.Sequence == owner.lastSequence && received.Packet.Opcode == owner.lastOpcode {
+		if received.Packet.Status != l8RuntimeOwnerStatusOK || !bytes.Equal(received.Packet.Body, owner.lastRequestBody) {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
 		result := l8RuntimeOwnerControlResult{Packet: owner.lastPacket}
 		if received.Packet.Opcode == l8RuntimeOwnerOpcodeAcquireNamespaces {
 			files, err := owner.duplicateNamespaces()
@@ -989,6 +1003,7 @@ func (owner *l8RuntimeOwnerSupervisor) HandleController(ctx context.Context, rec
 	owner.lastSequence = received.Packet.Sequence
 	owner.lastOpcode = received.Packet.Opcode
 	owner.lastPacket = result.Packet
+	owner.lastRequestBody = append(owner.lastRequestBody[:0], received.Packet.Body...)
 	owner.hasLast = true
 	return result, nil
 }
@@ -1009,6 +1024,7 @@ func (owner *l8RuntimeOwnerSupervisor) ControllerLost(ctx context.Context) error
 	owner.sessionGeneration = ""
 	owner.hasLast = false
 	owner.lastSequence = 0
+	owner.lastRequestBody = nil
 	return nil
 }
 
@@ -1045,10 +1061,11 @@ func (owner *l8RuntimeOwnerSupervisor) dispatchController(ctx context.Context, r
 		}
 		return owner.controllerOK(received.Packet, body, files, false), nil
 	case l8RuntimeOwnerOpcodeClose:
-		if _, err := owner.unclaim(ctx, record); err != nil {
+		next, err := owner.unclaim(ctx, record)
+		if err != nil {
 			return l8RuntimeOwnerControlResult{}, err
 		}
-		body, err := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseFromRecord(record, false))
+		body, err := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseFromRecord(next, false))
 		if err != nil {
 			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
 		}
@@ -1076,7 +1093,7 @@ func (owner *l8RuntimeOwnerSupervisor) dispatchController(ctx context.Context, r
 		expected := l8RuntimeOwnerCommitRequestV1{
 			ControllerSessionGeneration: owner.sessionGeneration,
 			CommitID:                    record.FinalizedCommitID,
-			FinalizedRevision:           record.Revision,
+			FinalizedRevision:           record.FinalizeTargetRevision,
 		}
 		if record.State != "finalized" || request != expected {
 			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
@@ -1085,7 +1102,7 @@ func (owner *l8RuntimeOwnerSupervisor) dispatchController(ctx context.Context, r
 			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
 		}
 		body := make([]byte, 8)
-		binary.BigEndian.PutUint64(body, record.Revision)
+		binary.BigEndian.PutUint64(body, record.FinalizeTargetRevision)
 		return owner.controllerOK(received.Packet, body, nil, true), nil
 	case l8RuntimeOwnerOpcodeAbortStart:
 		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
@@ -1129,6 +1146,9 @@ func (owner *l8RuntimeOwnerSupervisor) unclaim(ctx context.Context, record firec
 		}
 		next.ReconnectSecret = secret
 	}
+	if err := owner.refreshFinalizingIntent(&next); err != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
 	updated, err := owner.opts.Store.Transition(ctx, record.Revision, next)
 	if err != nil {
 		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
@@ -1158,7 +1178,8 @@ func (owner *l8RuntimeOwnerSupervisor) reinspectAbsence(ctx context.Context, rec
 }
 
 func (owner *l8RuntimeOwnerSupervisor) finalize(ctx context.Context, record firecrackerRuntimeOwnerRecordV1, request l8RuntimeOwnerFinalizeRequestV1) (l8RuntimeOwnerFinalizeAckV1, error) {
-	if record.State != "absent" || request.AbsenceRevision != record.AbsenceRevision || request.ObservedAtUnixNano != record.AbsenceObservedAtUnixNano {
+	if (record.State != "absent" && record.State != "finalizing" && record.State != "finalized") ||
+		request.AbsenceRevision != record.AbsenceRevision || request.ObservedAtUnixNano != record.AbsenceObservedAtUnixNano {
 		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
 	}
 	digestBytes, err := hex.DecodeString(record.SeedCorrelationDigest)
@@ -1167,29 +1188,67 @@ func (owner *l8RuntimeOwnerSupervisor) finalize(ctx context.Context, record fire
 	}
 	var seedDigest [32]byte
 	copy(seedDigest[:], digestBytes)
-	finalizedRevision := record.Revision + 2
-	commitID, err := l8RuntimeOwnerCommitID(owner.opts.CommitKey, seedDigest, finalizedRevision)
-	if err != nil {
-		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	if record.State == "finalized" {
+		expected, err := l8RuntimeOwnerCommitID(owner.opts.CommitKey, seedDigest, record.FinalizeTargetRevision)
+		if err != nil || subtle.ConstantTimeCompare([]byte(expected), []byte(record.FinalizedCommitID)) != 1 {
+			return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+		}
+		return l8RuntimeOwnerFinalizeAckV1{CommitID: record.FinalizedCommitID, FinalizedRevision: record.FinalizeTargetRevision}, nil
 	}
+
 	finalizing := record
-	finalizing.Revision = record.Revision + 1
-	finalizing.State = "finalizing"
-	finalizing.FinalizeTargetRevision = finalizedRevision
-	finalizing.FinalizedCommitID = commitID
-	if _, err := owner.opts.Store.Transition(ctx, record.Revision, finalizing); err != nil {
-		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	if record.State == "absent" {
+		if record.Revision > ^uint64(0)-2 {
+			return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+		}
+		finalizing.Revision = record.Revision + 1
+		finalizing.State = "finalizing"
+		finalizing.FinalizeTargetRevision = record.Revision + 2
+		finalizing.FinalizedCommitID, err = l8RuntimeOwnerCommitID(owner.opts.CommitKey, seedDigest, finalizing.FinalizeTargetRevision)
+		if err != nil {
+			return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+		}
+		if _, err := owner.opts.Store.Transition(ctx, record.Revision, finalizing); err != nil {
+			return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+		}
+	} else {
+		expected, err := l8RuntimeOwnerCommitID(owner.opts.CommitKey, seedDigest, record.FinalizeTargetRevision)
+		if err != nil || record.Revision == ^uint64(0) || record.FinalizeTargetRevision != record.Revision+1 ||
+			subtle.ConstantTimeCompare([]byte(expected), []byte(record.FinalizedCommitID)) != 1 {
+			return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+		}
 	}
 	if owner.opts.CloseNamespaces == nil || owner.opts.CloseNamespaces() != nil {
 		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
 	}
 	finalized := finalizing
-	finalized.Revision = finalizedRevision
+	finalized.Revision = finalizing.FinalizeTargetRevision
 	finalized.State = "finalized"
 	if _, err := owner.opts.Store.Transition(ctx, finalizing.Revision, finalized); err != nil {
 		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
 	}
-	return l8RuntimeOwnerFinalizeAckV1{CommitID: commitID, FinalizedRevision: finalizedRevision}, nil
+	return l8RuntimeOwnerFinalizeAckV1{CommitID: finalized.FinalizedCommitID, FinalizedRevision: finalized.FinalizeTargetRevision}, nil
+}
+
+func (owner *l8RuntimeOwnerSupervisor) refreshFinalizingIntent(record *firecrackerRuntimeOwnerRecordV1) error {
+	if record == nil || record.State != "finalizing" {
+		return nil
+	}
+	if record.Revision == ^uint64(0) {
+		return errL8RuntimeOwnerInvalid
+	}
+	digestBytes, err := hex.DecodeString(record.SeedCorrelationDigest)
+	if err != nil || len(digestBytes) != 32 {
+		return errL8RuntimeOwnerInvalid
+	}
+	var seedDigest [32]byte
+	copy(seedDigest[:], digestBytes)
+	record.FinalizeTargetRevision = record.Revision + 1
+	record.FinalizedCommitID, err = l8RuntimeOwnerCommitID(owner.opts.CommitKey, seedDigest, record.FinalizeTargetRevision)
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
 }
 
 func l8RuntimeOwnerControllerSession(packet l8RuntimeOwnerPacketV1) (string, error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
@@ -1,0 +1,167 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+const (
+	l8RuntimeOwnerProtocolMagic           = "HL8OWNR1"
+	l8RuntimeOwnerProtocolVersion  uint16 = 1
+	l8RuntimeOwnerPacketHeaderSize        = 24
+	l8RuntimeOwnerPacketLimit             = 512
+	l8RuntimeOwnerHandshakeTimeout        = 5 * time.Second
+
+	l8RuntimeOwnerOpcodeBootstrapStart     uint16 = 1
+	l8RuntimeOwnerOpcodeBootstrapPublished uint16 = 2
+	l8RuntimeOwnerOpcodeChildArmed         uint16 = 3
+	l8RuntimeOwnerOpcodeChildRelease       uint16 = 4
+	l8RuntimeOwnerOpcodeHandshake          uint16 = 5
+	l8RuntimeOwnerOpcodeAbortStart         uint16 = 6
+	l8RuntimeOwnerOpcodeInspect            uint16 = 7
+	l8RuntimeOwnerOpcodeStopReap           uint16 = 8
+	l8RuntimeOwnerOpcodeAcquireNamespaces  uint16 = 9
+	l8RuntimeOwnerOpcodeFinalize           uint16 = 10
+	l8RuntimeOwnerOpcodeCommit             uint16 = 11
+	l8RuntimeOwnerOpcodeClose              uint16 = 12
+
+	l8RuntimeOwnerStatusOK           uint16 = 0
+	l8RuntimeOwnerStatusRejected     uint16 = 1
+	l8RuntimeOwnerStatusInvalidState uint16 = 2
+	l8RuntimeOwnerStatusUncertain    uint16 = 3
+	l8RuntimeOwnerStatusUnsupported  uint16 = 4
+)
+
+var errL8RuntimeOwnerProtocol = errors.New("firecracker runtime owner protocol rejected")
+
+type l8RuntimeOwnerPacketHeaderV1 struct {
+	Magic      [8]byte
+	Version    uint16
+	Opcode     uint16
+	Status     uint16
+	BodyLength uint16
+	Sequence   uint64
+}
+
+type l8RuntimeOwnerPacketV1 struct {
+	Opcode   uint16
+	Status   uint16
+	Sequence uint64
+	Body     []byte
+}
+
+type l8RuntimeOwnerHandshakeV1 struct {
+	SupervisorGeneration string
+	RuntimeGeneration    string
+	RecordRevision       uint64
+	ReconnectSecret      string
+}
+
+type l8RuntimeOwnerHandshakeAckV1 struct {
+	ControllerSessionGeneration string
+	RecordRevision              uint64
+}
+
+type l8RuntimeOwnerResponseV1 struct {
+	State              byte
+	AbsenceKind        byte
+	RecordRevision     uint64
+	ObservedAtUnixNano int64
+}
+
+type l8RuntimeOwnerAbsenceObservation struct {
+	Kind       byte
+	Revision   uint64
+	ObservedAt time.Time
+}
+
+type l8RuntimeOwnerContainmentOps struct {
+	RecordStopping  func() error
+	Terminate       func() error
+	Wait            func(context.Context) (bool, error)
+	Kill            func() error
+	RecordAbsent    func(l8RuntimeOwnerAbsenceObservation) error
+	RecordUncertain func() error
+	Now             func() time.Time
+}
+
+type l8RuntimeOwnerContainmentController struct {
+	mu          sync.Mutex
+	completed   bool
+	observation l8RuntimeOwnerAbsenceObservation
+	result      error
+}
+
+type l8RuntimeOwnerReplacementOps struct {
+	CurrentBootID      func() (string, error)
+	InspectSupervisor  func(uint32) (l8RuntimeOwnerProcessObservation, bool, error)
+	InspectChild       func(uint32) (l8RuntimeOwnerProcessObservation, bool, error)
+	SignalKill         func(l8RuntimeOwnerProcessObservation) error
+	WaitTerminal       func(context.Context, l8RuntimeOwnerProcessObservation) error
+	ProcessAbsent      func(uint32) (bool, error)
+	AcquisitionBarrier func() error
+	RecordAbsent       func(l8RuntimeOwnerAbsenceObservation) error
+	RecordUncertain    func() error
+	Now                func() time.Time
+}
+
+func encodeL8RuntimeOwnerPacket(l8RuntimeOwnerPacketV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerPacket([]byte) (l8RuntimeOwnerPacketV1, error) {
+	return l8RuntimeOwnerPacketV1{}, errL8RuntimeOwnerProtocol
+}
+
+func encodeL8RuntimeOwnerHandshake(l8RuntimeOwnerHandshakeV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerHandshake([]byte) (l8RuntimeOwnerHandshakeV1, error) {
+	return l8RuntimeOwnerHandshakeV1{}, errL8RuntimeOwnerProtocol
+}
+
+func encodeL8RuntimeOwnerHandshakeAck(l8RuntimeOwnerHandshakeAckV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerHandshakeAck([]byte) (l8RuntimeOwnerHandshakeAckV1, error) {
+	return l8RuntimeOwnerHandshakeAckV1{}, errL8RuntimeOwnerProtocol
+}
+
+func encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerResponse([]byte) (l8RuntimeOwnerResponseV1, error) {
+	return l8RuntimeOwnerResponseV1{}, errL8RuntimeOwnerProtocol
+}
+
+func validL8RuntimeOwnerTransition(firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1) bool {
+	return false
+}
+
+func reconcileL8RuntimeOwnerCommitUncertain(firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, bool, error) {
+	return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+}
+
+func containL8RuntimeOwnerChild(l8RuntimeOwnerContainmentOps) (l8RuntimeOwnerAbsenceObservation, error) {
+	return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+}
+
+func (controller *l8RuntimeOwnerContainmentController) Stop(ops l8RuntimeOwnerContainmentOps) (l8RuntimeOwnerAbsenceObservation, error) {
+	controller.mu.Lock()
+	defer controller.mu.Unlock()
+	if controller.completed {
+		return controller.observation, controller.result
+	}
+	controller.observation, controller.result = containL8RuntimeOwnerChild(ops)
+	controller.completed = true
+	return controller.observation, controller.result
+}
+
+func containL8RuntimeOwnerReplacement(firecrackerRuntimeOwnerRecordV1, l8RuntimeOwnerReplacementOps) (l8RuntimeOwnerAbsenceObservation, error) {
+	return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
@@ -14,6 +14,7 @@ const (
 	l8RuntimeOwnerPacketLimit             = 512
 	l8RuntimeOwnerHandshakeTimeout        = 5 * time.Second
 
+	l8RuntimeOwnerOpcodeReject             uint16 = 0
 	l8RuntimeOwnerOpcodeBootstrapStart     uint16 = 1
 	l8RuntimeOwnerOpcodeBootstrapPublished uint16 = 2
 	l8RuntimeOwnerOpcodeChildArmed         uint16 = 3
@@ -64,6 +65,27 @@ type l8RuntimeOwnerHandshakeAckV1 struct {
 	RecordRevision              uint64
 }
 
+type l8RuntimeOwnerControllerRequestV1 struct {
+	ControllerSessionGeneration string
+}
+
+type l8RuntimeOwnerFinalizeRequestV1 struct {
+	ControllerSessionGeneration string
+	AbsenceRevision             uint64
+	ObservedAtUnixNano          int64
+}
+
+type l8RuntimeOwnerFinalizeAckV1 struct {
+	CommitID          string
+	FinalizedRevision uint64
+}
+
+type l8RuntimeOwnerCommitRequestV1 struct {
+	ControllerSessionGeneration string
+	CommitID                    string
+	FinalizedRevision           uint64
+}
+
 type l8RuntimeOwnerResponseV1 struct {
 	State              byte
 	AbsenceKind        byte
@@ -77,13 +99,57 @@ type l8RuntimeOwnerAbsenceObservation struct {
 	ObservedAt time.Time
 }
 
+type l8RuntimeOwnerRecordStore interface {
+	Load(context.Context) (firecrackerRuntimeOwnerRecordV1, error)
+	CreateGenesis(context.Context, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error)
+	Transition(context.Context, uint64, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error)
+	RetireStartingZero(context.Context, uint64) error
+	RetireFinalized(context.Context, uint64, string) error
+}
+
+type l8RuntimeOwnerTransactionOps struct {
+	Lock           func(context.Context) error
+	Unlock         func() error
+	Read           func() (firecrackerRuntimeOwnerRecordV1, bool, error)
+	WriteAndRename func(firecrackerRuntimeOwnerRecordV1) error
+	SyncDirectory  func() error
+}
+
+type l8RuntimeOwnerControlResult struct {
+	Packet l8RuntimeOwnerPacketV1
+	Files  []int
+	Exit   bool
+}
+
+type l8RuntimeOwnerStartedChild struct {
+	Observation l8RuntimeOwnerProcessObservation
+	Release     func() error
+	Abort       func() error
+}
+
+type l8RuntimeOwnerSupervisorOptions struct {
+	Store               l8RuntimeOwnerRecordStore
+	GenesisRecord       firecrackerRuntimeOwnerRecordV1
+	ExpectedUID         uint32
+	RandomToken         func() (string, error)
+	StartChild          func() (l8RuntimeOwnerStartedChild, error)
+	ContainChild        func() (l8RuntimeOwnerAbsenceObservation, error)
+	ReinspectAbsence    func() (l8RuntimeOwnerAbsenceObservation, error)
+	DuplicateNamespaces func() ([]int, error)
+	CloseNamespaces     func() error
+	AbortStartingZero   func() error
+	CommitKey           []byte
+}
+
+type l8RuntimeOwnerSupervisor struct{}
+
 type l8RuntimeOwnerContainmentOps struct {
-	RecordStopping  func() error
+	RecordStopping  func() (uint64, error)
 	Terminate       func() error
 	Wait            func(context.Context) (bool, error)
 	Kill            func() error
-	RecordAbsent    func(l8RuntimeOwnerAbsenceObservation) error
-	RecordUncertain func() error
+	RecordAbsent    func(l8RuntimeOwnerAbsenceObservation) (uint64, error)
+	RecordUncertain func() (uint64, error)
 	Now             func() time.Time
 }
 
@@ -102,8 +168,8 @@ type l8RuntimeOwnerReplacementOps struct {
 	WaitTerminal       func(context.Context, l8RuntimeOwnerProcessObservation) error
 	ProcessAbsent      func(uint32) (bool, error)
 	AcquisitionBarrier func() error
-	RecordAbsent       func(l8RuntimeOwnerAbsenceObservation) error
-	RecordUncertain    func() error
+	RecordAbsent       func(l8RuntimeOwnerAbsenceObservation) (uint64, error)
+	RecordUncertain    func() (uint64, error)
 	Now                func() time.Time
 }
 
@@ -139,12 +205,52 @@ func decodeL8RuntimeOwnerResponse([]byte) (l8RuntimeOwnerResponseV1, error) {
 	return l8RuntimeOwnerResponseV1{}, errL8RuntimeOwnerProtocol
 }
 
+func encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerControllerRequest([]byte) (l8RuntimeOwnerControllerRequestV1, error) {
+	return l8RuntimeOwnerControllerRequestV1{}, errL8RuntimeOwnerProtocol
+}
+
+func encodeL8RuntimeOwnerFinalizeRequest(l8RuntimeOwnerFinalizeRequestV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerFinalizeRequest([]byte) (l8RuntimeOwnerFinalizeRequestV1, error) {
+	return l8RuntimeOwnerFinalizeRequestV1{}, errL8RuntimeOwnerProtocol
+}
+
+func encodeL8RuntimeOwnerFinalizeAck(l8RuntimeOwnerFinalizeAckV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerFinalizeAck([]byte) (l8RuntimeOwnerFinalizeAckV1, error) {
+	return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerProtocol
+}
+
+func encodeL8RuntimeOwnerCommitRequest(l8RuntimeOwnerCommitRequestV1) ([]byte, error) {
+	return nil, errL8RuntimeOwnerProtocol
+}
+
+func decodeL8RuntimeOwnerCommitRequest([]byte) (l8RuntimeOwnerCommitRequestV1, error) {
+	return l8RuntimeOwnerCommitRequestV1{}, errL8RuntimeOwnerProtocol
+}
+
+func validateL8RuntimeOwnerPacketRole(l8RuntimeOwnerPacketV1, bool, int) error {
+	return errL8RuntimeOwnerProtocol
+}
+
 func validL8RuntimeOwnerTransition(firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1) bool {
 	return false
 }
 
 func reconcileL8RuntimeOwnerCommitUncertain(firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, bool, error) {
 	return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
+}
+
+func transitionL8RuntimeOwnerRecordLocked(context.Context, l8RuntimeOwnerTransactionOps, uint64, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 }
 
 func containL8RuntimeOwnerChild(l8RuntimeOwnerContainmentOps) (l8RuntimeOwnerAbsenceObservation, error) {
@@ -164,4 +270,28 @@ func (controller *l8RuntimeOwnerContainmentController) Stop(ops l8RuntimeOwnerCo
 
 func containL8RuntimeOwnerReplacement(firecrackerRuntimeOwnerRecordV1, l8RuntimeOwnerReplacementOps) (l8RuntimeOwnerAbsenceObservation, error) {
 	return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+}
+
+func newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions) (*l8RuntimeOwnerSupervisor, error) {
+	return nil, errL8RuntimeOwnerInvalid
+}
+
+func (*l8RuntimeOwnerSupervisor) HandleBootstrap(context.Context, uint32, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+}
+
+func (*l8RuntimeOwnerSupervisor) AbortStart(context.Context, uint32, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+}
+
+func (*l8RuntimeOwnerSupervisor) AdmitController(context.Context, uint32, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+}
+
+func (*l8RuntimeOwnerSupervisor) HandleController(context.Context, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+}
+
+func (*l8RuntimeOwnerSupervisor) ControllerLost(context.Context) error {
+	return errL8RuntimeOwnerInvalid
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
@@ -2,6 +2,10 @@ package firecrackerhost
 
 import (
 	"context"
+	"crypto/subtle"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"sync"
 	"time"
@@ -33,6 +37,22 @@ const (
 	l8RuntimeOwnerStatusInvalidState uint16 = 2
 	l8RuntimeOwnerStatusUncertain    uint16 = 3
 	l8RuntimeOwnerStatusUnsupported  uint16 = 4
+
+	l8RuntimeOwnerTokenSize                      = 43
+	l8RuntimeOwnerHandshakeGenerationMin         = 1
+	l8RuntimeOwnerHandshakeGenerationMax         = 128
+	l8RuntimeOwnerContainmentBudget              = 30 * time.Second
+	l8RuntimeOwnerContainmentTermWaitBudget      = 5 * time.Second
+	l8RuntimeOwnerAbsenceKindNone           byte = 0
+	l8RuntimeOwnerAbsenceKindWait           byte = 1
+	l8RuntimeOwnerAbsenceKindProc           byte = 2
+	l8RuntimeOwnerStateStarting             byte = 1
+	l8RuntimeOwnerStateRunning              byte = 2
+	l8RuntimeOwnerStateStopping             byte = 3
+	l8RuntimeOwnerStateAbsent               byte = 4
+	l8RuntimeOwnerStateFinalizing           byte = 5
+	l8RuntimeOwnerStateFinalized            byte = 6
+	l8RuntimeOwnerStateUncertain            byte = 7
 )
 
 var errL8RuntimeOwnerProtocol = errors.New("firecracker runtime owner protocol rejected")
@@ -141,7 +161,15 @@ type l8RuntimeOwnerSupervisorOptions struct {
 	CommitKey           []byte
 }
 
-type l8RuntimeOwnerSupervisor struct{}
+type l8RuntimeOwnerSupervisor struct {
+	mu                sync.Mutex
+	opts              l8RuntimeOwnerSupervisorOptions
+	sessionGeneration string
+	lastSequence      uint64
+	lastOpcode        uint16
+	lastPacket        l8RuntimeOwnerPacketV1
+	hasLast           bool
+}
 
 type l8RuntimeOwnerContainmentOps struct {
 	RecordStopping  func() (uint64, error)
@@ -173,88 +201,499 @@ type l8RuntimeOwnerReplacementOps struct {
 	Now                func() time.Time
 }
 
-func encodeL8RuntimeOwnerPacket(l8RuntimeOwnerPacketV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerPacket(packet l8RuntimeOwnerPacketV1) ([]byte, error) {
+	if len(packet.Body) > l8RuntimeOwnerPacketLimit-l8RuntimeOwnerPacketHeaderSize {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	if validateL8RuntimeOwnerPacketShape(packet) != nil {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	wire := make([]byte, l8RuntimeOwnerPacketHeaderSize+len(packet.Body))
+	copy(wire[:8], l8RuntimeOwnerProtocolMagic)
+	binary.BigEndian.PutUint16(wire[8:10], l8RuntimeOwnerProtocolVersion)
+	binary.BigEndian.PutUint16(wire[10:12], packet.Opcode)
+	binary.BigEndian.PutUint16(wire[12:14], packet.Status)
+	binary.BigEndian.PutUint16(wire[14:16], uint16(len(packet.Body)))
+	binary.BigEndian.PutUint64(wire[16:24], packet.Sequence)
+	copy(wire[l8RuntimeOwnerPacketHeaderSize:], packet.Body)
+	return wire, nil
 }
 
-func decodeL8RuntimeOwnerPacket([]byte) (l8RuntimeOwnerPacketV1, error) {
-	return l8RuntimeOwnerPacketV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerPacket(wire []byte) (l8RuntimeOwnerPacketV1, error) {
+	if len(wire) < l8RuntimeOwnerPacketHeaderSize || len(wire) > l8RuntimeOwnerPacketLimit {
+		return l8RuntimeOwnerPacketV1{}, errL8RuntimeOwnerProtocol
+	}
+	if string(wire[:8]) != l8RuntimeOwnerProtocolMagic {
+		return l8RuntimeOwnerPacketV1{}, errL8RuntimeOwnerProtocol
+	}
+	version := binary.BigEndian.Uint16(wire[8:10])
+	opcode := binary.BigEndian.Uint16(wire[10:12])
+	status := binary.BigEndian.Uint16(wire[12:14])
+	bodyLength := binary.BigEndian.Uint16(wire[14:16])
+	sequence := binary.BigEndian.Uint64(wire[16:24])
+	if version != l8RuntimeOwnerProtocolVersion || int(bodyLength) != len(wire)-l8RuntimeOwnerPacketHeaderSize {
+		return l8RuntimeOwnerPacketV1{}, errL8RuntimeOwnerProtocol
+	}
+	packet := l8RuntimeOwnerPacketV1{
+		Opcode:   opcode,
+		Status:   status,
+		Sequence: sequence,
+		Body:     append([]byte(nil), wire[l8RuntimeOwnerPacketHeaderSize:]...),
+	}
+	if validateL8RuntimeOwnerPacketShape(packet) != nil {
+		return l8RuntimeOwnerPacketV1{}, errL8RuntimeOwnerProtocol
+	}
+	return packet, nil
 }
 
-func encodeL8RuntimeOwnerHandshake(l8RuntimeOwnerHandshakeV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerHandshake(value l8RuntimeOwnerHandshakeV1) ([]byte, error) {
+	if !validL8RuntimeOwnerToken(value.SupervisorGeneration) || !validL8RuntimeOwnerToken(value.ReconnectSecret) ||
+		!validL8RuntimeOwnerSafeID(value.RuntimeGeneration) {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	generation := []byte(value.RuntimeGeneration)
+	body := make([]byte, l8RuntimeOwnerTokenSize+2+len(generation)+8+l8RuntimeOwnerTokenSize)
+	copy(body[:l8RuntimeOwnerTokenSize], value.SupervisorGeneration)
+	binary.BigEndian.PutUint16(body[l8RuntimeOwnerTokenSize:l8RuntimeOwnerTokenSize+2], uint16(len(generation)))
+	copy(body[l8RuntimeOwnerTokenSize+2:l8RuntimeOwnerTokenSize+2+len(generation)], generation)
+	binary.BigEndian.PutUint64(body[l8RuntimeOwnerTokenSize+2+len(generation):l8RuntimeOwnerTokenSize+2+len(generation)+8], value.RecordRevision)
+	copy(body[l8RuntimeOwnerTokenSize+2+len(generation)+8:], value.ReconnectSecret)
+	return body, nil
 }
 
-func decodeL8RuntimeOwnerHandshake([]byte) (l8RuntimeOwnerHandshakeV1, error) {
-	return l8RuntimeOwnerHandshakeV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerHandshake(body []byte) (l8RuntimeOwnerHandshakeV1, error) {
+	if len(body) < 97 || len(body) > 224 {
+		return l8RuntimeOwnerHandshakeV1{}, errL8RuntimeOwnerProtocol
+	}
+	generationLength := int(binary.BigEndian.Uint16(body[l8RuntimeOwnerTokenSize : l8RuntimeOwnerTokenSize+2]))
+	if generationLength < l8RuntimeOwnerHandshakeGenerationMin || generationLength > l8RuntimeOwnerHandshakeGenerationMax ||
+		len(body) != l8RuntimeOwnerTokenSize+2+generationLength+8+l8RuntimeOwnerTokenSize {
+		return l8RuntimeOwnerHandshakeV1{}, errL8RuntimeOwnerProtocol
+	}
+	value := l8RuntimeOwnerHandshakeV1{
+		SupervisorGeneration: string(body[:l8RuntimeOwnerTokenSize]),
+		RuntimeGeneration:    string(body[l8RuntimeOwnerTokenSize+2 : l8RuntimeOwnerTokenSize+2+generationLength]),
+		RecordRevision:       binary.BigEndian.Uint64(body[l8RuntimeOwnerTokenSize+2+generationLength : l8RuntimeOwnerTokenSize+2+generationLength+8]),
+		ReconnectSecret:      string(body[l8RuntimeOwnerTokenSize+2+generationLength+8:]),
+	}
+	if !validL8RuntimeOwnerToken(value.SupervisorGeneration) || !validL8RuntimeOwnerToken(value.ReconnectSecret) ||
+		!validL8RuntimeOwnerSafeID(value.RuntimeGeneration) {
+		return l8RuntimeOwnerHandshakeV1{}, errL8RuntimeOwnerProtocol
+	}
+	return value, nil
 }
 
-func encodeL8RuntimeOwnerHandshakeAck(l8RuntimeOwnerHandshakeAckV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerHandshakeAck(value l8RuntimeOwnerHandshakeAckV1) ([]byte, error) {
+	if !validL8RuntimeOwnerToken(value.ControllerSessionGeneration) {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	body := make([]byte, l8RuntimeOwnerTokenSize+8)
+	copy(body[:l8RuntimeOwnerTokenSize], value.ControllerSessionGeneration)
+	binary.BigEndian.PutUint64(body[l8RuntimeOwnerTokenSize:], value.RecordRevision)
+	return body, nil
 }
 
-func decodeL8RuntimeOwnerHandshakeAck([]byte) (l8RuntimeOwnerHandshakeAckV1, error) {
-	return l8RuntimeOwnerHandshakeAckV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerHandshakeAck(body []byte) (l8RuntimeOwnerHandshakeAckV1, error) {
+	if len(body) != l8RuntimeOwnerTokenSize+8 {
+		return l8RuntimeOwnerHandshakeAckV1{}, errL8RuntimeOwnerProtocol
+	}
+	value := l8RuntimeOwnerHandshakeAckV1{
+		ControllerSessionGeneration: string(body[:l8RuntimeOwnerTokenSize]),
+		RecordRevision:              binary.BigEndian.Uint64(body[l8RuntimeOwnerTokenSize:]),
+	}
+	if !validL8RuntimeOwnerToken(value.ControllerSessionGeneration) {
+		return l8RuntimeOwnerHandshakeAckV1{}, errL8RuntimeOwnerProtocol
+	}
+	return value, nil
 }
 
-func encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerResponse(value l8RuntimeOwnerResponseV1) ([]byte, error) {
+	if value.State == 0 && value.AbsenceKind == 0 && value.RecordRevision == 0 && value.ObservedAtUnixNano == 0 {
+		// zero value is still a legal 24-byte encoding
+	}
+	body := make([]byte, 24)
+	body[0] = value.State
+	body[1] = value.AbsenceKind
+	binary.BigEndian.PutUint64(body[8:16], value.RecordRevision)
+	binary.BigEndian.PutUint64(body[16:24], uint64(value.ObservedAtUnixNano))
+	return body, nil
 }
 
-func decodeL8RuntimeOwnerResponse([]byte) (l8RuntimeOwnerResponseV1, error) {
-	return l8RuntimeOwnerResponseV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerResponse(body []byte) (l8RuntimeOwnerResponseV1, error) {
+	if len(body) != 24 {
+		return l8RuntimeOwnerResponseV1{}, errL8RuntimeOwnerProtocol
+	}
+	for _, reserved := range body[2:8] {
+		if reserved != 0 {
+			return l8RuntimeOwnerResponseV1{}, errL8RuntimeOwnerProtocol
+		}
+	}
+	return l8RuntimeOwnerResponseV1{
+		State:              body[0],
+		AbsenceKind:        body[1],
+		RecordRevision:     binary.BigEndian.Uint64(body[8:16]),
+		ObservedAtUnixNano: int64(binary.BigEndian.Uint64(body[16:24])),
+	}, nil
 }
 
-func encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerControllerRequest(value l8RuntimeOwnerControllerRequestV1) ([]byte, error) {
+	if !validL8RuntimeOwnerToken(value.ControllerSessionGeneration) {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	return []byte(value.ControllerSessionGeneration), nil
 }
 
-func decodeL8RuntimeOwnerControllerRequest([]byte) (l8RuntimeOwnerControllerRequestV1, error) {
-	return l8RuntimeOwnerControllerRequestV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerControllerRequest(body []byte) (l8RuntimeOwnerControllerRequestV1, error) {
+	if len(body) != l8RuntimeOwnerTokenSize || !validL8RuntimeOwnerToken(string(body)) {
+		return l8RuntimeOwnerControllerRequestV1{}, errL8RuntimeOwnerProtocol
+	}
+	return l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: string(body)}, nil
 }
 
-func encodeL8RuntimeOwnerFinalizeRequest(l8RuntimeOwnerFinalizeRequestV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerFinalizeRequest(value l8RuntimeOwnerFinalizeRequestV1) ([]byte, error) {
+	if !validL8RuntimeOwnerToken(value.ControllerSessionGeneration) {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	body := make([]byte, l8RuntimeOwnerTokenSize+16)
+	copy(body[:l8RuntimeOwnerTokenSize], value.ControllerSessionGeneration)
+	binary.BigEndian.PutUint64(body[l8RuntimeOwnerTokenSize:l8RuntimeOwnerTokenSize+8], value.AbsenceRevision)
+	binary.BigEndian.PutUint64(body[l8RuntimeOwnerTokenSize+8:], uint64(value.ObservedAtUnixNano))
+	return body, nil
 }
 
-func decodeL8RuntimeOwnerFinalizeRequest([]byte) (l8RuntimeOwnerFinalizeRequestV1, error) {
-	return l8RuntimeOwnerFinalizeRequestV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerFinalizeRequest(body []byte) (l8RuntimeOwnerFinalizeRequestV1, error) {
+	if len(body) != l8RuntimeOwnerTokenSize+16 {
+		return l8RuntimeOwnerFinalizeRequestV1{}, errL8RuntimeOwnerProtocol
+	}
+	value := l8RuntimeOwnerFinalizeRequestV1{
+		ControllerSessionGeneration: string(body[:l8RuntimeOwnerTokenSize]),
+		AbsenceRevision:             binary.BigEndian.Uint64(body[l8RuntimeOwnerTokenSize : l8RuntimeOwnerTokenSize+8]),
+		ObservedAtUnixNano:          int64(binary.BigEndian.Uint64(body[l8RuntimeOwnerTokenSize+8:])),
+	}
+	if !validL8RuntimeOwnerToken(value.ControllerSessionGeneration) {
+		return l8RuntimeOwnerFinalizeRequestV1{}, errL8RuntimeOwnerProtocol
+	}
+	return value, nil
 }
 
-func encodeL8RuntimeOwnerFinalizeAck(l8RuntimeOwnerFinalizeAckV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerFinalizeAck(value l8RuntimeOwnerFinalizeAckV1) ([]byte, error) {
+	commitID, err := l8RuntimeOwnerExportedStringField(value, "CommitID")
+	if err != nil || !validL8RuntimeOwnerToken(commitID) {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	body := make([]byte, l8RuntimeOwnerTokenSize+8)
+	copy(body[:l8RuntimeOwnerTokenSize], commitID)
+	binary.BigEndian.PutUint64(body[l8RuntimeOwnerTokenSize:], value.FinalizedRevision)
+	return body, nil
 }
 
-func decodeL8RuntimeOwnerFinalizeAck([]byte) (l8RuntimeOwnerFinalizeAckV1, error) {
-	return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerFinalizeAck(body []byte) (l8RuntimeOwnerFinalizeAckV1, error) {
+	if len(body) != l8RuntimeOwnerTokenSize+8 {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerProtocol
+	}
+	commitID := string(body[:l8RuntimeOwnerTokenSize])
+	if !validL8RuntimeOwnerToken(commitID) {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerProtocol
+	}
+	return l8RuntimeOwnerFinalizeAckV1{
+		CommitID:          commitID,
+		FinalizedRevision: binary.BigEndian.Uint64(body[l8RuntimeOwnerTokenSize:]),
+	}, nil
 }
 
-func encodeL8RuntimeOwnerCommitRequest(l8RuntimeOwnerCommitRequestV1) ([]byte, error) {
-	return nil, errL8RuntimeOwnerProtocol
+func encodeL8RuntimeOwnerCommitRequest(value l8RuntimeOwnerCommitRequestV1) ([]byte, error) {
+	commitID, err := l8RuntimeOwnerExportedStringField(value, "CommitID")
+	if err != nil || !validL8RuntimeOwnerToken(value.ControllerSessionGeneration) || !validL8RuntimeOwnerToken(commitID) {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	body := make([]byte, l8RuntimeOwnerTokenSize+l8RuntimeOwnerTokenSize+8)
+	copy(body[:l8RuntimeOwnerTokenSize], value.ControllerSessionGeneration)
+	copy(body[l8RuntimeOwnerTokenSize:l8RuntimeOwnerTokenSize*2], commitID)
+	binary.BigEndian.PutUint64(body[l8RuntimeOwnerTokenSize*2:], value.FinalizedRevision)
+	return body, nil
 }
 
-func decodeL8RuntimeOwnerCommitRequest([]byte) (l8RuntimeOwnerCommitRequestV1, error) {
-	return l8RuntimeOwnerCommitRequestV1{}, errL8RuntimeOwnerProtocol
+func decodeL8RuntimeOwnerCommitRequest(body []byte) (l8RuntimeOwnerCommitRequestV1, error) {
+	if len(body) != l8RuntimeOwnerTokenSize+l8RuntimeOwnerTokenSize+8 {
+		return l8RuntimeOwnerCommitRequestV1{}, errL8RuntimeOwnerProtocol
+	}
+	session := string(body[:l8RuntimeOwnerTokenSize])
+	commitID := string(body[l8RuntimeOwnerTokenSize : l8RuntimeOwnerTokenSize*2])
+	if !validL8RuntimeOwnerToken(session) || !validL8RuntimeOwnerToken(commitID) {
+		return l8RuntimeOwnerCommitRequestV1{}, errL8RuntimeOwnerProtocol
+	}
+	return l8RuntimeOwnerCommitRequestV1{
+		ControllerSessionGeneration: session,
+		CommitID:                    commitID,
+		FinalizedRevision:           binary.BigEndian.Uint64(body[l8RuntimeOwnerTokenSize*2:]),
+	}, nil
 }
 
-func validateL8RuntimeOwnerPacketRole(l8RuntimeOwnerPacketV1, bool, int) error {
+func l8RuntimeOwnerExportedStringField(value any, name string) (string, error) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return "", errL8RuntimeOwnerProtocol
+	}
+	var object map[string]any
+	if json.Unmarshal(payload, &object) != nil {
+		return "", errL8RuntimeOwnerProtocol
+	}
+	field, _ := object[name].(string)
+	return field, nil
+}
+
+func validateL8RuntimeOwnerPacketRole(packet l8RuntimeOwnerPacketV1, response bool, rights int) error {
+	if validateL8RuntimeOwnerPacketShapeForRole(packet, response) != nil {
+		return errL8RuntimeOwnerProtocol
+	}
+	wantRights := 0
+	if !response && packet.Opcode == l8RuntimeOwnerOpcodeBootstrapStart {
+		wantRights = 2
+	}
+	if response && packet.Status == l8RuntimeOwnerStatusOK && packet.Opcode == l8RuntimeOwnerOpcodeAcquireNamespaces {
+		wantRights = 2
+	}
+	if rights != wantRights {
+		return errL8RuntimeOwnerProtocol
+	}
+	return nil
+}
+
+func validateL8RuntimeOwnerPacketShape(packet l8RuntimeOwnerPacketV1) error {
+	if validateL8RuntimeOwnerPacketShapeForRole(packet, false) == nil || validateL8RuntimeOwnerPacketShapeForRole(packet, true) == nil {
+		return nil
+	}
 	return errL8RuntimeOwnerProtocol
 }
 
-func validL8RuntimeOwnerTransition(firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1) bool {
+func validateL8RuntimeOwnerPacketShapeForRole(packet l8RuntimeOwnerPacketV1, response bool) error {
+	bodyLen := len(packet.Body)
+	if packet.Opcode == l8RuntimeOwnerOpcodeReject {
+		if !response || packet.Status != l8RuntimeOwnerStatusRejected || packet.Sequence != 0 || bodyLen != 0 {
+			return errL8RuntimeOwnerProtocol
+		}
+		return nil
+	}
+	if packet.Opcode > l8RuntimeOwnerOpcodeClose {
+		return errL8RuntimeOwnerProtocol
+	}
+	if !response {
+		if packet.Status != l8RuntimeOwnerStatusOK {
+			return errL8RuntimeOwnerProtocol
+		}
+		switch packet.Opcode {
+		case l8RuntimeOwnerOpcodeBootstrapStart:
+			if packet.Sequence != 0 || bodyLen != 32 {
+				return errL8RuntimeOwnerProtocol
+			}
+		case l8RuntimeOwnerOpcodeChildArmed:
+			if packet.Sequence != 0 || bodyLen != 0 {
+				return errL8RuntimeOwnerProtocol
+			}
+		case l8RuntimeOwnerOpcodeHandshake:
+			if packet.Sequence != 0 || bodyLen < 97 || bodyLen > 224 {
+				return errL8RuntimeOwnerProtocol
+			}
+		case l8RuntimeOwnerOpcodeAbortStart, l8RuntimeOwnerOpcodeInspect, l8RuntimeOwnerOpcodeStopReap, l8RuntimeOwnerOpcodeAcquireNamespaces, l8RuntimeOwnerOpcodeClose:
+			if packet.Sequence < 1 || bodyLen != l8RuntimeOwnerTokenSize {
+				return errL8RuntimeOwnerProtocol
+			}
+		case l8RuntimeOwnerOpcodeFinalize:
+			if packet.Sequence < 1 || bodyLen != 59 {
+				return errL8RuntimeOwnerProtocol
+			}
+		case l8RuntimeOwnerOpcodeCommit:
+			if packet.Sequence < 1 || bodyLen != 94 {
+				return errL8RuntimeOwnerProtocol
+			}
+		default:
+			return errL8RuntimeOwnerProtocol
+		}
+		return nil
+	}
+	if packet.Status == l8RuntimeOwnerStatusInvalidState || packet.Status == l8RuntimeOwnerStatusUncertain || packet.Status == l8RuntimeOwnerStatusUnsupported {
+		if packet.Sequence < 1 || bodyLen != 0 {
+			return errL8RuntimeOwnerProtocol
+		}
+		switch packet.Opcode {
+		case l8RuntimeOwnerOpcodeAbortStart, l8RuntimeOwnerOpcodeInspect, l8RuntimeOwnerOpcodeStopReap, l8RuntimeOwnerOpcodeAcquireNamespaces, l8RuntimeOwnerOpcodeFinalize, l8RuntimeOwnerOpcodeCommit, l8RuntimeOwnerOpcodeClose:
+			return nil
+		default:
+			return errL8RuntimeOwnerProtocol
+		}
+	}
+	if packet.Status != l8RuntimeOwnerStatusOK {
+		return errL8RuntimeOwnerProtocol
+	}
+	switch packet.Opcode {
+	case l8RuntimeOwnerOpcodeBootstrapPublished:
+		if packet.Sequence != 0 || bodyLen != 8 {
+			return errL8RuntimeOwnerProtocol
+		}
+	case l8RuntimeOwnerOpcodeChildRelease:
+		if packet.Sequence != 0 || bodyLen != 0 {
+			return errL8RuntimeOwnerProtocol
+		}
+	case l8RuntimeOwnerOpcodeHandshake:
+		if packet.Sequence != 0 || bodyLen != 51 {
+			return errL8RuntimeOwnerProtocol
+		}
+	case l8RuntimeOwnerOpcodeAbortStart, l8RuntimeOwnerOpcodeInspect, l8RuntimeOwnerOpcodeStopReap, l8RuntimeOwnerOpcodeClose, l8RuntimeOwnerOpcodeAcquireNamespaces:
+		if packet.Sequence < 1 || bodyLen != 24 {
+			return errL8RuntimeOwnerProtocol
+		}
+	case l8RuntimeOwnerOpcodeFinalize:
+		if packet.Sequence < 1 || bodyLen != 51 {
+			return errL8RuntimeOwnerProtocol
+		}
+	case l8RuntimeOwnerOpcodeCommit:
+		if packet.Sequence < 1 || bodyLen != 8 {
+			return errL8RuntimeOwnerProtocol
+		}
+	default:
+		return errL8RuntimeOwnerProtocol
+	}
+	return nil
+}
+
+func validL8RuntimeOwnerTransition(from, to firecrackerRuntimeOwnerRecordV1) bool {
+	if to.Revision != from.Revision+1 {
+		return false
+	}
+	if from.State == "starting" && from.ControllerState == "none" && from.Revision == 0 {
+		return to.State == "starting" && to.ControllerState == "none" && to.FirecrackerPID != 0 && to.FirecrackerStartTime != 0
+	}
+	if from.State == "starting" && from.ControllerState == "none" && from.Revision == 1 {
+		if to.State == "running" && to.ControllerState == "unclaimed" {
+			return true
+		}
+		if to.State == "stopping" && to.ControllerState == "none" {
+			return true
+		}
+		return false
+	}
+	if from.State == to.State && from.State != "starting" {
+		if from.ControllerState == "unclaimed" && to.ControllerState == "controlled" {
+			return true
+		}
+		if from.ControllerState == "controlled" && to.ControllerState == "unclaimed" {
+			return true
+		}
+		if from.State == "absent" && from.ControllerState == "controlled" && to.ControllerState == "controlled" {
+			return true
+		}
+	}
+	if from.ControllerState == "controlled" && to.ControllerState == "controlled" {
+		switch from.State + "->" + to.State {
+		case "running->stopping", "running->uncertain", "stopping->absent", "stopping->uncertain",
+			"uncertain->absent", "absent->finalizing", "finalizing->finalized":
+			return true
+		}
+	}
+	if from.State == "stopping" && from.ControllerState == "none" && to.State == "absent" && to.ControllerState == "none" {
+		return true
+	}
 	return false
 }
 
-func reconcileL8RuntimeOwnerCommitUncertain(firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, bool, error) {
+func reconcileL8RuntimeOwnerCommitUncertain(prior, intended, observed firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, bool, error) {
+	if observed == prior {
+		return prior, false, nil
+	}
+	if observed == intended {
+		return intended, true, nil
+	}
 	return firecrackerRuntimeOwnerRecordV1{}, false, errL8RuntimeOwnerInvalid
 }
 
-func transitionL8RuntimeOwnerRecordLocked(context.Context, l8RuntimeOwnerTransactionOps, uint64, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
-	return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+func transitionL8RuntimeOwnerRecordLocked(ctx context.Context, ops l8RuntimeOwnerTransactionOps, expected uint64, intended firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	if ops.Lock == nil || ops.Unlock == nil || ops.Read == nil || ops.WriteAndRename == nil || ops.SyncDirectory == nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	if err := ops.Lock(ctx); err != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			_ = ops.Unlock()
+		}
+	}()
+	current, present, err := ops.Read()
+	if err != nil || !present || current.Revision != expected {
+		_ = ops.Unlock()
+		unlocked = true
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	writeErr := ops.WriteAndRename(intended)
+	if writeErr == nil {
+		if syncErr := ops.SyncDirectory(); syncErr == nil {
+			_ = ops.Unlock()
+			unlocked = true
+			return intended, nil
+		}
+	}
+	reread, present, readErr := ops.Read()
+	_ = ops.Unlock()
+	unlocked = true
+	if readErr != nil || !present {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	got, committed, err := reconcileL8RuntimeOwnerCommitUncertain(current, intended, reread)
+	if err != nil || !committed {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	return got, nil
 }
 
-func containL8RuntimeOwnerChild(l8RuntimeOwnerContainmentOps) (l8RuntimeOwnerAbsenceObservation, error) {
-	return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+func containL8RuntimeOwnerChild(ops l8RuntimeOwnerContainmentOps) (observation l8RuntimeOwnerAbsenceObservation, err error) {
+	defer func() {
+		if recover() != nil {
+			observation = l8RuntimeOwnerAbsenceObservation{}
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	fail := func() (l8RuntimeOwnerAbsenceObservation, error) {
+		if ops.RecordUncertain != nil {
+			_, _ = l8RuntimeOwnerCallUint64(ops.RecordUncertain)
+		}
+		return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+	}
+	if _, err := l8RuntimeOwnerCallUint64(ops.RecordStopping); err != nil {
+		return fail()
+	}
+	started := time.Now()
+	overall := started.Add(l8RuntimeOwnerContainmentBudget)
+	_ = l8RuntimeOwnerCall(ops.Terminate)
+	firstCtx, cancelFirst := context.WithDeadline(context.Background(), started.Add(l8RuntimeOwnerContainmentTermWaitBudget))
+	reaped, waitErr := l8RuntimeOwnerCallWait(ops.Wait, firstCtx)
+	cancelFirst()
+	if waitErr != nil {
+		return fail()
+	}
+	if !reaped {
+		_ = l8RuntimeOwnerCall(ops.Kill)
+		finalCtx, cancelFinal := context.WithDeadline(context.Background(), overall)
+		reaped, waitErr = l8RuntimeOwnerCallWait(ops.Wait, finalCtx)
+		cancelFinal()
+		if waitErr != nil {
+			return fail()
+		}
+	}
+	if !reaped {
+		return fail()
+	}
+	observedAt := time.Now()
+	if ops.Now != nil {
+		observedAt = ops.Now()
+	}
+	candidate := l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: observedAt}
+	revision, recordErr := l8RuntimeOwnerCallRecordAbsent(ops.RecordAbsent, candidate)
+	if recordErr != nil {
+		return fail()
+	}
+	candidate.Revision = revision
+	return candidate, nil
 }
 
 func (controller *l8RuntimeOwnerContainmentController) Stop(ops l8RuntimeOwnerContainmentOps) (l8RuntimeOwnerAbsenceObservation, error) {
@@ -264,34 +703,651 @@ func (controller *l8RuntimeOwnerContainmentController) Stop(ops l8RuntimeOwnerCo
 		return controller.observation, controller.result
 	}
 	controller.observation, controller.result = containL8RuntimeOwnerChild(ops)
-	controller.completed = true
+	if controller.result == nil {
+		controller.completed = true
+	}
 	return controller.observation, controller.result
 }
 
-func containL8RuntimeOwnerReplacement(firecrackerRuntimeOwnerRecordV1, l8RuntimeOwnerReplacementOps) (l8RuntimeOwnerAbsenceObservation, error) {
-	return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+func containL8RuntimeOwnerReplacement(record firecrackerRuntimeOwnerRecordV1, ops l8RuntimeOwnerReplacementOps) (observation l8RuntimeOwnerAbsenceObservation, err error) {
+	defer func() {
+		if recover() != nil {
+			observation = l8RuntimeOwnerAbsenceObservation{}
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	fail := func() (l8RuntimeOwnerAbsenceObservation, error) {
+		if ops.RecordUncertain != nil {
+			_, _ = l8RuntimeOwnerCallUint64(ops.RecordUncertain)
+		}
+		return l8RuntimeOwnerAbsenceObservation{}, errL8RuntimeOwnerInvalid
+	}
+	if ops.CurrentBootID == nil || ops.InspectSupervisor == nil || ops.InspectChild == nil || ops.ProcessAbsent == nil {
+		return fail()
+	}
+	bootID, err := ops.CurrentBootID()
+	if err != nil || bootID != record.HostBootID {
+		return fail()
+	}
+	supervisor, supervisorExists, err := ops.InspectSupervisor(record.SupervisorPID)
+	if err != nil {
+		return fail()
+	}
+	if supervisorExists {
+		_ = supervisor.Close()
+		return fail()
+	}
+	child, childExists, err := ops.InspectChild(record.FirecrackerPID)
+	if err != nil {
+		return fail()
+	}
+	if childExists {
+		defer child.Close()
+		if child.PID != record.FirecrackerPID || child.StartTime != record.FirecrackerStartTime || child.ParentPID != 1 || child.state == 'Z' {
+			return fail()
+		}
+		if ops.SignalKill == nil || l8RuntimeOwnerCall(func() error { return ops.SignalKill(child) }) != nil {
+			return fail()
+		}
+		if ops.WaitTerminal != nil {
+			_ = l8RuntimeOwnerCall(func() error { return ops.WaitTerminal(context.Background(), child) })
+		}
+	}
+	firstAbsent, err := ops.ProcessAbsent(record.FirecrackerPID)
+	if err != nil || !firstAbsent {
+		return fail()
+	}
+	if ops.AcquisitionBarrier == nil || l8RuntimeOwnerCall(ops.AcquisitionBarrier) != nil {
+		return fail()
+	}
+	secondAbsent, err := ops.ProcessAbsent(record.FirecrackerPID)
+	if err != nil || !secondAbsent {
+		return fail()
+	}
+	observedAt := time.Now()
+	if ops.Now != nil {
+		observedAt = ops.Now()
+	}
+	candidate := l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindProc, ObservedAt: observedAt}
+	revision, recordErr := l8RuntimeOwnerCallRecordAbsent(ops.RecordAbsent, candidate)
+	if recordErr != nil {
+		return fail()
+	}
+	candidate.Revision = revision
+	return candidate, nil
 }
 
-func newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions) (*l8RuntimeOwnerSupervisor, error) {
-	return nil, errL8RuntimeOwnerInvalid
+func newL8RuntimeOwnerSupervisor(opts l8RuntimeOwnerSupervisorOptions) (*l8RuntimeOwnerSupervisor, error) {
+	if opts.Store == nil || len(opts.CommitKey) != 32 {
+		return nil, errL8RuntimeOwnerInvalid
+	}
+	opts.CommitKey = append([]byte(nil), opts.CommitKey...)
+	return &l8RuntimeOwnerSupervisor{opts: opts}, nil
 }
 
-func (*l8RuntimeOwnerSupervisor) HandleBootstrap(context.Context, uint32, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
-	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+func (owner *l8RuntimeOwnerSupervisor) HandleBootstrap(ctx context.Context, uid uint32, received l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	if owner == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	if uid != owner.opts.ExpectedUID || received.Packet.Opcode != l8RuntimeOwnerOpcodeBootstrapStart || owner.opts.StartChild == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	if _, err := decodeL8RuntimeOwnerNamespaceCorrelation(received.Packet.Body); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	if len(received.Files) != 2 {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	if _, err := owner.opts.Store.CreateGenesis(ctx, owner.opts.GenesisRecord); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	child, err := owner.opts.StartChild()
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	failed := true
+	defer func() {
+		if failed && child.Abort != nil {
+			_ = child.Abort()
+		}
+	}()
+	rev1 := owner.opts.GenesisRecord
+	rev1.Revision = 1
+	rev1.State = "starting"
+	rev1.ControllerState = "none"
+	rev1.FirecrackerPID = child.Observation.PID
+	rev1.FirecrackerStartTime = child.Observation.StartTime
+	if _, err := owner.opts.Store.Transition(ctx, 0, rev1); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	if child.Release == nil || child.Release() != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	rev2 := rev1
+	rev2.Revision = 2
+	rev2.State = "running"
+	rev2.ControllerState = "unclaimed"
+	if _, err := owner.opts.Store.Transition(ctx, 1, rev2); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	body := make([]byte, 8)
+	binary.BigEndian.PutUint64(body, 2)
+	failed = false
+	return l8RuntimeOwnerControlResult{Packet: l8RuntimeOwnerPacketV1{
+		Opcode: l8RuntimeOwnerOpcodeBootstrapPublished,
+		Status: l8RuntimeOwnerStatusOK,
+		Body:   body,
+	}}, nil
 }
 
-func (*l8RuntimeOwnerSupervisor) AbortStart(context.Context, uint32, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
-	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+func (owner *l8RuntimeOwnerSupervisor) AbortStart(ctx context.Context, uid uint32, received l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	if owner == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	if uid != owner.opts.ExpectedUID || received.Packet.Opcode != l8RuntimeOwnerOpcodeAbortStart {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	record, err := owner.opts.Store.Load(ctx)
+	if err != nil || record.State != "starting" {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	if record.Revision == 0 {
+		if owner.opts.AbortStartingZero == nil || owner.opts.AbortStartingZero() != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+		}
+		if err := owner.opts.Store.RetireStartingZero(ctx, 0); err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+		}
+		return l8RuntimeOwnerControlResult{Exit: true}, nil
+	}
+	if record.Revision != 1 || owner.opts.ContainChild == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	stopping := record
+	stopping.Revision = 2
+	stopping.State = "stopping"
+	if _, err := owner.opts.Store.Transition(ctx, 1, stopping); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	observation, err := owner.opts.ContainChild()
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	absent := stopping
+	absent.Revision = 3
+	absent.State = "absent"
+	absent.AbsenceKind = l8RuntimeOwnerAbsenceKindName(observation.Kind)
+	absent.AbsenceRevision = observation.Revision
+	if observation.Revision == 0 {
+		absent.AbsenceRevision = 3
+	}
+	absent.AbsenceObservedAtUnixNano = observation.ObservedAt.UnixNano()
+	if _, err := owner.opts.Store.Transition(ctx, 2, absent); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+	}
+	return l8RuntimeOwnerControlResult{Exit: true}, nil
 }
 
-func (*l8RuntimeOwnerSupervisor) AdmitController(context.Context, uint32, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
-	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+func (owner *l8RuntimeOwnerSupervisor) AdmitController(ctx context.Context, uid uint32, received l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	if owner == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	if uid != owner.opts.ExpectedUID || received.Packet.Opcode != l8RuntimeOwnerOpcodeHandshake {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	handshake, err := decodeL8RuntimeOwnerHandshake(received.Packet.Body)
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	record, err := owner.opts.Store.Load(ctx)
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	if handshake.SupervisorGeneration != record.SupervisorGeneration || handshake.RuntimeGeneration != record.RuntimeGeneration ||
+		handshake.RecordRevision != record.Revision ||
+		subtle.ConstantTimeCompare([]byte(handshake.ReconnectSecret), []byte(record.ReconnectSecret)) != 1 {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	if record.ControllerState != "unclaimed" || owner.opts.RandomToken == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	session, err := owner.opts.RandomToken()
+	if err != nil || !validL8RuntimeOwnerToken(session) {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	secret, err := owner.opts.RandomToken()
+	if err != nil || !validL8RuntimeOwnerToken(secret) {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	next := record
+	next.Revision = record.Revision + 1
+	next.ControllerState = "controlled"
+	next.ReconnectSecret = secret
+	if _, err := owner.opts.Store.Transition(ctx, record.Revision, next); err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	ack, err := encodeL8RuntimeOwnerHandshakeAck(l8RuntimeOwnerHandshakeAckV1{
+		ControllerSessionGeneration: session,
+		RecordRevision:              next.Revision,
+	})
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	owner.sessionGeneration = session
+	owner.hasLast = false
+	owner.lastSequence = 0
+	return l8RuntimeOwnerControlResult{Packet: l8RuntimeOwnerPacketV1{
+		Opcode: l8RuntimeOwnerOpcodeHandshake,
+		Status: l8RuntimeOwnerStatusOK,
+		Body:   ack,
+	}}, nil
 }
 
-func (*l8RuntimeOwnerSupervisor) HandleController(context.Context, l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
-	return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+func (owner *l8RuntimeOwnerSupervisor) HandleController(ctx context.Context, received l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	if owner == nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	if owner.hasLast && received.Packet.Sequence == owner.lastSequence && received.Packet.Opcode == owner.lastOpcode {
+		result := l8RuntimeOwnerControlResult{Packet: owner.lastPacket}
+		if received.Packet.Opcode == l8RuntimeOwnerOpcodeAcquireNamespaces {
+			files, err := owner.duplicateNamespaces()
+			if err != nil {
+				return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+			}
+			result.Files = files
+		}
+		return result, nil
+	}
+	if owner.hasLast && received.Packet.Sequence != owner.lastSequence+1 {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	if !owner.hasLast && received.Packet.Sequence != 1 {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	session, err := l8RuntimeOwnerControllerSession(received.Packet)
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	if owner.sessionGeneration != "" && session != owner.sessionGeneration {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	if owner.sessionGeneration == "" {
+		owner.sessionGeneration = session
+	}
+	result, err := owner.dispatchController(ctx, received)
+	if err != nil {
+		return l8RuntimeOwnerControlResult{}, err
+	}
+	owner.lastSequence = received.Packet.Sequence
+	owner.lastOpcode = received.Packet.Opcode
+	owner.lastPacket = result.Packet
+	owner.hasLast = true
+	return result, nil
 }
 
-func (*l8RuntimeOwnerSupervisor) ControllerLost(context.Context) error {
-	return errL8RuntimeOwnerInvalid
+func (owner *l8RuntimeOwnerSupervisor) ControllerLost(ctx context.Context) error {
+	if owner == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	owner.mu.Lock()
+	defer owner.mu.Unlock()
+	record, err := owner.opts.Store.Load(ctx)
+	if err != nil || record.ControllerState != "controlled" {
+		return errL8RuntimeOwnerInvalid
+	}
+	if _, err := owner.unclaim(ctx, record); err != nil {
+		return err
+	}
+	owner.sessionGeneration = ""
+	owner.hasLast = false
+	owner.lastSequence = 0
+	return nil
+}
+
+func (owner *l8RuntimeOwnerSupervisor) dispatchController(ctx context.Context, received l8RuntimeOwnerReceivedPacketV1) (l8RuntimeOwnerControlResult, error) {
+	record, err := owner.opts.Store.Load(ctx)
+	if err != nil || record.ControllerState != "controlled" {
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+	switch received.Packet.Opcode {
+	case l8RuntimeOwnerOpcodeInspect:
+		body, err := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseFromRecord(record, false))
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		return owner.controllerOK(received.Packet, body, nil, false), nil
+	case l8RuntimeOwnerOpcodeStopReap:
+		next, err := owner.reinspectAbsence(ctx, record)
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, err
+		}
+		body, err := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseFromRecord(next, true))
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		return owner.controllerOK(received.Packet, body, nil, false), nil
+	case l8RuntimeOwnerOpcodeAcquireNamespaces:
+		files, err := owner.duplicateNamespaces()
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		body, err := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseFromRecord(record, false))
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		return owner.controllerOK(received.Packet, body, files, false), nil
+	case l8RuntimeOwnerOpcodeClose:
+		if _, err := owner.unclaim(ctx, record); err != nil {
+			return l8RuntimeOwnerControlResult{}, err
+		}
+		body, err := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseFromRecord(record, false))
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		owner.sessionGeneration = ""
+		return owner.controllerOK(received.Packet, body, nil, false), nil
+	case l8RuntimeOwnerOpcodeFinalize:
+		request, err := decodeL8RuntimeOwnerFinalizeRequest(received.Packet.Body)
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		ack, err := owner.finalize(ctx, record, request)
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, err
+		}
+		body, err := encodeL8RuntimeOwnerFinalizeAck(ack)
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		return owner.controllerOK(received.Packet, body, nil, false), nil
+	case l8RuntimeOwnerOpcodeCommit:
+		request, err := decodeL8RuntimeOwnerCommitRequest(received.Packet.Body)
+		if err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		expected := l8RuntimeOwnerCommitRequestV1{
+			ControllerSessionGeneration: owner.sessionGeneration,
+			CommitID:                    record.FinalizedCommitID,
+			FinalizedRevision:           record.Revision,
+		}
+		if record.State != "finalized" || request != expected {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+		}
+		if err := owner.opts.Store.RetireFinalized(ctx, record.Revision, record.FinalizedCommitID); err != nil {
+			return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerInvalid
+		}
+		body := make([]byte, 8)
+		binary.BigEndian.PutUint64(body, record.Revision)
+		return owner.controllerOK(received.Packet, body, nil, true), nil
+	case l8RuntimeOwnerOpcodeAbortStart:
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	default:
+		return l8RuntimeOwnerControlResult{}, errL8RuntimeOwnerProtocol
+	}
+}
+
+func (owner *l8RuntimeOwnerSupervisor) controllerOK(request l8RuntimeOwnerPacketV1, body []byte, files []int, exit bool) l8RuntimeOwnerControlResult {
+	return l8RuntimeOwnerControlResult{
+		Packet: l8RuntimeOwnerPacketV1{
+			Opcode:   request.Opcode,
+			Status:   l8RuntimeOwnerStatusOK,
+			Sequence: request.Sequence,
+			Body:     body,
+		},
+		Files: files,
+		Exit:  exit,
+	}
+}
+
+func (owner *l8RuntimeOwnerSupervisor) duplicateNamespaces() ([]int, error) {
+	if owner.opts.DuplicateNamespaces == nil {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	files, err := owner.opts.DuplicateNamespaces()
+	if err != nil || len(files) != 2 {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	return append([]int(nil), files...), nil
+}
+
+func (owner *l8RuntimeOwnerSupervisor) unclaim(ctx context.Context, record firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	next := record
+	next.Revision = record.Revision + 1
+	next.ControllerState = "unclaimed"
+	if owner.opts.RandomToken != nil {
+		secret, err := owner.opts.RandomToken()
+		if err != nil || !validL8RuntimeOwnerToken(secret) {
+			return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+		}
+		next.ReconnectSecret = secret
+	}
+	updated, err := owner.opts.Store.Transition(ctx, record.Revision, next)
+	if err != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	return updated, nil
+}
+
+func (owner *l8RuntimeOwnerSupervisor) reinspectAbsence(ctx context.Context, record firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	if record.State != "absent" || owner.opts.ReinspectAbsence == nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	observation, err := owner.opts.ReinspectAbsence()
+	if err != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	next := record
+	next.Revision = record.Revision + 1
+	next.State = "absent"
+	next.AbsenceKind = l8RuntimeOwnerAbsenceKindName(observation.Kind)
+	next.AbsenceRevision = next.Revision
+	next.AbsenceObservedAtUnixNano = observation.ObservedAt.UnixNano()
+	updated, err := owner.opts.Store.Transition(ctx, record.Revision, next)
+	if err != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	return updated, nil
+}
+
+func (owner *l8RuntimeOwnerSupervisor) finalize(ctx context.Context, record firecrackerRuntimeOwnerRecordV1, request l8RuntimeOwnerFinalizeRequestV1) (l8RuntimeOwnerFinalizeAckV1, error) {
+	if record.State != "absent" || request.AbsenceRevision != record.AbsenceRevision || request.ObservedAtUnixNano != record.AbsenceObservedAtUnixNano {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	}
+	digestBytes, err := hex.DecodeString(record.SeedCorrelationDigest)
+	if err != nil || len(digestBytes) != 32 {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	}
+	var seedDigest [32]byte
+	copy(seedDigest[:], digestBytes)
+	finalizedRevision := record.Revision + 2
+	commitID, err := l8RuntimeOwnerCommitID(owner.opts.CommitKey, seedDigest, finalizedRevision)
+	if err != nil {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	}
+	finalizing := record
+	finalizing.Revision = record.Revision + 1
+	finalizing.State = "finalizing"
+	finalizing.FinalizeTargetRevision = finalizedRevision
+	finalizing.FinalizedCommitID = commitID
+	if _, err := owner.opts.Store.Transition(ctx, record.Revision, finalizing); err != nil {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	}
+	if owner.opts.CloseNamespaces == nil || owner.opts.CloseNamespaces() != nil {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	}
+	finalized := finalizing
+	finalized.Revision = finalizedRevision
+	finalized.State = "finalized"
+	if _, err := owner.opts.Store.Transition(ctx, finalizing.Revision, finalized); err != nil {
+		return l8RuntimeOwnerFinalizeAckV1{}, errL8RuntimeOwnerInvalid
+	}
+	return l8RuntimeOwnerFinalizeAckV1{CommitID: commitID, FinalizedRevision: finalizedRevision}, nil
+}
+
+func l8RuntimeOwnerControllerSession(packet l8RuntimeOwnerPacketV1) (string, error) {
+	switch packet.Opcode {
+	case l8RuntimeOwnerOpcodeInspect, l8RuntimeOwnerOpcodeStopReap, l8RuntimeOwnerOpcodeAcquireNamespaces, l8RuntimeOwnerOpcodeClose, l8RuntimeOwnerOpcodeAbortStart:
+		request, err := decodeL8RuntimeOwnerControllerRequest(packet.Body)
+		if err != nil {
+			return "", err
+		}
+		return request.ControllerSessionGeneration, nil
+	case l8RuntimeOwnerOpcodeFinalize:
+		request, err := decodeL8RuntimeOwnerFinalizeRequest(packet.Body)
+		if err != nil {
+			return "", err
+		}
+		return request.ControllerSessionGeneration, nil
+	case l8RuntimeOwnerOpcodeCommit:
+		request, err := decodeL8RuntimeOwnerCommitRequest(packet.Body)
+		if err != nil {
+			return "", err
+		}
+		return request.ControllerSessionGeneration, nil
+	default:
+		return "", errL8RuntimeOwnerProtocol
+	}
+}
+
+func l8RuntimeOwnerResponseFromRecord(record firecrackerRuntimeOwnerRecordV1, includeAbsence bool) l8RuntimeOwnerResponseV1 {
+	response := l8RuntimeOwnerResponseV1{
+		State:          l8RuntimeOwnerStateByte(record.State),
+		RecordRevision: record.Revision,
+	}
+	if includeAbsence && record.State == "absent" {
+		response.AbsenceKind = l8RuntimeOwnerAbsenceKindByte(record.AbsenceKind)
+		response.ObservedAtUnixNano = record.AbsenceObservedAtUnixNano
+	}
+	return response
+}
+
+func l8RuntimeOwnerStateByte(state string) byte {
+	switch state {
+	case "starting":
+		return l8RuntimeOwnerStateStarting
+	case "running":
+		return l8RuntimeOwnerStateRunning
+	case "stopping":
+		return l8RuntimeOwnerStateStopping
+	case "absent":
+		return l8RuntimeOwnerStateAbsent
+	case "finalizing":
+		return l8RuntimeOwnerStateFinalizing
+	case "finalized":
+		return l8RuntimeOwnerStateFinalized
+	case "uncertain":
+		return l8RuntimeOwnerStateUncertain
+	default:
+		return 0
+	}
+}
+
+func l8RuntimeOwnerAbsenceKindByte(kind string) byte {
+	switch kind {
+	case "direct_wait":
+		return l8RuntimeOwnerAbsenceKindWait
+	case "replacement_proc":
+		return l8RuntimeOwnerAbsenceKindProc
+	default:
+		return l8RuntimeOwnerAbsenceKindNone
+	}
+}
+
+func l8RuntimeOwnerAbsenceKindName(kind byte) string {
+	switch kind {
+	case l8RuntimeOwnerAbsenceKindWait:
+		return "direct_wait"
+	case l8RuntimeOwnerAbsenceKindProc:
+		return "replacement_proc"
+	default:
+		return ""
+	}
+}
+
+func validL8RuntimeOwnerSafeID(value string) bool {
+	if value == "" || len(value) > l8RuntimeOwnerHandshakeGenerationMax {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' ||
+			character == '-' || character == '_' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func l8RuntimeOwnerCall(fn func() error) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if fn == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := fn(); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func l8RuntimeOwnerCallUint64(fn func() (uint64, error)) (value uint64, err error) {
+	defer func() {
+		if recover() != nil {
+			value = 0
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if fn == nil {
+		return 0, errL8RuntimeOwnerInvalid
+	}
+	value, callErr := fn()
+	if callErr != nil {
+		return 0, errL8RuntimeOwnerInvalid
+	}
+	return value, nil
+}
+
+func l8RuntimeOwnerCallWait(fn func(context.Context) (bool, error), ctx context.Context) (reaped bool, err error) {
+	defer func() {
+		if recover() != nil {
+			reaped = false
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if fn == nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	reaped, callErr := fn(ctx)
+	if callErr != nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	return reaped, nil
+}
+
+func l8RuntimeOwnerCallRecordAbsent(fn func(l8RuntimeOwnerAbsenceObservation) (uint64, error), observation l8RuntimeOwnerAbsenceObservation) (revision uint64, err error) {
+	defer func() {
+		if recover() != nil {
+			revision = 0
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if fn == nil {
+		return 0, errL8RuntimeOwnerInvalid
+	}
+	revision, callErr := fn(observation)
+	if callErr != nil {
+		return 0, errL8RuntimeOwnerInvalid
+	}
+	return revision, nil
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor.go
@@ -1157,20 +1157,57 @@ func (owner *l8RuntimeOwnerSupervisor) unclaim(ctx context.Context, record firec
 }
 
 func (owner *l8RuntimeOwnerSupervisor) reinspectAbsence(ctx context.Context, record firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
-	if record.State != "absent" || owner.opts.ReinspectAbsence == nil {
+	var observation l8RuntimeOwnerAbsenceObservation
+	var err error
+	prior := record
+	switch record.State {
+	case "running":
+		if owner.opts.ContainChild == nil {
+			return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+		}
+		stopping := record
+		stopping.Revision++
+		stopping.State = "stopping"
+		stopping.AbsenceKind = ""
+		stopping.AbsenceRevision = 0
+		stopping.AbsenceObservedAtUnixNano = 0
+		prior, err = owner.opts.Store.Transition(ctx, record.Revision, stopping)
+		if err != nil {
+			return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+		}
+		observation, err = owner.opts.ContainChild()
+	case "stopping", "uncertain":
+		if owner.opts.ContainChild == nil {
+			return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+		}
+		observation, err = owner.opts.ContainChild()
+	case "absent":
+		if owner.opts.ReinspectAbsence == nil {
+			return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+		}
+		observation, err = owner.opts.ReinspectAbsence()
+	default:
 		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 	}
-	observation, err := owner.opts.ReinspectAbsence()
 	if err != nil {
+		if prior.State == "stopping" {
+			uncertain := prior
+			uncertain.Revision++
+			uncertain.State = "uncertain"
+			uncertain.AbsenceKind = ""
+			uncertain.AbsenceRevision = 0
+			uncertain.AbsenceObservedAtUnixNano = 0
+			_, _ = owner.opts.Store.Transition(ctx, prior.Revision, uncertain)
+		}
 		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 	}
-	next := record
-	next.Revision = record.Revision + 1
+	next := prior
+	next.Revision = prior.Revision + 1
 	next.State = "absent"
 	next.AbsenceKind = l8RuntimeOwnerAbsenceKindName(observation.Kind)
 	next.AbsenceRevision = next.Revision
 	next.AbsenceObservedAtUnixNano = observation.ObservedAt.UnixNano()
-	updated, err := owner.opts.Store.Transition(ctx, record.Revision, next)
+	updated, err := owner.opts.Store.Transition(ctx, prior.Revision, next)
 	if err != nil {
 		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 	}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
@@ -1,0 +1,262 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type l8RuntimeOwnerTestStore struct {
+	record       firecrackerRuntimeOwnerRecordV1
+	events       []string
+	transitions  []firecrackerRuntimeOwnerRecordV1
+	retiredZero  bool
+	retiredFinal bool
+}
+
+func (store *l8RuntimeOwnerTestStore) Load(context.Context) (firecrackerRuntimeOwnerRecordV1, error) {
+	store.events = append(store.events, "load")
+	return store.record, nil
+}
+func (store *l8RuntimeOwnerTestStore) CreateGenesis(_ context.Context, next firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	store.events = append(store.events, "genesis")
+	store.record = next
+	return next, nil
+}
+func (store *l8RuntimeOwnerTestStore) Transition(_ context.Context, expected uint64, next firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	store.events = append(store.events, "transition")
+	if store.record.Revision != expected || next.Revision != expected+1 {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	store.record = next
+	store.transitions = append(store.transitions, next)
+	return next, nil
+}
+func (store *l8RuntimeOwnerTestStore) RetireStartingZero(_ context.Context, expected uint64) error {
+	store.events = append(store.events, "retire_zero")
+	if expected != 0 || store.record.State != "starting" || store.record.Revision != 0 {
+		return errL8RuntimeOwnerInvalid
+	}
+	store.retiredZero = true
+	return nil
+}
+func (store *l8RuntimeOwnerTestStore) RetireFinalized(_ context.Context, expected uint64, commitID string) error {
+	store.events = append(store.events, "retire_final")
+	if store.record.State != "finalized" || store.record.Revision != expected || store.record.FinalizedCommitID != commitID {
+		return errL8RuntimeOwnerInvalid
+	}
+	store.retiredFinal = true
+	return nil
+}
+
+func TestL8RuntimeOwnerAdmissionPreservesLifecycleAndRotatesOneUseSecret(t *testing.T) {
+	for _, state := range []string{"running", "stopping", "absent", "uncertain", "finalizing", "finalized"} {
+		t.Run(state, func(t *testing.T) {
+			record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+			record.State, record.ControllerState, record.Revision = state, "unclaimed", 7
+			if state == "absent" || state == "uncertain" || state == "finalizing" || state == "finalized" {
+				record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "direct_wait", 6, time.Unix(600, 0).UnixNano()
+			}
+			if state == "finalizing" || state == "finalized" {
+				record.FinalizedCommitID, record.FinalizeTargetRevision = l8RuntimeOwnerTestToken(8), 8
+			}
+			store := &l8RuntimeOwnerTestStore{record: record}
+			owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, RandomToken: func() (string, error) { return l8RuntimeOwnerTestToken(9), nil }, CommitKey: make([]byte, 32)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := encodeL8RuntimeOwnerHandshake(l8RuntimeOwnerHandshakeV1{SupervisorGeneration: record.SupervisorGeneration, RuntimeGeneration: record.RuntimeGeneration, RecordRevision: record.Revision, ReconnectSecret: record.ReconnectSecret})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := owner.AdmitController(context.Background(), 1000, l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Body: body}})
+			if err != nil || result.Packet.Status != l8RuntimeOwnerStatusOK {
+				t.Fatalf("admit = %#v, %v", result, err)
+			}
+			if store.record.State != state || store.record.ControllerState != "controlled" || store.record.Revision != 8 || store.record.ReconnectSecret == record.ReconnectSecret || store.record.AbsenceRevision != record.AbsenceRevision {
+				t.Fatalf("admitted record = %#v", store.record)
+			}
+			if err := owner.ControllerLost(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if store.record.State != state || store.record.ControllerState != "unclaimed" || store.record.AbsenceRevision != record.AbsenceRevision {
+				t.Fatalf("lost record = %#v", store.record)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerAdmissionRejectsPeerSecretRevisionAndReplayWithoutMutation(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "running", "unclaimed", 2
+	for _, scenario := range []struct {
+		name   string
+		uid    uint32
+		mutate func(*l8RuntimeOwnerHandshakeV1)
+	}{
+		{name: "wrong uid", uid: 1001},
+		{name: "wrong secret", uid: 1000, mutate: func(value *l8RuntimeOwnerHandshakeV1) { value.ReconnectSecret = l8RuntimeOwnerTestToken(31) }},
+		{name: "wrong revision", uid: 1000, mutate: func(value *l8RuntimeOwnerHandshakeV1) { value.RecordRevision++ }},
+		{name: "wrong generation", uid: 1000, mutate: func(value *l8RuntimeOwnerHandshakeV1) { value.SupervisorGeneration = l8RuntimeOwnerTestToken(30) }},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			store := &l8RuntimeOwnerTestStore{record: record}
+			owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, RandomToken: func() (string, error) { return l8RuntimeOwnerTestToken(9), nil }, CommitKey: make([]byte, 32)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			handshake := l8RuntimeOwnerHandshakeV1{SupervisorGeneration: record.SupervisorGeneration, RuntimeGeneration: record.RuntimeGeneration, RecordRevision: record.Revision, ReconnectSecret: record.ReconnectSecret}
+			if scenario.mutate != nil {
+				scenario.mutate(&handshake)
+			}
+			body, _ := encodeL8RuntimeOwnerHandshake(handshake)
+			if _, err := owner.AdmitController(context.Background(), scenario.uid, l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Body: body}}); !errors.Is(err, errL8RuntimeOwnerProtocol) || err.Error() != errL8RuntimeOwnerProtocol.Error() {
+				t.Fatalf("admit = %v", err)
+			}
+			if store.record != record || len(store.transitions) != 0 {
+				t.Fatalf("record mutated = %#v", store.record)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerAbortStartIsCausalAtRevisionZeroAndContainedAtRevisionOne(t *testing.T) {
+	for _, revision := range []uint64{0, 1} {
+		t.Run(string(rune('0'+revision)), func(t *testing.T) {
+			record := l8RuntimeOwnerTestGenesis(l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef"))
+			record.Revision = revision
+			if revision == 1 {
+				record.FirecrackerPID, record.FirecrackerStartTime = 5001, 7001
+			}
+			store := &l8RuntimeOwnerTestStore{record: record}
+			var events []string
+			owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, AbortStartingZero: func() error { events = append(events, "prove_no_fork_close_assets"); return nil }, ContainChild: func() (l8RuntimeOwnerAbsenceObservation, error) {
+				events = append(events, "contain")
+				return l8RuntimeOwnerAbsenceObservation{Kind: 1, Revision: 3, ObservedAt: time.Unix(1, 0)}, nil
+			}, CommitKey: make([]byte, 32)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := owner.AbortStart(context.Background(), 1000, l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeAbortStart, Sequence: 1}})
+			if err != nil || !result.Exit {
+				t.Fatalf("abort = %#v, %v", result, err)
+			}
+			if revision == 0 && (!store.retiredZero || !reflect.DeepEqual(events, []string{"prove_no_fork_close_assets"})) {
+				t.Fatalf("rev0 = %v %#v", events, store)
+			}
+			if revision == 1 && (!reflect.DeepEqual(events, []string{"contain"}) || store.record.State != "absent" || store.record.Revision != 3) {
+				t.Fatalf("rev1 = %v %#v", events, store.record)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerStopReinspectsAndPersistsFreshAbsenceAcrossReconnect(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "absent", "controlled", 9
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "replacement_proc", 9, time.Unix(9, 0).UnixNano()
+	store := &l8RuntimeOwnerTestStore{record: record}
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, ReinspectAbsence: func() (l8RuntimeOwnerAbsenceObservation, error) {
+		return l8RuntimeOwnerAbsenceObservation{Kind: 2, Revision: 10, ObservedAt: time.Unix(10, 0)}, nil
+	}, CommitKey: make([]byte, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(1)})
+	first, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeStopReap, Sequence: 1, Body: body}})
+	if err != nil || first.Packet.Status != 0 || store.record.AbsenceRevision != 10 || store.record.AbsenceObservedAtUnixNano != time.Unix(10, 0).UnixNano() {
+		t.Fatalf("first inspect = %#v %#v %v", first, store.record, err)
+	}
+	second, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeStopReap, Sequence: 2, Body: body}})
+	if err != nil || second.Packet.Sequence != 2 || store.record.AbsenceRevision != 11 {
+		t.Fatalf("second inspect = %#v %#v %v", second, store.record, err)
+	}
+}
+
+func TestL8RuntimeOwnerReplayReissuesFreshNamespaceDuplicatesAndClosePreservesOriginals(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "absent", "unclaimed", 5
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "direct_wait", 5, time.Unix(5, 0).UnixNano()
+	store := &l8RuntimeOwnerTestStore{record: record}
+	tokenIndex := byte(20)
+	duplicateCall := 0
+	closedOriginals := 0
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store: store, ExpectedUID: 1000, CommitKey: make([]byte, 32),
+		RandomToken: func() (string, error) { tokenIndex++; return l8RuntimeOwnerTestToken(tokenIndex), nil },
+		DuplicateNamespaces: func() ([]int, error) {
+			duplicateCall++
+			return []int{100 + duplicateCall*2, 101 + duplicateCall*2}, nil
+		},
+		CloseNamespaces: func() error { closedOriginals++; return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handshakeBody, _ := encodeL8RuntimeOwnerHandshake(l8RuntimeOwnerHandshakeV1{SupervisorGeneration: record.SupervisorGeneration, RuntimeGeneration: record.RuntimeGeneration, RecordRevision: record.Revision, ReconnectSecret: record.ReconnectSecret})
+	admitted, err := owner.AdmitController(context.Background(), 1000, l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Body: handshakeBody}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ack, err := decodeL8RuntimeOwnerHandshakeAck(admitted.Packet.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestBody, _ := encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: ack.ControllerSessionGeneration})
+	inspect := l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Sequence: 1, Body: requestBody}}
+	first, err := owner.HandleController(context.Background(), inspect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duplicate, err := owner.HandleController(context.Background(), inspect)
+	if err != nil || !reflect.DeepEqual(duplicate.Packet, first.Packet) {
+		t.Fatalf("inspect replay = %#v / %#v, %v", first, duplicate, err)
+	}
+	acquire := l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeAcquireNamespaces, Sequence: 2, Body: requestBody}}
+	rightsOne, err := owner.HandleController(context.Background(), acquire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rightsTwo, err := owner.HandleController(context.Background(), acquire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(rightsOne.Packet, rightsTwo.Packet) || reflect.DeepEqual(rightsOne.Files, rightsTwo.Files) || duplicateCall != 2 || closedOriginals != 0 {
+		t.Fatalf("namespace replay = %#v / %#v calls %d closed %d", rightsOne, rightsTwo, duplicateCall, closedOriginals)
+	}
+	if _, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Sequence: 4, Body: requestBody}}); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+		t.Fatalf("skipped sequence = %v", err)
+	}
+	closed, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeClose, Sequence: 3, Body: requestBody}})
+	if err != nil || closed.Exit || closedOriginals != 0 || store.record.State != "absent" || store.record.ControllerState != "unclaimed" {
+		t.Fatalf("close = %#v record %#v originals %d err %v", closed, store.record, closedOriginals, err)
+	}
+}
+
+func TestL8RuntimeOwnerFinalizeIsCrashSafeAndCommitRetiresOnlyFinalized(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "absent", "controlled", 12
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "direct_wait", 12, time.Unix(12, 0).UnixNano()
+	store := &l8RuntimeOwnerTestStore{record: record}
+	var events []string
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, CloseNamespaces: func() error { events = append(events, "close_namespace_originals"); return nil }, CommitKey: []byte("01234567890123456789012345678901")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestBody, _ := encodeL8RuntimeOwnerFinalizeRequest(l8RuntimeOwnerFinalizeRequestV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(1), AbsenceRevision: 12, ObservedAtUnixNano: time.Unix(12, 0).UnixNano()})
+	result, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeFinalize, Sequence: 1, Body: requestBody}})
+	if err != nil || store.record.State != "finalized" || len(store.transitions) != 2 || store.transitions[0].State != "finalizing" || store.transitions[1].State != "finalized" || !reflect.DeepEqual(events, []string{"close_namespace_originals"}) {
+		t.Fatalf("finalize = %#v %#v %v events %v", result, store.transitions, err, events)
+	}
+	ack, err := decodeL8RuntimeOwnerFinalizeAck(result.Packet.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitBody, _ := encodeL8RuntimeOwnerCommitRequest(l8RuntimeOwnerCommitRequestV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(1), CommitID: ack.CommitID, FinalizedRevision: ack.FinalizedRevision})
+	committed, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeCommit, Sequence: 2, Body: commitBody}})
+	if err != nil || !committed.Exit || !store.retiredFinal {
+		t.Fatalf("commit = %#v %v retired %t", committed, err, store.retiredFinal)
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
@@ -300,6 +300,38 @@ func TestL8RuntimeOwnerStopReapContainsRunningChildBeforePublishingAbsence(t *te
 	}
 }
 
+func TestL8RuntimeOwnerStopReapResumesContainmentFromNonterminalRecoveryStates(t *testing.T) {
+	for _, state := range []string{"stopping", "uncertain"} {
+		t.Run(state, func(t *testing.T) {
+			record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+			record.State, record.ControllerState, record.Revision = state, "controlled", 4
+			record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "", 0, 0
+			store := &l8RuntimeOwnerTestStore{record: record}
+			containCalls := 0
+			owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+				Store: store, ExpectedUID: 1000, CommitKey: make([]byte, 32),
+				ContainChild: func() (l8RuntimeOwnerAbsenceObservation, error) {
+					containCalls++
+					return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: time.Unix(25, 0)}, nil
+				},
+				ReinspectAbsence: func() (l8RuntimeOwnerAbsenceObservation, error) {
+					t.Fatal("nonterminal recovery used passive absence inspection")
+					return l8RuntimeOwnerAbsenceObservation{}, nil
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			owner.sessionGeneration = l8RuntimeOwnerTestToken(1)
+			body, _ := encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: owner.sessionGeneration})
+			result, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeStopReap, Sequence: 1, Body: body}})
+			if err != nil || result.Packet.Status != l8RuntimeOwnerStatusOK || containCalls != 1 || store.record.State != "absent" || store.record.Revision != 5 {
+				t.Fatalf("resumed stop/reap = %#v record %#v calls %d err %v", result, store.record, containCalls, err)
+			}
+		})
+	}
+}
+
 func TestL8RuntimeOwnerReplayReissuesFreshNamespaceDuplicatesAndClosePreservesOriginals(t *testing.T) {
 	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
 	record.State, record.ControllerState, record.Revision = "absent", "unclaimed", 5

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
@@ -60,7 +60,12 @@ func TestL8RuntimeOwnerAdmissionPreservesLifecycleAndRotatesOneUseSecret(t *test
 				record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "direct_wait", 6, time.Unix(600, 0).UnixNano()
 			}
 			if state == "finalizing" || state == "finalized" {
-				record.FinalizedCommitID, record.FinalizeTargetRevision = l8RuntimeOwnerTestToken(8), 8
+				record.FinalizedCommitID = l8RuntimeOwnerTestToken(8)
+				if state == "finalizing" {
+					record.FinalizeTargetRevision = 8
+				} else {
+					record.FinalizeTargetRevision = 7
+				}
 			}
 			store := &l8RuntimeOwnerTestStore{record: record}
 			owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, RandomToken: func() (string, error) { return l8RuntimeOwnerTestToken(9), nil }, CommitKey: make([]byte, 32)})
@@ -85,6 +90,95 @@ func TestL8RuntimeOwnerAdmissionPreservesLifecycleAndRotatesOneUseSecret(t *test
 				t.Fatalf("lost record = %#v", store.record)
 			}
 		})
+	}
+}
+
+func TestL8RuntimeOwnerFinalizeRetriesBothDurablePhasesAndPreservesReceiptAcrossReconnect(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "absent", "controlled", 12
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "direct_wait", 12, time.Unix(12, 0).UnixNano()
+	store := &l8RuntimeOwnerTestStore{record: record}
+	closeCalls := 0
+	closeFails := true
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store: store, ExpectedUID: 1000, CommitKey: make([]byte, 32),
+		CloseNamespaces: func() error {
+			closeCalls++
+			if closeFails {
+				closeFails = false
+				return errors.New("private close uncertainty")
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8RuntimeOwnerFinalizeRequestV1{
+		ControllerSessionGeneration: l8RuntimeOwnerTestToken(1),
+		AbsenceRevision:             record.AbsenceRevision,
+		ObservedAtUnixNano:          record.AbsenceObservedAtUnixNano,
+	}
+	if _, err := owner.finalize(context.Background(), record, request); !errors.Is(err, errL8RuntimeOwnerInvalid) || store.record.State != "finalizing" {
+		t.Fatalf("first finalize = %#v, %v", store.record, err)
+	}
+	ack, err := owner.finalize(context.Background(), store.record, request)
+	if err != nil || store.record.State != "finalized" || store.record.Revision != ack.FinalizedRevision || closeCalls != 2 {
+		t.Fatalf("retry finalize = %#v, %#v, calls %d, %v", store.record, ack, closeCalls, err)
+	}
+	transitions := len(store.transitions)
+	replayed, err := owner.finalize(context.Background(), store.record, request)
+	if err != nil || replayed != ack || len(store.transitions) != transitions || closeCalls != 2 {
+		t.Fatalf("finalized replay = %#v, transitions %d, calls %d, %v", replayed, len(store.transitions), closeCalls, err)
+	}
+
+	store.record.ControllerState = "unclaimed"
+	store.record.Revision++
+	owner.opts.RandomToken = func() (string, error) { return l8RuntimeOwnerTestToken(byte(20 + store.record.Revision)), nil }
+	body, _ := encodeL8RuntimeOwnerHandshake(l8RuntimeOwnerHandshakeV1{
+		SupervisorGeneration: store.record.SupervisorGeneration,
+		RuntimeGeneration:    store.record.RuntimeGeneration,
+		RecordRevision:       store.record.Revision,
+		ReconnectSecret:      store.record.ReconnectSecret,
+	})
+	admitted, err := owner.AdmitController(context.Background(), 1000, l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Body: body}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handshake, err := decodeL8RuntimeOwnerHandshakeAck(admitted.Packet.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitBody, _ := encodeL8RuntimeOwnerCommitRequest(l8RuntimeOwnerCommitRequestV1{
+		ControllerSessionGeneration: handshake.ControllerSessionGeneration,
+		CommitID:                    ack.CommitID,
+		FinalizedRevision:           ack.FinalizedRevision,
+	})
+	committed, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeCommit, Sequence: 1, Body: commitBody}})
+	if err != nil || !committed.Exit || !store.retiredFinal {
+		t.Fatalf("commit after reconnect = %#v, %v", committed, err)
+	}
+}
+
+func TestL8RuntimeOwnerReplayRequiresByteIdenticalRequest(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "absent", "controlled", 5
+	store := &l8RuntimeOwnerTestStore{record: record}
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, ExpectedUID: 1000, CommitKey: make([]byte, 32)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner.sessionGeneration = l8RuntimeOwnerTestToken(1)
+	body, _ := encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: owner.sessionGeneration})
+	request := l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Sequence: 1, Body: body}}
+	if _, err := owner.HandleController(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	mutated := request
+	mutated.Packet.Body = append([]byte(nil), body...)
+	mutated.Packet.Body[0] ^= 1
+	if _, err := owner.HandleController(context.Background(), mutated); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+		t.Fatalf("mutated replay = %v", err)
 	}
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_fsm_test.go
@@ -269,6 +269,37 @@ func TestL8RuntimeOwnerStopReinspectsAndPersistsFreshAbsenceAcrossReconnect(t *t
 	}
 }
 
+func TestL8RuntimeOwnerStopReapContainsRunningChildBeforePublishingAbsence(t *testing.T) {
+	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "running", "controlled", 2
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "", 0, 0
+	store := &l8RuntimeOwnerTestStore{record: record}
+	var events []string
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store: store, ExpectedUID: 1000, CommitKey: make([]byte, 32),
+		ContainChild: func() (l8RuntimeOwnerAbsenceObservation, error) {
+			events = append(events, "contain")
+			if store.record.State != "stopping" || store.record.Revision != 3 {
+				t.Fatalf("contain before stopping durability: %#v", store.record)
+			}
+			return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: time.Unix(20, 0)}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	owner.sessionGeneration = l8RuntimeOwnerTestToken(1)
+	body, _ := encodeL8RuntimeOwnerControllerRequest(l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: owner.sessionGeneration})
+	result, err := owner.HandleController(context.Background(), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeStopReap, Sequence: 1, Body: body}})
+	if err != nil || result.Packet.Status != l8RuntimeOwnerStatusOK || !reflect.DeepEqual(events, []string{"contain"}) {
+		t.Fatalf("stop/reap = %#v events %v err %v", result, events, err)
+	}
+	if store.record.State != "absent" || store.record.Revision != 4 || store.record.AbsenceKind != "direct_wait" ||
+		store.record.AbsenceRevision != 4 || store.record.AbsenceObservedAtUnixNano != time.Unix(20, 0).UnixNano() {
+		t.Fatalf("absent record = %#v", store.record)
+	}
+}
+
 func TestL8RuntimeOwnerReplayReissuesFreshNamespaceDuplicatesAndClosePreservesOriginals(t *testing.T) {
 	record := l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef")
 	record.State, record.ControllerState, record.Revision = "absent", "unclaimed", 5

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_test.go
@@ -1,0 +1,444 @@
+package firecrackerhost
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestL8RuntimeOwnerProtocolExactRoundTripsAndRejectsMutations(t *testing.T) {
+	handshake := l8RuntimeOwnerHandshakeV1{
+		SupervisorGeneration: l8RuntimeOwnerTestToken(1),
+		RuntimeGeneration:    "runtime-generation-1",
+		RecordRevision:       9,
+		ReconnectSecret:      l8RuntimeOwnerTestToken(2),
+	}
+	body, err := encodeL8RuntimeOwnerHandshake(handshake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packet := l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Body: body}
+	wire, err := encodeL8RuntimeOwnerPacket(packet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wire) != l8RuntimeOwnerPacketHeaderSize+len(body) || string(wire[:8]) != l8RuntimeOwnerProtocolMagic || binary.BigEndian.Uint16(wire[8:10]) != l8RuntimeOwnerProtocolVersion {
+		t.Fatalf("wire header = %x", wire)
+	}
+	decodedPacket, err := decodeL8RuntimeOwnerPacket(wire)
+	if err != nil || !reflect.DeepEqual(decodedPacket, packet) {
+		t.Fatalf("decoded packet = %#v, %v", decodedPacket, err)
+	}
+	decodedHandshake, err := decodeL8RuntimeOwnerHandshake(decodedPacket.Body)
+	if err != nil || decodedHandshake != handshake {
+		t.Fatalf("decoded handshake = %#v, %v", decodedHandshake, err)
+	}
+
+	mutations := map[string]func([]byte) []byte{
+		"magic":              func(value []byte) []byte { value[0] ^= 1; return value },
+		"version":            func(value []byte) []byte { binary.BigEndian.PutUint16(value[8:10], 2); return value },
+		"opcode":             func(value []byte) []byte { binary.BigEndian.PutUint16(value[10:12], 99); return value },
+		"request status":     func(value []byte) []byte { binary.BigEndian.PutUint16(value[12:14], 1); return value },
+		"body length":        func(value []byte) []byte { binary.BigEndian.PutUint16(value[14:16], uint16(len(body)+1)); return value },
+		"handshake sequence": func(value []byte) []byte { binary.BigEndian.PutUint64(value[16:24], 1); return value },
+		"trailing":           func(value []byte) []byte { return append(value, 0) },
+		"truncated":          func(value []byte) []byte { return value[:len(value)-1] },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			candidate := append([]byte(nil), wire...)
+			if _, err := decodeL8RuntimeOwnerPacket(mutate(candidate)); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+				t.Fatalf("mutation error = %v", err)
+			}
+		})
+	}
+	if _, err := decodeL8RuntimeOwnerPacket(make([]byte, l8RuntimeOwnerPacketLimit+1)); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+		t.Fatalf("oversize error = %v", err)
+	}
+}
+
+func TestL8RuntimeOwnerProtocolExactBodies(t *testing.T) {
+	ack := l8RuntimeOwnerHandshakeAckV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(3), RecordRevision: 11}
+	ackBody, err := encodeL8RuntimeOwnerHandshakeAck(ack)
+	if err != nil || len(ackBody) != 51 {
+		t.Fatalf("ack body length = %d, %v", len(ackBody), err)
+	}
+	if got, err := decodeL8RuntimeOwnerHandshakeAck(ackBody); err != nil || got != ack {
+		t.Fatalf("ack = %#v, %v", got, err)
+	}
+	response := l8RuntimeOwnerResponseV1{State: 5, AbsenceKind: 1, RecordRevision: 12, ObservedAtUnixNano: 123456789}
+	responseBody, err := encodeL8RuntimeOwnerResponse(response)
+	if err != nil || len(responseBody) != 24 {
+		t.Fatalf("response body length = %d, %v", len(responseBody), err)
+	}
+	if got, err := decodeL8RuntimeOwnerResponse(responseBody); err != nil || got != response {
+		t.Fatalf("response = %#v, %v", got, err)
+	}
+	for _, malformed := range [][]byte{
+		ackBody[:len(ackBody)-1], append(append([]byte(nil), ackBody...), 0),
+		responseBody[:len(responseBody)-1], append(append([]byte(nil), responseBody...), 0),
+	} {
+		if len(malformed) < 40 {
+			if _, err := decodeL8RuntimeOwnerResponse(malformed); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+				t.Errorf("response mutation = %v", err)
+			}
+		} else if _, err := decodeL8RuntimeOwnerHandshakeAck(malformed); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+			t.Errorf("ack mutation = %v", err)
+		}
+	}
+}
+
+func TestL8RuntimeOwnerTransitionGraphRejectsResurrection(t *testing.T) {
+	seed := l8RuntimeOwnerTestSeed()
+	base := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record := func(state string, revision uint64) firecrackerRuntimeOwnerRecordV1 {
+		value := base
+		value.State, value.Revision = state, revision
+		value.FinalizedCommitID = ""
+		if state == "finalized" {
+			value.FinalizedCommitID = l8RuntimeOwnerTestToken(9)
+		}
+		if state == "starting" && revision == 0 {
+			value.FirecrackerPID, value.FirecrackerStartTime = 0, 0
+		}
+		return value
+	}
+	genesis := record("starting", 0)
+	revisionOne := record("starting", 1)
+	if !validL8RuntimeOwnerTransition(genesis, revisionOne) {
+		t.Fatal("revision-zero starting did not advance to revision-one starting")
+	}
+	for _, state := range []string{"unclaimed", "stopping", "absent", "uncertain"} {
+		if !validL8RuntimeOwnerTransition(revisionOne, record(state, 2)) {
+			t.Errorf("revision-one starting -> %s rejected", state)
+		}
+	}
+	allowed := [][2]string{
+		{"unclaimed", "controlled"}, {"unclaimed", "stopping"}, {"unclaimed", "absent"}, {"unclaimed", "uncertain"},
+		{"controlled", "unclaimed"}, {"controlled", "stopping"}, {"controlled", "absent"}, {"controlled", "uncertain"},
+		{"stopping", "absent"}, {"stopping", "uncertain"}, {"absent", "finalized"},
+	}
+	for _, transition := range allowed {
+		fromRevision := uint64(2)
+		if !validL8RuntimeOwnerTransition(record(transition[0], fromRevision), record(transition[1], fromRevision+1)) {
+			t.Errorf("allowed transition %s -> %s rejected", transition[0], transition[1])
+		}
+	}
+	for _, transition := range [][2]string{
+		{"absent", "controlled"}, {"absent", "unclaimed"}, {"finalized", "absent"}, {"uncertain", "stopping"},
+		{"stopping", "controlled"}, {"controlled", "starting"},
+	} {
+		if validL8RuntimeOwnerTransition(record(transition[0], 4), record(transition[1], 5)) {
+			t.Errorf("resurrection %s -> %s accepted", transition[0], transition[1])
+		}
+	}
+	if validL8RuntimeOwnerTransition(record("starting", 1), record("starting", 2)) ||
+		validL8RuntimeOwnerTransition(record("starting", 0), record("unclaimed", 1)) ||
+		validL8RuntimeOwnerTransition(record("unclaimed", 2), record("controlled", 4)) {
+		t.Fatal("noncanonical starting or revision jump accepted")
+	}
+}
+
+func TestL8RuntimeOwnerCommitUncertainAcceptsOnlyPriorOrIntended(t *testing.T) {
+	seed := l8RuntimeOwnerTestSeed()
+	prior := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	prior.State, prior.Revision = "unclaimed", 2
+	intended := prior
+	intended.State, intended.Revision, intended.ReconnectSecret = "controlled", 3, l8RuntimeOwnerTestToken(4)
+	if got, committed, err := reconcileL8RuntimeOwnerCommitUncertain(prior, intended, prior); err != nil || committed || got != prior {
+		t.Fatalf("prior reconciliation = %#v, %t, %v", got, committed, err)
+	}
+	if got, committed, err := reconcileL8RuntimeOwnerCommitUncertain(prior, intended, intended); err != nil || !committed || got != intended {
+		t.Fatalf("intended reconciliation = %#v, %t, %v", got, committed, err)
+	}
+	third := intended
+	third.ReconnectSecret = l8RuntimeOwnerTestToken(5)
+	if _, _, err := reconcileL8RuntimeOwnerCommitUncertain(prior, intended, third); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("third-value reconciliation = %v", err)
+	}
+}
+
+func TestL8RuntimeOwnerContainmentUsesOneIndependentBudgetAndNeverSkipsWait(t *testing.T) {
+	for _, scenario := range []struct {
+		name            string
+		terminatePanic  bool
+		terminateErr    bool
+		firstWaitReaped bool
+		killPanic       bool
+		killErr         bool
+		finalReaped     bool
+		wantAbsent      bool
+	}{
+		{name: "term exit", firstWaitReaped: true, wantAbsent: true},
+		{name: "term error still kill wait", terminateErr: true, finalReaped: true, wantAbsent: true},
+		{name: "term panic still kill wait", terminatePanic: true, finalReaped: true, wantAbsent: true},
+		{name: "kill error still wait", killErr: true, finalReaped: true, wantAbsent: true},
+		{name: "kill panic still wait", killPanic: true, finalReaped: true, wantAbsent: true},
+		{name: "unreaped uncertain"},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			var events []string
+			waitCalls := 0
+			var waitDeadlines []time.Time
+			started := time.Now()
+			ops := l8RuntimeOwnerContainmentOps{
+				RecordStopping: func() error { events = append(events, "record_stopping"); return nil },
+				Terminate: func() error {
+					events = append(events, "term")
+					if scenario.terminatePanic {
+						panic("private term panic")
+					}
+					if scenario.terminateErr {
+						return errors.New("private term error")
+					}
+					return nil
+				},
+				Wait: func(ctx context.Context) (bool, error) {
+					events = append(events, "wait")
+					deadline, ok := ctx.Deadline()
+					if !ok {
+						t.Error("wait context has no deadline")
+					}
+					waitDeadlines = append(waitDeadlines, deadline)
+					waitCalls++
+					if waitCalls == 1 {
+						return scenario.firstWaitReaped, nil
+					}
+					return scenario.finalReaped, nil
+				},
+				Kill: func() error {
+					events = append(events, "kill")
+					if scenario.killPanic {
+						panic("private kill panic")
+					}
+					if scenario.killErr {
+						return errors.New("private kill error")
+					}
+					return nil
+				},
+				RecordAbsent: func(observation l8RuntimeOwnerAbsenceObservation) error {
+					events = append(events, "record_absent")
+					return nil
+				},
+				RecordUncertain: func() error { events = append(events, "record_uncertain"); return nil },
+				Now:             func() time.Time { return time.Unix(100, 0) },
+			}
+			observation, err := containL8RuntimeOwnerChild(ops)
+			if scenario.wantAbsent {
+				if err != nil || observation.Kind != 1 || !observation.ObservedAt.Equal(time.Unix(100, 0)) || events[len(events)-1] != "record_absent" {
+					t.Fatalf("containment = %#v, %v, events %v", observation, err, events)
+				}
+			} else if !errors.Is(err, errL8RuntimeOwnerInvalid) || observation != (l8RuntimeOwnerAbsenceObservation{}) || len(events) == 0 || events[len(events)-1] != "record_uncertain" {
+				t.Fatalf("uncertain containment = %#v, %v, events %v", observation, err, events)
+			}
+			if !scenario.firstWaitReaped && !reflect.DeepEqual(events[1:4], []string{"term", "wait", "kill"}) {
+				t.Fatalf("containment order = %v", events)
+			}
+			if len(waitDeadlines) != 0 {
+				first := waitDeadlines[0].Sub(started)
+				if first < 4*time.Second || first > 6*time.Second {
+					t.Fatalf("first wait budget = %v", first)
+				}
+			}
+			if len(waitDeadlines) == 2 {
+				final := waitDeadlines[1].Sub(started)
+				if final < 29*time.Second || final > 31*time.Second || !waitDeadlines[1].After(waitDeadlines[0]) {
+					t.Fatalf("shared final deadline = %v after first %v", final, waitDeadlines[0].Sub(started))
+				}
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerContainmentStoreFailuresNeverPublishAbsence(t *testing.T) {
+	for _, scenario := range []struct {
+		name                 string
+		stoppingFailure      string
+		absentFailure        string
+		wantContainmentCalls bool
+	}{
+		{name: "stopping error", stoppingFailure: "error"},
+		{name: "stopping panic", stoppingFailure: "panic"},
+		{name: "absent error", absentFailure: "error", wantContainmentCalls: true},
+		{name: "absent panic", absentFailure: "panic", wantContainmentCalls: true},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			var events []string
+			ops := l8RuntimeOwnerContainmentOps{
+				RecordStopping: func() error {
+					events = append(events, "record_stopping")
+					if scenario.stoppingFailure == "panic" {
+						panic("private stopping panic")
+					}
+					if scenario.stoppingFailure == "error" {
+						return errors.New("private stopping error")
+					}
+					return nil
+				},
+				Terminate: func() error { events = append(events, "term"); return nil },
+				Wait:      func(context.Context) (bool, error) { events = append(events, "wait"); return true, nil },
+				Kill:      func() error { events = append(events, "kill"); return nil },
+				RecordAbsent: func(l8RuntimeOwnerAbsenceObservation) error {
+					events = append(events, "record_absent")
+					if scenario.absentFailure == "panic" {
+						panic("private absent panic")
+					}
+					if scenario.absentFailure == "error" {
+						return errors.New("private absent error")
+					}
+					return nil
+				},
+				RecordUncertain: func() error { events = append(events, "record_uncertain"); return nil },
+				Now:             func() time.Time { return time.Unix(200, 0) },
+			}
+			observation, err := containL8RuntimeOwnerChild(ops)
+			if observation != (l8RuntimeOwnerAbsenceObservation{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) || err.Error() != errL8RuntimeOwnerInvalid.Error() {
+				t.Fatalf("failure result = %#v, %v", observation, err)
+			}
+			if containsString(events, "record_absent") != scenario.wantContainmentCalls || len(events) == 0 || events[len(events)-1] != "record_uncertain" {
+				t.Fatalf("failure events = %v", events)
+			}
+			if !scenario.wantContainmentCalls && (containsString(events, "term") || containsString(events, "wait") || containsString(events, "kill")) {
+				t.Fatalf("signalled before stopping durability: %v", events)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerContainmentSerializesConcurrentStop(t *testing.T) {
+	controller := &l8RuntimeOwnerContainmentController{}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var muEvents []string
+	var eventMu = make(chan struct{}, 1)
+	eventMu <- struct{}{}
+	add := func(event string) {
+		<-eventMu
+		muEvents = append(muEvents, event)
+		eventMu <- struct{}{}
+	}
+	ops := l8RuntimeOwnerContainmentOps{
+		RecordStopping:  func() error { add("record_stopping"); close(entered); <-release; return nil },
+		Terminate:       func() error { add("term"); return nil },
+		Wait:            func(context.Context) (bool, error) { add("wait"); return true, nil },
+		Kill:            func() error { add("kill"); return nil },
+		RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) error { add("record_absent"); return nil },
+		RecordUncertain: func() error { add("record_uncertain"); return nil },
+		Now:             func() time.Time { return time.Unix(300, 0) },
+	}
+	results := make(chan l8RuntimeOwnerAbsenceObservation, 2)
+	for index := 0; index < 2; index++ {
+		go func() { observation, _ := controller.Stop(ops); results <- observation }()
+	}
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		t.Fatal("containment never admitted a single owner")
+	}
+	close(release)
+	first, second := <-results, <-results
+	if first != second || first.Kind != 1 {
+		t.Fatalf("concurrent observations = %#v / %#v", first, second)
+	}
+	<-eventMu
+	events := append([]string(nil), muEvents...)
+	eventMu <- struct{}{}
+	if got := countString(events, "record_stopping"); got != 1 || countString(events, "term") != 1 || countString(events, "wait") != 1 || countString(events, "record_absent") != 1 {
+		t.Fatalf("concurrent containment events = %v", events)
+	}
+}
+
+func TestL8RuntimeOwnerReplacementRequiresExactSameBootAndDoubleProcAbsence(t *testing.T) {
+	seed := l8RuntimeOwnerTestSeed()
+	bootID := "01234567-89ab-cdef-0123-456789abcdef"
+	record := l8RuntimeOwnerTestRecord(t, seed, bootID)
+	record.State, record.Revision = "unclaimed", 2
+	exactChild := l8RuntimeOwnerProcessObservation{
+		PID: record.FirecrackerPID, ParentPID: record.SupervisorPID, StartTime: record.FirecrackerStartTime,
+		state: 'S', pidfd: 11, pidfdOwned: true,
+	}
+	for _, scenario := range []struct {
+		name             string
+		currentBoot      string
+		supervisorExists bool
+		child            l8RuntimeOwnerProcessObservation
+		childExists      bool
+		absences         []bool
+		wantSignal       bool
+		wantAbsent       bool
+	}{
+		{name: "exact child killed then absent", currentBoot: bootID, child: exactChild, childExists: true, absences: []bool{true, true}, wantSignal: true, wantAbsent: true},
+		{name: "already absent twice", currentBoot: bootID, absences: []bool{true, true}, wantAbsent: true},
+		{name: "old boot", currentBoot: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
+		{name: "live supervisor", currentBoot: bootID, supervisorExists: true},
+		{name: "PID reused", currentBoot: bootID, child: func() l8RuntimeOwnerProcessObservation { value := exactChild; value.StartTime++; return value }(), childExists: true},
+		{name: "zombie", currentBoot: bootID, child: func() l8RuntimeOwnerProcessObservation { value := exactChild; value.state = 'Z'; return value }(), childExists: true},
+		{name: "only one absence", currentBoot: bootID, absences: []bool{true, false}},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			var events []string
+			absenceIndex := 0
+			ops := l8RuntimeOwnerReplacementOps{
+				CurrentBootID: func() (string, error) { events = append(events, "boot"); return scenario.currentBoot, nil },
+				InspectSupervisor: func(uint32) (l8RuntimeOwnerProcessObservation, bool, error) {
+					events = append(events, "inspect_supervisor")
+					if scenario.supervisorExists {
+						return l8RuntimeOwnerProcessObservation{PID: record.SupervisorPID, StartTime: record.SupervisorStartTime, state: 'S', pidfd: 10, pidfdOwned: true}, true, nil
+					}
+					return l8RuntimeOwnerProcessObservation{}, false, nil
+				},
+				InspectChild: func(uint32) (l8RuntimeOwnerProcessObservation, bool, error) {
+					events = append(events, "inspect_child")
+					return scenario.child, scenario.childExists, nil
+				},
+				SignalKill: func(l8RuntimeOwnerProcessObservation) error { events = append(events, "pidfd_kill"); return nil },
+				WaitTerminal: func(context.Context, l8RuntimeOwnerProcessObservation) error {
+					events = append(events, "pidfd_terminal")
+					return nil
+				},
+				ProcessAbsent: func(uint32) (bool, error) {
+					events = append(events, "proc_absence")
+					if absenceIndex >= len(scenario.absences) {
+						return false, nil
+					}
+					value := scenario.absences[absenceIndex]
+					absenceIndex++
+					return value, nil
+				},
+				AcquisitionBarrier: func() error { events = append(events, "acquisition_barrier"); return nil },
+				RecordAbsent:       func(l8RuntimeOwnerAbsenceObservation) error { events = append(events, "record_absent"); return nil },
+				RecordUncertain:    func() error { events = append(events, "record_uncertain"); return nil },
+				Now:                func() time.Time { return time.Unix(400, 0) },
+			}
+			observation, err := containL8RuntimeOwnerReplacement(record, ops)
+			if containsString(events, "pidfd_kill") != scenario.wantSignal {
+				t.Fatalf("replacement signal events = %v", events)
+			}
+			if scenario.wantAbsent {
+				if err != nil || observation.Kind != 2 || countString(events, "proc_absence") != 2 || !containsString(events, "acquisition_barrier") {
+					t.Fatalf("replacement absence = %#v, %v, events %v", observation, err, events)
+				}
+			} else if observation != (l8RuntimeOwnerAbsenceObservation{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) || containsString(events, "record_absent") {
+				t.Fatalf("uncertain replacement = %#v, %v, events %v", observation, err, events)
+			}
+			if scenario.currentBoot != bootID && (containsString(events, "inspect_supervisor") || containsString(events, "inspect_child") || containsString(events, "pidfd_kill")) {
+				t.Fatalf("old boot reached process authority: %v", events)
+			}
+		})
+	}
+}
+
+func containsString(values []string, target string) bool { return countString(values, target) != 0 }
+
+func countString(values []string, target string) int {
+	count := 0
+	for _, value := range values {
+		if value == target {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_supervisor_test.go
@@ -77,6 +77,11 @@ func TestL8RuntimeOwnerProtocolExactBodies(t *testing.T) {
 	if got, err := decodeL8RuntimeOwnerResponse(responseBody); err != nil || got != response {
 		t.Fatalf("response = %#v, %v", got, err)
 	}
+	reserved := append([]byte(nil), responseBody...)
+	reserved[2] = 1
+	if _, err := decodeL8RuntimeOwnerResponse(reserved); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+		t.Fatalf("nonzero reserved response = %v", err)
+	}
 	for _, malformed := range [][]byte{
 		ackBody[:len(ackBody)-1], append(append([]byte(nil), ackBody...), 0),
 		responseBody[:len(responseBody)-1], append(append([]byte(nil), responseBody...), 0),
@@ -91,53 +96,233 @@ func TestL8RuntimeOwnerProtocolExactBodies(t *testing.T) {
 	}
 }
 
+func TestL8RuntimeOwnerTypedBodiesAndRoleMatrixAreExact(t *testing.T) {
+	controller := l8RuntimeOwnerControllerRequestV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(1)}
+	finalize := l8RuntimeOwnerFinalizeRequestV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(2), AbsenceRevision: 17, ObservedAtUnixNano: 123}
+	ack := l8RuntimeOwnerFinalizeAckV1{CommitID: l8RuntimeOwnerTestToken(3), FinalizedRevision: 19}
+	commit := l8RuntimeOwnerCommitRequestV1{ControllerSessionGeneration: l8RuntimeOwnerTestToken(4), CommitID: l8RuntimeOwnerTestToken(5), FinalizedRevision: 19}
+	for _, scenario := range []struct {
+		name   string
+		want   int
+		encode func() ([]byte, error)
+		decode func([]byte) error
+	}{
+		{name: "controller", want: 43, encode: func() ([]byte, error) { return encodeL8RuntimeOwnerControllerRequest(controller) }, decode: func(body []byte) error {
+			got, err := decodeL8RuntimeOwnerControllerRequest(body)
+			if got != controller {
+				return errL8RuntimeOwnerProtocol
+			}
+			return err
+		}},
+		{name: "finalize", want: 59, encode: func() ([]byte, error) { return encodeL8RuntimeOwnerFinalizeRequest(finalize) }, decode: func(body []byte) error {
+			got, err := decodeL8RuntimeOwnerFinalizeRequest(body)
+			if got != finalize {
+				return errL8RuntimeOwnerProtocol
+			}
+			return err
+		}},
+		{name: "finalize ack", want: 51, encode: func() ([]byte, error) { return encodeL8RuntimeOwnerFinalizeAck(ack) }, decode: func(body []byte) error {
+			got, err := decodeL8RuntimeOwnerFinalizeAck(body)
+			if got != ack {
+				return errL8RuntimeOwnerProtocol
+			}
+			return err
+		}},
+		{name: "commit", want: 94, encode: func() ([]byte, error) { return encodeL8RuntimeOwnerCommitRequest(commit) }, decode: func(body []byte) error {
+			got, err := decodeL8RuntimeOwnerCommitRequest(body)
+			if got != commit {
+				return errL8RuntimeOwnerProtocol
+			}
+			return err
+		}},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			body, err := scenario.encode()
+			if err != nil || len(body) != scenario.want {
+				t.Fatalf("encoded = %d, %v", len(body), err)
+			}
+			if err := scenario.decode(body); err != nil {
+				t.Fatalf("decode = %v", err)
+			}
+			for _, bad := range [][]byte{body[:len(body)-1], append(append([]byte(nil), body...), 0)} {
+				if err := scenario.decode(bad); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+					t.Fatalf("mutation = %v", err)
+				}
+			}
+		})
+	}
+
+	type roleCase struct {
+		name     string
+		packet   l8RuntimeOwnerPacketV1
+		response bool
+		rights   int
+		ok       bool
+	}
+	controllerBody, _ := encodeL8RuntimeOwnerControllerRequest(controller)
+	finalizeBody, _ := encodeL8RuntimeOwnerFinalizeRequest(finalize)
+	commitBody, _ := encodeL8RuntimeOwnerCommitRequest(commit)
+	responseBody, _ := encodeL8RuntimeOwnerResponse(l8RuntimeOwnerResponseV1{State: 4, AbsenceKind: 1, RecordRevision: 17, ObservedAtUnixNano: 123})
+	for _, scenario := range []roleCase{
+		{name: "reject", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeReject, Status: l8RuntimeOwnerStatusRejected}, response: true, ok: true},
+		{name: "bootstrap", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeBootstrapStart, Body: make([]byte, 32)}, rights: 2, ok: true},
+		{name: "published", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeBootstrapPublished, Body: make([]byte, 8)}, response: true, ok: true},
+		{name: "child armed", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeChildArmed}, ok: true},
+		{name: "child release", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeChildRelease}, response: true, ok: true},
+		{name: "handshake", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Body: make([]byte, 97)}, ok: true},
+		{name: "handshake response", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeHandshake, Status: l8RuntimeOwnerStatusOK, Body: make([]byte, 51)}, response: true, ok: true},
+		{name: "abort", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeAbortStart, Sequence: 1, Body: controllerBody}, ok: true},
+		{name: "inspect", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Sequence: 1, Body: controllerBody}, ok: true},
+		{name: "stop", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeStopReap, Sequence: 1, Body: controllerBody}, ok: true},
+		{name: "acquire", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeAcquireNamespaces, Sequence: 1, Body: controllerBody}, ok: true},
+		{name: "close", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeClose, Sequence: 1, Body: controllerBody}, ok: true},
+		{name: "inspect response", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Status: l8RuntimeOwnerStatusOK, Sequence: 1, Body: responseBody}, response: true, ok: true},
+		{name: "invalid state response", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Status: l8RuntimeOwnerStatusInvalidState, Sequence: 1}, response: true, ok: true},
+		{name: "uncertain response", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Status: l8RuntimeOwnerStatusUncertain, Sequence: 1}, response: true, ok: true},
+		{name: "unsupported response", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Status: l8RuntimeOwnerStatusUnsupported, Sequence: 1}, response: true, ok: true},
+		{name: "acquire response", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeAcquireNamespaces, Status: l8RuntimeOwnerStatusOK, Sequence: 1, Body: responseBody}, response: true, rights: 2, ok: true},
+		{name: "finalize", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeFinalize, Sequence: 1, Body: finalizeBody}, ok: true},
+		{name: "commit", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeCommit, Sequence: 1, Body: commitBody}, ok: true},
+		{name: "wrong rights", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Sequence: 1, Body: controllerBody}, rights: 1},
+		{name: "request status", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Status: 1, Sequence: 1, Body: controllerBody}},
+		{name: "error response body", packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeInspect, Status: l8RuntimeOwnerStatusUncertain, Sequence: 1, Body: []byte{1}}, response: true},
+		{name: "unknown opcode", packet: l8RuntimeOwnerPacketV1{Opcode: 99, Sequence: 1}},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			err := validateL8RuntimeOwnerPacketRole(scenario.packet, scenario.response, scenario.rights)
+			if scenario.ok && err != nil {
+				t.Fatal(err)
+			}
+			if !scenario.ok && !errors.Is(err, errL8RuntimeOwnerProtocol) {
+				t.Fatalf("role = %v", err)
+			}
+		})
+	}
+}
+
+func TestL8RuntimeOwnerLockedTransitionReconcilesEveryCommitOutcome(t *testing.T) {
+	seed := l8RuntimeOwnerTestSeed()
+	prior := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	prior.State, prior.ControllerState, prior.Revision = "running", "unclaimed", 2
+	intended := prior
+	intended.ControllerState, intended.Revision, intended.ReconnectSecret = "controlled", 3, l8RuntimeOwnerTestToken(7)
+	for _, scenario := range []struct {
+		name              string
+		writeErr, syncErr error
+		reread            firecrackerRuntimeOwnerRecordV1
+		present           bool
+		readErr           error
+		want              bool
+	}{
+		{name: "durable", reread: intended, present: true, want: true},
+		{name: "rename uncertain intended", writeErr: errors.New("commit uncertain"), reread: intended, present: true, want: true},
+		{name: "directory uncertain intended", syncErr: errors.New("commit uncertain"), reread: intended, present: true, want: true},
+		{name: "prior retained", writeErr: errors.New("commit uncertain"), reread: prior, present: true},
+		{name: "missing", writeErr: errors.New("commit uncertain")},
+		{name: "read error", writeErr: errors.New("commit uncertain"), readErr: errors.New("private read")},
+		{name: "third", writeErr: errors.New("commit uncertain"), reread: func() firecrackerRuntimeOwnerRecordV1 {
+			v := intended
+			v.ReconnectSecret = l8RuntimeOwnerTestToken(8)
+			return v
+		}(), present: true},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			var events []string
+			reads := 0
+			ops := l8RuntimeOwnerTransactionOps{
+				Lock:   func(context.Context) error { events = append(events, "lock"); return nil },
+				Unlock: func() error { events = append(events, "unlock"); return nil },
+				Read: func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
+					events = append(events, "read")
+					reads++
+					if reads == 1 {
+						return prior, true, nil
+					}
+					return scenario.reread, scenario.present, scenario.readErr
+				},
+				WriteAndRename: func(firecrackerRuntimeOwnerRecordV1) error {
+					events = append(events, "rename")
+					return scenario.writeErr
+				},
+				SyncDirectory: func() error { events = append(events, "fsync"); return scenario.syncErr },
+			}
+			got, err := transitionL8RuntimeOwnerRecordLocked(context.Background(), ops, prior.Revision, intended)
+			if scenario.want {
+				if err != nil || got != intended {
+					t.Fatalf("transition = %#v, %v", got, err)
+				}
+			} else if !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("transition = %#v, %v", got, err)
+			}
+			if len(events) == 0 || events[0] != "lock" || events[len(events)-1] != "unlock" {
+				t.Fatalf("lock events = %v", events)
+			}
+		})
+	}
+}
+
 func TestL8RuntimeOwnerTransitionGraphRejectsResurrection(t *testing.T) {
 	seed := l8RuntimeOwnerTestSeed()
 	base := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
-	record := func(state string, revision uint64) firecrackerRuntimeOwnerRecordV1 {
+	record := func(state, controller string, revision uint64) firecrackerRuntimeOwnerRecordV1 {
 		value := base
-		value.State, value.Revision = state, revision
-		value.FinalizedCommitID = ""
+		value.State, value.ControllerState, value.Revision = state, controller, revision
+		value.FinalizedCommitID, value.FinalizeTargetRevision = "", 0
+		if state != "absent" && state != "finalizing" && state != "finalized" && state != "uncertain" {
+			value.AbsenceKind, value.AbsenceRevision, value.AbsenceObservedAtUnixNano = "", 0, 0
+		}
+		if state == "absent" || state == "uncertain" {
+			value.AbsenceRevision = revision
+		}
+		if state == "finalizing" {
+			value.AbsenceRevision = revision - 1
+			value.FinalizedCommitID, value.FinalizeTargetRevision = l8RuntimeOwnerTestToken(9), revision+1
+		}
 		if state == "finalized" {
-			value.FinalizedCommitID = l8RuntimeOwnerTestToken(9)
+			value.AbsenceRevision = revision - 2
+			value.FinalizedCommitID, value.FinalizeTargetRevision = l8RuntimeOwnerTestToken(9), revision
 		}
 		if state == "starting" && revision == 0 {
 			value.FirecrackerPID, value.FirecrackerStartTime = 0, 0
 		}
 		return value
 	}
-	genesis := record("starting", 0)
-	revisionOne := record("starting", 1)
+	genesis := record("starting", "none", 0)
+	revisionOne := record("starting", "none", 1)
 	if !validL8RuntimeOwnerTransition(genesis, revisionOne) {
 		t.Fatal("revision-zero starting did not advance to revision-one starting")
 	}
-	for _, state := range []string{"unclaimed", "stopping", "absent", "uncertain"} {
-		if !validL8RuntimeOwnerTransition(revisionOne, record(state, 2)) {
-			t.Errorf("revision-one starting -> %s rejected", state)
-		}
+	if !validL8RuntimeOwnerTransition(revisionOne, record("running", "unclaimed", 2)) ||
+		!validL8RuntimeOwnerTransition(revisionOne, record("stopping", "none", 2)) ||
+		validL8RuntimeOwnerTransition(revisionOne, record("absent", "none", 2)) {
+		t.Fatal("revision-one publication/abort ordering is not exact")
 	}
-	allowed := [][2]string{
-		{"unclaimed", "controlled"}, {"unclaimed", "stopping"}, {"unclaimed", "absent"}, {"unclaimed", "uncertain"},
-		{"controlled", "unclaimed"}, {"controlled", "stopping"}, {"controlled", "absent"}, {"controlled", "uncertain"},
-		{"stopping", "absent"}, {"stopping", "uncertain"}, {"absent", "finalized"},
+	allowed := [][4]string{
+		{"running", "unclaimed", "running", "controlled"}, {"running", "controlled", "running", "unclaimed"},
+		{"stopping", "unclaimed", "stopping", "controlled"}, {"absent", "unclaimed", "absent", "controlled"},
+		{"uncertain", "unclaimed", "uncertain", "controlled"}, {"finalizing", "unclaimed", "finalizing", "controlled"},
+		{"finalized", "unclaimed", "finalized", "controlled"}, {"running", "controlled", "stopping", "controlled"},
+		{"running", "controlled", "uncertain", "controlled"}, {"stopping", "controlled", "absent", "controlled"},
+		{"stopping", "controlled", "uncertain", "controlled"}, {"uncertain", "controlled", "absent", "controlled"},
+		{"absent", "controlled", "absent", "controlled"}, {"absent", "controlled", "finalizing", "controlled"},
+		{"finalizing", "controlled", "finalized", "controlled"},
 	}
 	for _, transition := range allowed {
-		fromRevision := uint64(2)
-		if !validL8RuntimeOwnerTransition(record(transition[0], fromRevision), record(transition[1], fromRevision+1)) {
-			t.Errorf("allowed transition %s -> %s rejected", transition[0], transition[1])
+		if !validL8RuntimeOwnerTransition(record(transition[0], transition[1], 4), record(transition[2], transition[3], 5)) {
+			t.Errorf("allowed transition %s/%s -> %s/%s rejected", transition[0], transition[1], transition[2], transition[3])
 		}
 	}
 	for _, transition := range [][2]string{
-		{"absent", "controlled"}, {"absent", "unclaimed"}, {"finalized", "absent"}, {"uncertain", "stopping"},
-		{"stopping", "controlled"}, {"controlled", "starting"},
+		{"absent", "running"}, {"finalized", "absent"}, {"uncertain", "stopping"},
+		{"stopping", "running"}, {"running", "starting"}, {"absent", "finalized"},
 	} {
-		if validL8RuntimeOwnerTransition(record(transition[0], 4), record(transition[1], 5)) {
+		if validL8RuntimeOwnerTransition(record(transition[0], "controlled", 4), record(transition[1], "controlled", 5)) {
 			t.Errorf("resurrection %s -> %s accepted", transition[0], transition[1])
 		}
 	}
-	if validL8RuntimeOwnerTransition(record("starting", 1), record("starting", 2)) ||
-		validL8RuntimeOwnerTransition(record("starting", 0), record("unclaimed", 1)) ||
-		validL8RuntimeOwnerTransition(record("unclaimed", 2), record("controlled", 4)) {
+	if validL8RuntimeOwnerTransition(record("starting", "none", 1), record("starting", "none", 2)) ||
+		validL8RuntimeOwnerTransition(record("starting", "none", 0), record("running", "unclaimed", 1)) ||
+		validL8RuntimeOwnerTransition(record("running", "unclaimed", 2), record("running", "controlled", 4)) {
 		t.Fatal("noncanonical starting or revision jump accepted")
 	}
 }
@@ -145,9 +330,9 @@ func TestL8RuntimeOwnerTransitionGraphRejectsResurrection(t *testing.T) {
 func TestL8RuntimeOwnerCommitUncertainAcceptsOnlyPriorOrIntended(t *testing.T) {
 	seed := l8RuntimeOwnerTestSeed()
 	prior := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
-	prior.State, prior.Revision = "unclaimed", 2
+	prior.State, prior.ControllerState, prior.Revision = "running", "unclaimed", 2
 	intended := prior
-	intended.State, intended.Revision, intended.ReconnectSecret = "controlled", 3, l8RuntimeOwnerTestToken(4)
+	intended.ControllerState, intended.Revision, intended.ReconnectSecret = "controlled", 3, l8RuntimeOwnerTestToken(4)
 	if got, committed, err := reconcileL8RuntimeOwnerCommitUncertain(prior, intended, prior); err != nil || committed || got != prior {
 		t.Fatalf("prior reconciliation = %#v, %t, %v", got, committed, err)
 	}
@@ -185,7 +370,7 @@ func TestL8RuntimeOwnerContainmentUsesOneIndependentBudgetAndNeverSkipsWait(t *t
 			var waitDeadlines []time.Time
 			started := time.Now()
 			ops := l8RuntimeOwnerContainmentOps{
-				RecordStopping: func() error { events = append(events, "record_stopping"); return nil },
+				RecordStopping: func() (uint64, error) { events = append(events, "record_stopping"); return 3, nil },
 				Terminate: func() error {
 					events = append(events, "term")
 					if scenario.terminatePanic {
@@ -219,16 +404,16 @@ func TestL8RuntimeOwnerContainmentUsesOneIndependentBudgetAndNeverSkipsWait(t *t
 					}
 					return nil
 				},
-				RecordAbsent: func(observation l8RuntimeOwnerAbsenceObservation) error {
+				RecordAbsent: func(observation l8RuntimeOwnerAbsenceObservation) (uint64, error) {
 					events = append(events, "record_absent")
-					return nil
+					return 4, nil
 				},
-				RecordUncertain: func() error { events = append(events, "record_uncertain"); return nil },
+				RecordUncertain: func() (uint64, error) { events = append(events, "record_uncertain"); return 4, nil },
 				Now:             func() time.Time { return time.Unix(100, 0) },
 			}
 			observation, err := containL8RuntimeOwnerChild(ops)
 			if scenario.wantAbsent {
-				if err != nil || observation.Kind != 1 || !observation.ObservedAt.Equal(time.Unix(100, 0)) || events[len(events)-1] != "record_absent" {
+				if err != nil || observation.Kind != 1 || observation.Revision != 4 || !observation.ObservedAt.Equal(time.Unix(100, 0)) || events[len(events)-1] != "record_absent" {
 					t.Fatalf("containment = %#v, %v, events %v", observation, err, events)
 				}
 			} else if !errors.Is(err, errL8RuntimeOwnerInvalid) || observation != (l8RuntimeOwnerAbsenceObservation{}) || len(events) == 0 || events[len(events)-1] != "record_uncertain" {
@@ -239,7 +424,7 @@ func TestL8RuntimeOwnerContainmentUsesOneIndependentBudgetAndNeverSkipsWait(t *t
 			}
 			if len(waitDeadlines) != 0 {
 				first := waitDeadlines[0].Sub(started)
-				if first < 4*time.Second || first > 6*time.Second {
+				if first < 4*time.Second || first > 5*time.Second+100*time.Millisecond {
 					t.Fatalf("first wait budget = %v", first)
 				}
 			}
@@ -268,30 +453,30 @@ func TestL8RuntimeOwnerContainmentStoreFailuresNeverPublishAbsence(t *testing.T)
 		t.Run(scenario.name, func(t *testing.T) {
 			var events []string
 			ops := l8RuntimeOwnerContainmentOps{
-				RecordStopping: func() error {
+				RecordStopping: func() (uint64, error) {
 					events = append(events, "record_stopping")
 					if scenario.stoppingFailure == "panic" {
 						panic("private stopping panic")
 					}
 					if scenario.stoppingFailure == "error" {
-						return errors.New("private stopping error")
+						return 0, errors.New("private stopping error")
 					}
-					return nil
+					return 3, nil
 				},
 				Terminate: func() error { events = append(events, "term"); return nil },
 				Wait:      func(context.Context) (bool, error) { events = append(events, "wait"); return true, nil },
 				Kill:      func() error { events = append(events, "kill"); return nil },
-				RecordAbsent: func(l8RuntimeOwnerAbsenceObservation) error {
+				RecordAbsent: func(l8RuntimeOwnerAbsenceObservation) (uint64, error) {
 					events = append(events, "record_absent")
 					if scenario.absentFailure == "panic" {
 						panic("private absent panic")
 					}
 					if scenario.absentFailure == "error" {
-						return errors.New("private absent error")
+						return 0, errors.New("private absent error")
 					}
-					return nil
+					return 4, nil
 				},
-				RecordUncertain: func() error { events = append(events, "record_uncertain"); return nil },
+				RecordUncertain: func() (uint64, error) { events = append(events, "record_uncertain"); return 4, nil },
 				Now:             func() time.Time { return time.Unix(200, 0) },
 			}
 			observation, err := containL8RuntimeOwnerChild(ops)
@@ -308,6 +493,64 @@ func TestL8RuntimeOwnerContainmentStoreFailuresNeverPublishAbsence(t *testing.T)
 	}
 }
 
+func TestL8RuntimeOwnerContainmentRejectsNilPanicWaitAndRetriesUncertain(t *testing.T) {
+	base := l8RuntimeOwnerContainmentOps{
+		RecordStopping:  func() (uint64, error) { return 3, nil },
+		Terminate:       func() error { return nil },
+		Wait:            func(context.Context) (bool, error) { return true, nil },
+		Kill:            func() error { return nil },
+		RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) (uint64, error) { return 4, nil },
+		RecordUncertain: func() (uint64, error) { return 4, nil },
+		Now:             func() time.Time { return time.Unix(1, 0) },
+	}
+	for _, scenario := range []struct {
+		name   string
+		mutate func(*l8RuntimeOwnerContainmentOps)
+	}{
+		{name: "nil stopping", mutate: func(value *l8RuntimeOwnerContainmentOps) { value.RecordStopping = nil }},
+		{name: "nil wait", mutate: func(value *l8RuntimeOwnerContainmentOps) { value.Wait = nil }},
+		{name: "wait error", mutate: func(value *l8RuntimeOwnerContainmentOps) {
+			value.Wait = func(context.Context) (bool, error) { return false, errors.New("private wait path") }
+		}},
+		{name: "wait panic", mutate: func(value *l8RuntimeOwnerContainmentOps) {
+			value.Wait = func(context.Context) (bool, error) { panic("private wait panic") }
+		}},
+		{name: "uncertain panic", mutate: func(value *l8RuntimeOwnerContainmentOps) {
+			value.Wait = func(context.Context) (bool, error) { return false, nil }
+			value.RecordUncertain = func() (uint64, error) { panic("private uncertain panic") }
+		}},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			value := base
+			scenario.mutate(&value)
+			observation, err := containL8RuntimeOwnerChild(value)
+			if observation != (l8RuntimeOwnerAbsenceObservation{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) || err.Error() != errL8RuntimeOwnerInvalid.Error() {
+				t.Fatalf("containment = %#v, %v", observation, err)
+			}
+		})
+	}
+
+	controller := &l8RuntimeOwnerContainmentController{}
+	attempts := 0
+	ops := base
+	ops.RecordStopping = func() (uint64, error) {
+		attempts++
+		if attempts == 1 {
+			return 0, errors.New("private transient")
+		}
+		return 3, nil
+	}
+	if _, err := controller.Stop(ops); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("first attempt = %v", err)
+	}
+	if observation, err := controller.Stop(ops); err != nil || observation.Revision != 4 || attempts != 2 {
+		t.Fatalf("retry = %#v, %v attempts %d", observation, err, attempts)
+	}
+	if _, err := controller.Stop(ops); err != nil || attempts != 2 {
+		t.Fatalf("cached success = %v attempts %d", err, attempts)
+	}
+}
+
 func TestL8RuntimeOwnerContainmentSerializesConcurrentStop(t *testing.T) {
 	controller := &l8RuntimeOwnerContainmentController{}
 	entered := make(chan struct{})
@@ -321,12 +564,12 @@ func TestL8RuntimeOwnerContainmentSerializesConcurrentStop(t *testing.T) {
 		eventMu <- struct{}{}
 	}
 	ops := l8RuntimeOwnerContainmentOps{
-		RecordStopping:  func() error { add("record_stopping"); close(entered); <-release; return nil },
+		RecordStopping:  func() (uint64, error) { add("record_stopping"); close(entered); <-release; return 3, nil },
 		Terminate:       func() error { add("term"); return nil },
 		Wait:            func(context.Context) (bool, error) { add("wait"); return true, nil },
 		Kill:            func() error { add("kill"); return nil },
-		RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) error { add("record_absent"); return nil },
-		RecordUncertain: func() error { add("record_uncertain"); return nil },
+		RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) (uint64, error) { add("record_absent"); return 4, nil },
+		RecordUncertain: func() (uint64, error) { add("record_uncertain"); return 4, nil },
 		Now:             func() time.Time { return time.Unix(300, 0) },
 	}
 	results := make(chan l8RuntimeOwnerAbsenceObservation, 2)
@@ -355,9 +598,10 @@ func TestL8RuntimeOwnerReplacementRequiresExactSameBootAndDoubleProcAbsence(t *t
 	seed := l8RuntimeOwnerTestSeed()
 	bootID := "01234567-89ab-cdef-0123-456789abcdef"
 	record := l8RuntimeOwnerTestRecord(t, seed, bootID)
-	record.State, record.Revision = "unclaimed", 2
+	record.State, record.ControllerState, record.Revision = "running", "unclaimed", 2
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "", 0, 0
 	exactChild := l8RuntimeOwnerProcessObservation{
-		PID: record.FirecrackerPID, ParentPID: record.SupervisorPID, StartTime: record.FirecrackerStartTime,
+		PID: record.FirecrackerPID, ParentPID: 1, StartTime: record.FirecrackerStartTime,
 		state: 'S', pidfd: 11, pidfdOwned: true,
 	}
 	for _, scenario := range []struct {
@@ -375,6 +619,7 @@ func TestL8RuntimeOwnerReplacementRequiresExactSameBootAndDoubleProcAbsence(t *t
 		{name: "old boot", currentBoot: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"},
 		{name: "live supervisor", currentBoot: bootID, supervisorExists: true},
 		{name: "PID reused", currentBoot: bootID, child: func() l8RuntimeOwnerProcessObservation { value := exactChild; value.StartTime++; return value }(), childExists: true},
+		{name: "unexpected reparent", currentBoot: bootID, child: func() l8RuntimeOwnerProcessObservation { value := exactChild; value.ParentPID = 2; return value }(), childExists: true},
 		{name: "zombie", currentBoot: bootID, child: func() l8RuntimeOwnerProcessObservation { value := exactChild; value.state = 'Z'; return value }(), childExists: true},
 		{name: "only one absence", currentBoot: bootID, absences: []bool{true, false}},
 	} {
@@ -409,9 +654,12 @@ func TestL8RuntimeOwnerReplacementRequiresExactSameBootAndDoubleProcAbsence(t *t
 					return value, nil
 				},
 				AcquisitionBarrier: func() error { events = append(events, "acquisition_barrier"); return nil },
-				RecordAbsent:       func(l8RuntimeOwnerAbsenceObservation) error { events = append(events, "record_absent"); return nil },
-				RecordUncertain:    func() error { events = append(events, "record_uncertain"); return nil },
-				Now:                func() time.Time { return time.Unix(400, 0) },
+				RecordAbsent: func(l8RuntimeOwnerAbsenceObservation) (uint64, error) {
+					events = append(events, "record_absent")
+					return 5, nil
+				},
+				RecordUncertain: func() (uint64, error) { events = append(events, "record_uncertain"); return 5, nil },
+				Now:             func() time.Time { return time.Unix(400, 0) },
 			}
 			observation, err := containL8RuntimeOwnerReplacement(record, ops)
 			if containsString(events, "pidfd_kill") != scenario.wantSignal {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux.go
@@ -74,10 +74,11 @@ func receiveL8RuntimeOwnerSeqpacket(fd int) (l8RuntimeOwnerReceivedPacketV1, err
 	buf := make([]byte, l8RuntimeOwnerPacketLimit)
 	oob := make([]byte, unix.CmsgSpace(4*4))
 	n, oobn, flags, _, err := unix.Recvmsg(fd, buf, oob, unix.MSG_CMSG_CLOEXEC)
+	files, fileErr := l8RuntimeOwnerFilesFromControl(oob[:oobn])
 	if err != nil || flags&unix.MSG_TRUNC != 0 || flags&unix.MSG_CTRUNC != 0 || n < l8RuntimeOwnerPacketHeaderSize {
+		closeL8RuntimeOwnerFiles(files)
 		return l8RuntimeOwnerReceivedPacketV1{}, errL8RuntimeOwnerProtocol
 	}
-	files, fileErr := l8RuntimeOwnerFilesFromControl(oob[:oobn])
 	packet, packetErr := decodeL8RuntimeOwnerPacket(buf[:n])
 	if fileErr != nil || packetErr != nil {
 		closeL8RuntimeOwnerFiles(files)
@@ -91,34 +92,45 @@ func l8RuntimeOwnerFilesFromControl(oob []byte) ([]*os.File, error) {
 		return nil, nil
 	}
 	messages, err := unix.ParseSocketControlMessage(oob)
-	if err != nil || len(messages) != 1 {
-		return nil, errL8RuntimeOwnerProtocol
-	}
-	if messages[0].Header.Type != unix.SCM_RIGHTS {
-		return nil, errL8RuntimeOwnerProtocol
-	}
-	rights, err := unix.ParseUnixRights(&messages[0])
 	if err != nil {
 		return nil, errL8RuntimeOwnerProtocol
 	}
-	files := make([]*os.File, 0, len(rights))
+	allRights := make([]int, 0, 4)
+	valid := len(messages) == 1
+	for index := range messages {
+		if messages[index].Header.Level != unix.SOL_SOCKET || messages[index].Header.Type != unix.SCM_RIGHTS {
+			valid = false
+			continue
+		}
+		rights, parseErr := unix.ParseUnixRights(&messages[index])
+		if parseErr != nil {
+			valid = false
+			continue
+		}
+		allRights = append(allRights, rights...)
+	}
+	if !valid {
+		for _, fd := range allRights {
+			_ = unix.Close(fd)
+		}
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	files := make([]*os.File, 0, len(allRights))
 	failed := true
 	defer func() {
 		if failed {
 			closeL8RuntimeOwnerFiles(files)
-			for _, fd := range rights[len(files):] {
+			for _, fd := range allRights[len(files):] {
 				_ = unix.Close(fd)
 			}
 		}
 	}()
-	for _, fd := range rights {
+	for _, fd := range allRights {
 		if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
-			_ = unix.Close(fd)
 			return nil, errL8RuntimeOwnerProtocol
 		}
 		file := os.NewFile(uintptr(fd), "runtime-owner-fd")
 		if file == nil {
-			_ = unix.Close(fd)
 			return nil, errL8RuntimeOwnerProtocol
 		}
 		files = append(files, file)

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux.go
@@ -4,7 +4,15 @@ package firecrackerhost
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
 	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 type l8RuntimeOwnerNamespaceCorrelationV1 struct {
@@ -19,42 +27,245 @@ type l8RuntimeOwnerReceivedPacketV1 struct {
 	Files  []*os.File
 }
 
-func encodeL8RuntimeOwnerNamespaceCorrelation(l8RuntimeOwnerNamespaceCorrelationV1) []byte {
+func encodeL8RuntimeOwnerNamespaceCorrelation(value l8RuntimeOwnerNamespaceCorrelationV1) []byte {
+	body := make([]byte, 32)
+	binary.BigEndian.PutUint64(body[0:8], value.UserDevice)
+	binary.BigEndian.PutUint64(body[8:16], value.UserInode)
+	binary.BigEndian.PutUint64(body[16:24], value.NetworkDevice)
+	binary.BigEndian.PutUint64(body[24:32], value.NetworkInode)
+	return body
+}
+
+func decodeL8RuntimeOwnerNamespaceCorrelation(body []byte) (l8RuntimeOwnerNamespaceCorrelationV1, error) {
+	if len(body) != 32 {
+		return l8RuntimeOwnerNamespaceCorrelationV1{}, errL8RuntimeOwnerProtocol
+	}
+	return l8RuntimeOwnerNamespaceCorrelationV1{
+		UserDevice:    binary.BigEndian.Uint64(body[0:8]),
+		UserInode:     binary.BigEndian.Uint64(body[8:16]),
+		NetworkDevice: binary.BigEndian.Uint64(body[16:24]),
+		NetworkInode:  binary.BigEndian.Uint64(body[24:32]),
+	}, nil
+}
+
+func sendL8RuntimeOwnerSeqpacket(fd int, packet l8RuntimeOwnerPacketV1, files []*os.File) error {
+	wire, err := encodeL8RuntimeOwnerPacket(packet)
+	if err != nil {
+		return errL8RuntimeOwnerProtocol
+	}
+	var oob []byte
+	if len(files) != 0 {
+		rights := make([]int, len(files))
+		for index, file := range files {
+			if file == nil {
+				return errL8RuntimeOwnerProtocol
+			}
+			rights[index] = int(file.Fd())
+		}
+		oob = unix.UnixRights(rights...)
+	}
+	if err := unix.Sendmsg(fd, wire, oob, nil, 0); err != nil {
+		return errL8RuntimeOwnerProtocol
+	}
 	return nil
 }
 
-func decodeL8RuntimeOwnerNamespaceCorrelation([]byte) (l8RuntimeOwnerNamespaceCorrelationV1, error) {
-	return l8RuntimeOwnerNamespaceCorrelationV1{}, errL8RuntimeOwnerProtocol
+func receiveL8RuntimeOwnerSeqpacket(fd int) (l8RuntimeOwnerReceivedPacketV1, error) {
+	buf := make([]byte, l8RuntimeOwnerPacketLimit)
+	oob := make([]byte, unix.CmsgSpace(4*4))
+	n, oobn, flags, _, err := unix.Recvmsg(fd, buf, oob, unix.MSG_CMSG_CLOEXEC)
+	if err != nil || flags&unix.MSG_TRUNC != 0 || flags&unix.MSG_CTRUNC != 0 || n < l8RuntimeOwnerPacketHeaderSize {
+		return l8RuntimeOwnerReceivedPacketV1{}, errL8RuntimeOwnerProtocol
+	}
+	files, fileErr := l8RuntimeOwnerFilesFromControl(oob[:oobn])
+	packet, packetErr := decodeL8RuntimeOwnerPacket(buf[:n])
+	if fileErr != nil || packetErr != nil {
+		closeL8RuntimeOwnerFiles(files)
+		return l8RuntimeOwnerReceivedPacketV1{}, errL8RuntimeOwnerProtocol
+	}
+	return l8RuntimeOwnerReceivedPacketV1{Packet: packet, Files: files}, nil
 }
 
-func sendL8RuntimeOwnerSeqpacket(int, l8RuntimeOwnerPacketV1, []*os.File) error {
-	return errL8RuntimeOwnerProtocol
+func l8RuntimeOwnerFilesFromControl(oob []byte) ([]*os.File, error) {
+	if len(oob) == 0 {
+		return nil, nil
+	}
+	messages, err := unix.ParseSocketControlMessage(oob)
+	if err != nil || len(messages) != 1 {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	if messages[0].Header.Type != unix.SCM_RIGHTS {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	rights, err := unix.ParseUnixRights(&messages[0])
+	if err != nil {
+		return nil, errL8RuntimeOwnerProtocol
+	}
+	files := make([]*os.File, 0, len(rights))
+	failed := true
+	defer func() {
+		if failed {
+			closeL8RuntimeOwnerFiles(files)
+			for _, fd := range rights[len(files):] {
+				_ = unix.Close(fd)
+			}
+		}
+	}()
+	for _, fd := range rights {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+			_ = unix.Close(fd)
+			return nil, errL8RuntimeOwnerProtocol
+		}
+		file := os.NewFile(uintptr(fd), "runtime-owner-fd")
+		if file == nil {
+			_ = unix.Close(fd)
+			return nil, errL8RuntimeOwnerProtocol
+		}
+		files = append(files, file)
+	}
+	failed = false
+	return files, nil
 }
 
-func receiveL8RuntimeOwnerSeqpacket(int) (l8RuntimeOwnerReceivedPacketV1, error) {
-	return l8RuntimeOwnerReceivedPacketV1{}, errL8RuntimeOwnerProtocol
+func closeL8RuntimeOwnerFiles(files []*os.File) {
+	for _, file := range files {
+		if file != nil {
+			_ = file.Close()
+		}
+	}
 }
 
-func validateL8RuntimeOwnerNamespaceFiles([]*os.File, l8RuntimeOwnerNamespaceCorrelationV1) error {
-	return errL8RuntimeOwnerInvalid
+func validateL8RuntimeOwnerNamespaceFiles(files []*os.File, correlation l8RuntimeOwnerNamespaceCorrelationV1) error {
+	if len(files) != 2 || files[0] == nil || files[1] == nil || files[0] == files[1] {
+		return errL8RuntimeOwnerInvalid
+	}
+	user, err := l8RuntimeOwnerStatNamespace(files[0])
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	network, err := l8RuntimeOwnerStatNamespace(files[1])
+	if err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if user.device != correlation.UserDevice || user.inode != correlation.UserInode ||
+		network.device != correlation.NetworkDevice || network.inode != correlation.NetworkInode ||
+		(user.device == network.device && user.inode == network.inode) {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
 }
 
-func l8RuntimeOwnerPeerUID(int) (uint32, error) {
-	return 0, errL8RuntimeOwnerInvalid
+type l8RuntimeOwnerNSIdentity struct {
+	device uint64
+	inode  uint64
 }
 
-func parseL8RuntimeOwnerProcIdentity([]byte, uint32) (uint32, uint64, byte, error) {
-	return 0, 0, 0, errL8RuntimeOwnerInvalid
+func l8RuntimeOwnerStatNamespace(file *os.File) (l8RuntimeOwnerNSIdentity, error) {
+	var stat unix.Stat_t
+	var statfs unix.Statfs_t
+	if unix.Fstat(int(file.Fd()), &stat) != nil || unix.Fstatfs(int(file.Fd()), &statfs) != nil || statfs.Type != unix.NSFS_MAGIC {
+		return l8RuntimeOwnerNSIdentity{}, errL8RuntimeOwnerInvalid
+	}
+	if _, err := unix.FcntlInt(file.Fd(), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+		return l8RuntimeOwnerNSIdentity{}, errL8RuntimeOwnerInvalid
+	}
+	return l8RuntimeOwnerNSIdentity{device: uint64(stat.Dev), inode: stat.Ino}, nil
 }
 
-func signalL8RuntimeOwnerProcess(l8RuntimeOwnerProcessObservation, os.Signal) error {
-	return errL8RuntimeOwnerInvalid
+func l8RuntimeOwnerPeerUID(fd int) (uint32, error) {
+	credentials, err := unix.GetsockoptUcred(fd, unix.SOL_SOCKET, unix.SO_PEERCRED)
+	if err != nil || credentials == nil {
+		return 0, errL8RuntimeOwnerInvalid
+	}
+	return credentials.Uid, nil
 }
 
-func waitL8RuntimeOwnerProcessTerminal(context.Context, l8RuntimeOwnerProcessObservation) error {
-	return errL8RuntimeOwnerInvalid
+func parseL8RuntimeOwnerProcIdentity(payload []byte, expectedPID uint32) (uint32, uint64, byte, error) {
+	value := strings.TrimSuffix(string(payload), "\n")
+	open := strings.IndexByte(value, '(')
+	close := strings.LastIndexByte(value, ')')
+	if open <= 0 || close <= open || strings.TrimSpace(value[close+1:]) == "" {
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
+	}
+	parsedPID, err := strconv.ParseUint(strings.TrimSpace(value[:open]), 10, 32)
+	fields := strings.Fields(value[close+1:])
+	if err != nil || uint32(parsedPID) != expectedPID || len(fields) < 20 || len(fields[0]) != 1 {
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
+	}
+	parent, err := strconv.ParseUint(fields[1], 10, 32)
+	if err != nil {
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
+	}
+	startTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil || startTime == 0 {
+		return 0, 0, 0, errL8RuntimeOwnerInvalid
+	}
+	return uint32(parent), startTime, fields[0][0], nil
 }
 
-func inspectL8RuntimeOwnerProcessAbsent(uint32) (bool, error) {
-	return false, errL8RuntimeOwnerInvalid
+func signalL8RuntimeOwnerProcess(observation l8RuntimeOwnerProcessObservation, signal os.Signal) error {
+	if !observation.pidfdOwned || observation.pidfd < 0 {
+		return errL8RuntimeOwnerInvalid
+	}
+	sysSignal, ok := signal.(syscall.Signal)
+	if !ok {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := unix.PidfdSendSignal(observation.pidfd, sysSignal, nil, 0); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func waitL8RuntimeOwnerProcessTerminal(ctx context.Context, observation l8RuntimeOwnerProcessObservation) error {
+	if ctx == nil || !observation.pidfdOwned || observation.pidfd < 0 {
+		return errL8RuntimeOwnerInvalid
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return errL8RuntimeOwnerInvalid
+		}
+		timeout := 100
+		if deadline, ok := ctx.Deadline(); ok {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return errL8RuntimeOwnerInvalid
+			}
+			timeout = int(remaining / time.Millisecond)
+			if timeout <= 0 {
+				timeout = 1
+			}
+		}
+		poll := []unix.PollFd{{Fd: int32(observation.pidfd), Events: unix.POLLIN}}
+		ready, err := unix.Poll(poll, timeout)
+		if err != nil {
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+			return errL8RuntimeOwnerInvalid
+		}
+		if ready > 0 && poll[0].Revents&(unix.POLLIN|unix.POLLHUP) != 0 {
+			return nil
+		}
+	}
+}
+
+func inspectL8RuntimeOwnerProcessAbsent(pid uint32) (bool, error) {
+	if pid == 0 || uint64(pid) > uint64(^uint(0)>>1) {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	procfd, err := unix.Open("/proc", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	defer unix.Close(procfd)
+	processfd, err := unix.Openat(procfd, strconv.FormatUint(uint64(pid), 10), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if errors.Is(err, unix.ENOENT) {
+		return true, nil
+	}
+	if err != nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	_ = unix.Close(processfd)
+	return false, nil
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"os"
+)
+
+type l8RuntimeOwnerNamespaceCorrelationV1 struct {
+	UserDevice    uint64
+	UserInode     uint64
+	NetworkDevice uint64
+	NetworkInode  uint64
+}
+
+type l8RuntimeOwnerReceivedPacketV1 struct {
+	Packet l8RuntimeOwnerPacketV1
+	Files  []*os.File
+}
+
+func encodeL8RuntimeOwnerNamespaceCorrelation(l8RuntimeOwnerNamespaceCorrelationV1) []byte {
+	return nil
+}
+
+func decodeL8RuntimeOwnerNamespaceCorrelation([]byte) (l8RuntimeOwnerNamespaceCorrelationV1, error) {
+	return l8RuntimeOwnerNamespaceCorrelationV1{}, errL8RuntimeOwnerProtocol
+}
+
+func sendL8RuntimeOwnerSeqpacket(int, l8RuntimeOwnerPacketV1, []*os.File) error {
+	return errL8RuntimeOwnerProtocol
+}
+
+func receiveL8RuntimeOwnerSeqpacket(int) (l8RuntimeOwnerReceivedPacketV1, error) {
+	return l8RuntimeOwnerReceivedPacketV1{}, errL8RuntimeOwnerProtocol
+}
+
+func validateL8RuntimeOwnerNamespaceFiles([]*os.File, l8RuntimeOwnerNamespaceCorrelationV1) error {
+	return errL8RuntimeOwnerInvalid
+}
+
+func l8RuntimeOwnerPeerUID(int) (uint32, error) {
+	return 0, errL8RuntimeOwnerInvalid
+}
+
+func parseL8RuntimeOwnerProcIdentity([]byte, uint32) (uint32, uint64, byte, error) {
+	return 0, 0, 0, errL8RuntimeOwnerInvalid
+}
+
+func signalL8RuntimeOwnerProcess(l8RuntimeOwnerProcessObservation, os.Signal) error {
+	return errL8RuntimeOwnerInvalid
+}
+
+func waitL8RuntimeOwnerProcessTerminal(context.Context, l8RuntimeOwnerProcessObservation) error {
+	return errL8RuntimeOwnerInvalid
+}
+
+func inspectL8RuntimeOwnerProcessAbsent(uint32) (bool, error) {
+	return false, errL8RuntimeOwnerInvalid
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux_test.go
@@ -1,0 +1,126 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestL8RuntimeOwnerSeqpacketTransfersExactlyCorrelatedNamespaces(t *testing.T) {
+	sockets, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(sockets[0])
+	defer unix.Close(sockets[1])
+	user, err := os.Open("/proc/self/ns/user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer user.Close()
+	network, err := os.Open("/proc/self/ns/net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer network.Close()
+	correlation := l8RuntimeOwnerTestNamespaceCorrelation(t, user, network)
+	body := encodeL8RuntimeOwnerNamespaceCorrelation(correlation)
+	if len(body) != 32 {
+		t.Fatalf("namespace correlation body = %d bytes", len(body))
+	}
+	packet := l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeBootstrapStart, Body: body}
+	if err := sendL8RuntimeOwnerSeqpacket(sockets[0], packet, []*os.File{user, network}); err != nil {
+		t.Fatal(err)
+	}
+	received, err := receiveL8RuntimeOwnerSeqpacket(sockets[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeL8RuntimeOwnerTestFiles(received.Files)
+	if received.Packet.Opcode != packet.Opcode || len(received.Files) != 2 {
+		t.Fatalf("received = %#v, files %d", received.Packet, len(received.Files))
+	}
+	decoded, err := decodeL8RuntimeOwnerNamespaceCorrelation(received.Packet.Body)
+	if err != nil || decoded != correlation {
+		t.Fatalf("correlation = %#v, %v", decoded, err)
+	}
+	if err := validateL8RuntimeOwnerNamespaceFiles(received.Files, decoded); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range received.Files {
+		flags, err := unix.FcntlInt(file.Fd(), unix.F_GETFD, 0)
+		if err != nil || flags&unix.FD_CLOEXEC == 0 {
+			t.Fatalf("received namespace CLOEXEC = %#x, %v", flags, err)
+		}
+	}
+	uid, err := l8RuntimeOwnerPeerUID(sockets[1])
+	if err != nil || uid != uint32(os.Geteuid()) {
+		t.Fatalf("peer UID = %d, %v", uid, err)
+	}
+}
+
+func TestL8RuntimeOwnerNamespaceTransferRejectsCountOrderKindAndCorrelation(t *testing.T) {
+	user, err := os.Open("/proc/self/ns/user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer user.Close()
+	network, err := os.Open("/proc/self/ns/net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer network.Close()
+	regular, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer regular.Close()
+	correlation := l8RuntimeOwnerTestNamespaceCorrelation(t, user, network)
+	for name, files := range map[string][]*os.File{
+		"missing":       {user},
+		"extra":         {user, network, regular},
+		"reordered":     {network, user},
+		"non namespace": {user, regular},
+		"duplicate":     {user, user},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateL8RuntimeOwnerNamespaceFiles(files, correlation); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+				t.Fatalf("validation = %v", err)
+			}
+		})
+	}
+	mutated := correlation
+	mutated.NetworkInode++
+	if err := validateL8RuntimeOwnerNamespaceFiles([]*os.File{user, network}, mutated); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("mismatched correlation = %v", err)
+	}
+	for _, body := range [][]byte{nil, make([]byte, 31), make([]byte, 33)} {
+		if _, err := decodeL8RuntimeOwnerNamespaceCorrelation(body); !errors.Is(err, errL8RuntimeOwnerProtocol) {
+			t.Fatalf("correlation length %d = %v", len(body), err)
+		}
+	}
+}
+
+func l8RuntimeOwnerTestNamespaceCorrelation(t *testing.T, user, network *os.File) l8RuntimeOwnerNamespaceCorrelationV1 {
+	t.Helper()
+	var userStat, networkStat unix.Stat_t
+	if unix.Fstat(int(user.Fd()), &userStat) != nil || unix.Fstat(int(network.Fd()), &networkStat) != nil {
+		t.Fatal("stat namespace descriptors")
+	}
+	return l8RuntimeOwnerNamespaceCorrelationV1{
+		UserDevice: uint64(userStat.Dev), UserInode: userStat.Ino,
+		NetworkDevice: uint64(networkStat.Dev), NetworkInode: networkStat.Ino,
+	}
+}
+
+func closeL8RuntimeOwnerTestFiles(files []*os.File) {
+	for _, file := range files {
+		if file != nil {
+			_ = file.Close()
+		}
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux_test.go
@@ -107,6 +107,27 @@ func TestL8RuntimeOwnerNamespaceTransferRejectsCountOrderKindAndCorrelation(t *t
 	}
 }
 
+func TestL8RuntimeOwnerSeqpacketRejectsMultipleRightsMessagesWithoutLeakingDescriptors(t *testing.T) {
+	first, err := unix.Dup(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := unix.Dup(0)
+	if err != nil {
+		_ = unix.Close(first)
+		t.Fatal(err)
+	}
+	oob := append(unix.UnixRights(first), unix.UnixRights(second)...)
+	if files, err := l8RuntimeOwnerFilesFromControl(oob); !errors.Is(err, errL8RuntimeOwnerProtocol) || len(files) != 0 {
+		t.Fatalf("multiple rights = %v, %v", files, err)
+	}
+	for _, fd := range []int{first, second} {
+		if _, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0); !errors.Is(err, unix.EBADF) {
+			t.Fatalf("received fd %d remains open: %v", fd, err)
+		}
+	}
+}
+
 func TestL8RuntimeOwnerBootstrapPublishesOnlyAfterArmedChildRevisionOne(t *testing.T) {
 	user, err := os.Open("/proc/self/ns/user")
 	if err != nil {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_linux_test.go
@@ -3,8 +3,10 @@
 package firecrackerhost
 
 import (
+	"context"
 	"errors"
 	"os"
+	"reflect"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -103,6 +105,90 @@ func TestL8RuntimeOwnerNamespaceTransferRejectsCountOrderKindAndCorrelation(t *t
 			t.Fatalf("correlation length %d = %v", len(body), err)
 		}
 	}
+}
+
+func TestL8RuntimeOwnerBootstrapPublishesOnlyAfterArmedChildRevisionOne(t *testing.T) {
+	user, err := os.Open("/proc/self/ns/user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer user.Close()
+	network, err := os.Open("/proc/self/ns/net")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer network.Close()
+	correlation := l8RuntimeOwnerTestNamespaceCorrelation(t, user, network)
+	genesis := l8RuntimeOwnerTestGenesis(l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef"))
+	store := &l8RuntimeOwnerTestStore{}
+	var events []string
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store: store, GenesisRecord: genesis, ExpectedUID: uint32(os.Geteuid()), CommitKey: make([]byte, 32),
+		StartChild: func() (l8RuntimeOwnerStartedChild, error) {
+			events = append(events, "armed")
+			return l8RuntimeOwnerStartedChild{
+				Observation: l8RuntimeOwnerProcessObservation{PID: 5001, ParentPID: genesis.SupervisorPID, StartTime: 7001, state: 'S', pidfd: 10, pidfdOwned: true},
+				Release: func() error {
+					events = append(events, "release")
+					if store.record.Revision != 1 || store.record.State != "starting" {
+						t.Fatalf("released before revision one: %#v", store.record)
+					}
+					return nil
+				},
+				Abort: func() error { events = append(events, "abort"); return nil },
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := owner.HandleBootstrap(context.Background(), uint32(os.Geteuid()), l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeBootstrapStart, Body: encodeL8RuntimeOwnerNamespaceCorrelation(correlation)}, Files: []*os.File{user, network}})
+	if err != nil || result.Packet.Opcode != l8RuntimeOwnerOpcodeBootstrapPublished || store.record.Revision != 2 || store.record.State != "running" || store.record.ControllerState != "unclaimed" || !reflect.DeepEqual(events, []string{"armed", "release"}) {
+		t.Fatalf("bootstrap = %#v record %#v events %v err %v", result, store.record, events, err)
+	}
+}
+
+func TestL8RuntimeOwnerBootstrapFailureAbortsAndNeverAcknowledgesPublication(t *testing.T) {
+	for _, scenario := range []struct {
+		name          string
+		releaseErr    bool
+		transitionErr bool
+	}{
+		{name: "release failure", releaseErr: true}, {name: "revision one durability", transitionErr: true},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			genesis := l8RuntimeOwnerTestGenesis(l8RuntimeOwnerTestRecord(t, l8RuntimeOwnerTestSeed(), "01234567-89ab-cdef-0123-456789abcdef"))
+			store := &l8RuntimeOwnerFailingTransitionStore{l8RuntimeOwnerTestStore: l8RuntimeOwnerTestStore{}, failTransition: scenario.transitionErr}
+			aborts := 0
+			owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{Store: store, GenesisRecord: genesis, ExpectedUID: 1000, CommitKey: make([]byte, 32), StartChild: func() (l8RuntimeOwnerStartedChild, error) {
+				return l8RuntimeOwnerStartedChild{Observation: l8RuntimeOwnerProcessObservation{PID: 5, ParentPID: genesis.SupervisorPID, StartTime: 7, state: 'S', pidfd: 9, pidfdOwned: true}, Release: func() error {
+					if scenario.releaseErr {
+						return errors.New("private release")
+					}
+					return nil
+				}, Abort: func() error { aborts++; return nil }}, nil
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := owner.HandleBootstrap(context.Background(), 1000, l8RuntimeOwnerReceivedPacketV1{Packet: l8RuntimeOwnerPacketV1{Opcode: l8RuntimeOwnerOpcodeBootstrapStart, Body: make([]byte, 32)}, Files: make([]*os.File, 2)})
+			if !errors.Is(err, errL8RuntimeOwnerInvalid) || result.Packet.Opcode == l8RuntimeOwnerOpcodeBootstrapPublished || aborts != 1 {
+				t.Fatalf("bootstrap failure = %#v, %v aborts %d", result, err, aborts)
+			}
+		})
+	}
+}
+
+type l8RuntimeOwnerFailingTransitionStore struct {
+	l8RuntimeOwnerTestStore
+	failTransition bool
+}
+
+func (store *l8RuntimeOwnerFailingTransitionStore) Transition(ctx context.Context, expected uint64, next firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	if store.failTransition {
+		return firecrackerRuntimeOwnerRecordV1{}, errors.New("private durable path")
+	}
+	return store.l8RuntimeOwnerTestStore.Transition(ctx, expected, next)
 }
 
 func l8RuntimeOwnerTestNamespaceCorrelation(t *testing.T, user, network *os.File) l8RuntimeOwnerNamespaceCorrelationV1 {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_other.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_transport_other.go
@@ -1,0 +1,49 @@
+//go:build !linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"os"
+)
+
+type l8RuntimeOwnerNamespaceCorrelationV1 struct {
+	UserDevice    uint64
+	UserInode     uint64
+	NetworkDevice uint64
+	NetworkInode  uint64
+}
+
+type l8RuntimeOwnerReceivedPacketV1 struct {
+	Packet l8RuntimeOwnerPacketV1
+	Files  []*os.File
+}
+
+func encodeL8RuntimeOwnerNamespaceCorrelation(l8RuntimeOwnerNamespaceCorrelationV1) []byte {
+	return nil
+}
+func decodeL8RuntimeOwnerNamespaceCorrelation([]byte) (l8RuntimeOwnerNamespaceCorrelationV1, error) {
+	return l8RuntimeOwnerNamespaceCorrelationV1{}, errL8RuntimeOwnerUnsupported
+}
+func sendL8RuntimeOwnerSeqpacket(int, l8RuntimeOwnerPacketV1, []*os.File) error {
+	return errL8RuntimeOwnerUnsupported
+}
+func receiveL8RuntimeOwnerSeqpacket(int) (l8RuntimeOwnerReceivedPacketV1, error) {
+	return l8RuntimeOwnerReceivedPacketV1{}, errL8RuntimeOwnerUnsupported
+}
+func validateL8RuntimeOwnerNamespaceFiles([]*os.File, l8RuntimeOwnerNamespaceCorrelationV1) error {
+	return errL8RuntimeOwnerUnsupported
+}
+func l8RuntimeOwnerPeerUID(int) (uint32, error) { return 0, errL8RuntimeOwnerUnsupported }
+func parseL8RuntimeOwnerProcIdentity([]byte, uint32) (uint32, uint64, byte, error) {
+	return 0, 0, 0, errL8RuntimeOwnerUnsupported
+}
+func signalL8RuntimeOwnerProcess(l8RuntimeOwnerProcessObservation, os.Signal) error {
+	return errL8RuntimeOwnerUnsupported
+}
+func waitL8RuntimeOwnerProcessTerminal(context.Context, l8RuntimeOwnerProcessObservation) error {
+	return errL8RuntimeOwnerUnsupported
+}
+func inspectL8RuntimeOwnerProcessAbsent(uint32) (bool, error) {
+	return false, errL8RuntimeOwnerUnsupported
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/real_process_runner_boundary_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/real_process_runner_boundary_test.go
@@ -15,7 +15,10 @@ import (
 
 func TestOSExecImportIsConfinedToRealProcessRunner(t *testing.T) {
 	paths := firecrackerHostProductionFiles(t)
-	found := false
+	allowed := map[string]bool{
+		"real_process_runner.go":               false,
+		"l8_runtime_owner_executable_linux.go": false,
+	}
 
 	for _, path := range paths {
 		file, err := parser.ParseFile(token.NewFileSet(), path, nil, parser.ImportsOnly)
@@ -30,15 +33,17 @@ func TestOSExecImportIsConfinedToRealProcessRunner(t *testing.T) {
 			if importPath != "os/exec" {
 				continue
 			}
-			if path != "real_process_runner.go" {
-				t.Fatalf("%s imports os/exec; real Firecracker process launch must stay in real_process_runner.go", path)
+			if _, ok := allowed[path]; !ok {
+				t.Fatalf("%s imports os/exec; Firecracker process launch must stay in an exact reviewed owner", path)
 			}
-			found = true
+			allowed[path] = true
 		}
 	}
 
-	if !found {
-		t.Fatal("real_process_runner.go does not import os/exec; US-005 requires the real host runner to own that boundary")
+	for path, found := range allowed {
+		if !found {
+			t.Fatalf("%s does not import os/exec; an exact Firecracker launch owner disappeared", path)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Stacked on `feature/sandbox-runtime-secure-default-v2` (`058e727f`) / working PR https://github.com/j-yw/hal/pull/37.

GREEN for the L8 runtime-owner supervisor RED contract (`64ee5aa7` plus `9a8e8799`). Independent Grok review of the RED tip was **fix-then-merge** (fail-closed stubs, unvalidated DTO fields, architecture contradiction on finalize order and absence-kind tokens). This successor implements the FSM, codec, executable ABI, and Linux seqpacket transfer.

Does **not** implement host `JobCredentialRuntime` / absence-proof issuance. Default Firecracker backend stays planning-only. No sandboxd/worker wiring.

## Review focus

- Finalize is two-phase `finalizing` then `finalized`. Architecture prose still disagrees with itself; confirm this is the frozen test contract.
- Absence kind used in tests/production is `replacement_proc`, not `replacement_proc_absence`.
- `cmd/hal-firecracker-runtime-owner` still imports the full `firecrackerhost` package (link isolation vs process isolation).
- Durable record extra fields must actually be validated, not only persisted.

## Tests

```
go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner' -count=1
go test ./cmd -run '^TestL8D6RuntimeOwnerSupervisor|^TestL8D6RuntimeOwnerContract' -count=1
```

Author also reported count=20 and race count=5 on those selectors. `golangci-lint` is not installed.

## Queue

Do not merge to `develop`. Codex review should wait until PR https://github.com/j-yw/hal/pull/38 is idle. Also queued behind https://github.com/j-yw/hal/pull/39 and https://github.com/j-yw/hal/pull/40.