### PR TITLE
feat: validate L8 PID1 start-gate process descriptors

### DIFF
--- a/internal/sandboxruntime/microvm/guestagent/l8composition/helper_bootstrap_state.go
+++ b/internal/sandboxruntime/microvm/guestagent/l8composition/helper_bootstrap_state.go
@@ -181,9 +181,9 @@ func ValidateHelperBootstrapRightKind(kind HelperBootstrapRightKind) error {
 
 // Accept authenticates one complete datagram and advances only the locked
 // helper-ready/bootstrap/ack/hello/ack transition. Every failure is terminal.
-// The composition coordinator must deliver agent_hello only after both HL8L
-// and HL8A composition acceptance. That cross-protocol precondition is outside
-// HL8P; completion here does not claim global composition or admission.
+// PID1StartGateState must release before agent_hello. That cross-protocol
+// precondition is outside HL8P; completion here does not claim global
+// composition or admission.
 func (machine *HelperBootstrapPreAdmissionState) Accept(metadata HelperBootstrapReceiveMetadata, encoded []byte) (HelperBootstrapDecision, error) {
 	if machine == nil || machine.state == nil {
 		return HelperBootstrapDecisionStopVM, ErrHelperBootstrapStateTerminal

--- a/internal/sandboxruntime/microvm/guestagent/l8composition/pid1_start_gate.go
+++ b/internal/sandboxruntime/microvm/guestagent/l8composition/pid1_start_gate.go
@@ -1,0 +1,311 @@
+package l8composition
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	ErrPID1StartGateSerialization       = errors.New("L8 PID1 start-gate serialization is denied")
+	ErrPID1StartGateDigestZero          = errors.New("L8 PID1 start-gate sealed digest is zero")
+	ErrPID1StartGateDigestAlias         = errors.New("L8 PID1 start-gate sealed digests alias")
+	ErrPID1StartGateDigestMismatch      = errors.New("L8 PID1 start-gate descriptor digest does not match")
+	ErrPID1StartGateRole                = errors.New("L8 PID1 start-gate descriptor role is invalid")
+	ErrPID1StartGateRoleOrder           = errors.New("L8 PID1 start-gate descriptors are not helper then client")
+	ErrPID1StartGateTransition          = errors.New("L8 PID1 start-gate transition is invalid")
+	ErrPID1StartGateReleased            = errors.New("L8 PID1 start-gate already released")
+	ErrPID1StartGateTerminal            = errors.New("L8 PID1 start-gate state is terminal")
+	ErrPID1StartGateRegistration        = errors.New("L8 PID1 start-gate registration is invalid")
+	ErrPID1StartGateCompositionMismatch = errors.New("L8 PID1 start-gate composition digest does not match")
+)
+
+// PID1StartGateDecision is the complete fail-closed start-gate disposition.
+type PID1StartGateDecision uint8
+
+const (
+	PID1StartGateDecisionContinue PID1StartGateDecision = 1
+	PID1StartGateDecisionRelease  PID1StartGateDecision = 2
+	PID1StartGateDecisionStopVM   PID1StartGateDecision = 3
+)
+
+// PID1StartGateExpected is sealed image-profile correlation owned by PID1.
+// It contains no live handle, path, descriptor body, or secret.
+type PID1StartGateExpected struct {
+	HelperDescriptorSHA256 [32]byte
+	ClientDescriptorSHA256 [32]byte
+	CompositionSHA256      [32]byte
+}
+
+type pid1StartGatePhase uint8
+
+const (
+	pid1StartGatePhaseHelper pid1StartGatePhase = iota + 1
+	pid1StartGatePhaseClient
+	pid1StartGatePhaseReleased
+	pid1StartGatePhaseStopped
+)
+
+type pid1StartGateOwner struct {
+	mu          sync.Mutex
+	phase       pid1StartGatePhase
+	expected    PID1StartGateExpected
+	helper      ProcessDescriptor
+	helperWire  []byte
+	client      ProcessDescriptor
+	clientWire  []byte
+	composition CompositionDescriptor
+}
+
+// PID1StartGateState is a copy-safe PID1 composition coordinator. Value copies
+// share one owner. It constructs no helper or client object and owns no
+// endpoint, right, or start-gate file descriptor.
+type PID1StartGateState struct {
+	owner *pid1StartGateOwner
+}
+
+// NewPID1StartGateState snapshots sealed helper, client, and composition
+// digests. Zero or aliased descriptor digests fail closed before any accept.
+func NewPID1StartGateState(expected PID1StartGateExpected) (*PID1StartGateState, error) {
+	if expected.HelperDescriptorSHA256 == [32]byte{} ||
+		expected.ClientDescriptorSHA256 == [32]byte{} ||
+		expected.CompositionSHA256 == [32]byte{} {
+		return nil, ErrPID1StartGateDigestZero
+	}
+	if expected.HelperDescriptorSHA256 == expected.ClientDescriptorSHA256 {
+		return nil, ErrPID1StartGateDigestAlias
+	}
+	return &PID1StartGateState{owner: &pid1StartGateOwner{
+		phase:    pid1StartGatePhaseHelper,
+		expected: expected,
+	}}, nil
+}
+
+// AcceptHelperDescriptor admits the authenticated helper-role descriptor first.
+func (state *PID1StartGateState) AcceptHelperDescriptor(descriptor ProcessDescriptor) (PID1StartGateDecision, error) {
+	owner, err := state.lockOwner()
+	if err != nil {
+		return PID1StartGateDecisionStopVM, err
+	}
+	defer owner.mu.Unlock()
+	if decision, err := owner.guardAccept(); err != nil {
+		return decision, err
+	}
+	if owner.phase != pid1StartGatePhaseHelper {
+		return owner.stop(ErrPID1StartGateTransition)
+	}
+	canonical, wire, err := canonicalStartGateDescriptor(descriptor, ProcessRoleHelper, owner.expected.HelperDescriptorSHA256)
+	if err != nil {
+		return owner.stop(err)
+	}
+	owner.helper = canonical
+	owner.helperWire = wire
+	owner.phase = pid1StartGatePhaseClient
+	return PID1StartGateDecisionContinue, nil
+}
+
+// AcceptClientDescriptor admits the authenticated client-role descriptor and
+// releases the agent start gate only after ValidateProcessDescriptors agrees
+// with the sealed image-profile composition digest.
+func (state *PID1StartGateState) AcceptClientDescriptor(descriptor ProcessDescriptor) (PID1StartGateDecision, error) {
+	owner, err := state.lockOwner()
+	if err != nil {
+		return PID1StartGateDecisionStopVM, err
+	}
+	defer owner.mu.Unlock()
+	if decision, err := owner.guardAccept(); err != nil {
+		return decision, err
+	}
+	if owner.phase != pid1StartGatePhaseClient {
+		return owner.stop(ErrPID1StartGateRoleOrder)
+	}
+	canonical, wire, err := canonicalStartGateDescriptor(descriptor, ProcessRoleClient, owner.expected.ClientDescriptorSHA256)
+	if err != nil {
+		return owner.stop(err)
+	}
+	owner.client = canonical
+	owner.clientWire = wire
+	composition, err := ValidateProcessDescriptors(owner.helper, owner.client)
+	if err != nil {
+		return owner.stop(err)
+	}
+	if composition.HelperSHA256 != owner.expected.HelperDescriptorSHA256 ||
+		composition.ClientSHA256 != owner.expected.ClientDescriptorSHA256 {
+		return owner.stop(ErrPID1StartGateDigestMismatch)
+	}
+	if composition.CompositionSHA256 != owner.expected.CompositionSHA256 {
+		return owner.stop(ErrPID1StartGateCompositionMismatch)
+	}
+	if !exactSSHCompositionExtensions(owner.helper.Extensions) || !exactSSHCompositionExtensions(owner.client.Extensions) {
+		return owner.stop(ErrPID1StartGateRegistration)
+	}
+	owner.helper = ProcessDescriptor{}
+	owner.helperWire = nil
+	owner.client = ProcessDescriptor{}
+	owner.clientWire = nil
+	owner.composition = composition
+	owner.phase = pid1StartGatePhaseReleased
+	return PID1StartGateDecisionRelease, nil
+}
+
+// Composition returns the independently computed composition only after
+// start-gate release. Failure and incomplete states expose nothing.
+func (state *PID1StartGateState) Composition() (CompositionDescriptor, bool) {
+	if state == nil || state.owner == nil {
+		return CompositionDescriptor{}, false
+	}
+	state.owner.mu.Lock()
+	defer state.owner.mu.Unlock()
+	if state.owner.phase != pid1StartGatePhaseReleased {
+		return CompositionDescriptor{}, false
+	}
+	return state.owner.composition, true
+}
+
+// Lost permanently requires whole-VM stop and forgets any attested descriptors.
+func (state *PID1StartGateState) Lost() PID1StartGateDecision {
+	if state == nil || state.owner == nil {
+		return PID1StartGateDecisionStopVM
+	}
+	state.owner.mu.Lock()
+	defer state.owner.mu.Unlock()
+	_, _ = state.owner.stop(ErrPID1StartGateTerminal)
+	return PID1StartGateDecisionStopVM
+}
+
+// Decision returns the current fail-closed disposition.
+func (state *PID1StartGateState) Decision() PID1StartGateDecision {
+	if state == nil || state.owner == nil {
+		return PID1StartGateDecisionStopVM
+	}
+	state.owner.mu.Lock()
+	defer state.owner.mu.Unlock()
+	switch state.owner.phase {
+	case pid1StartGatePhaseReleased:
+		return PID1StartGateDecisionRelease
+	case pid1StartGatePhaseStopped:
+		return PID1StartGateDecisionStopVM
+	default:
+		return PID1StartGateDecisionContinue
+	}
+}
+
+func (state *PID1StartGateState) lockOwner() (*pid1StartGateOwner, error) {
+	if state == nil || state.owner == nil {
+		return nil, ErrPID1StartGateTerminal
+	}
+	state.owner.mu.Lock()
+	return state.owner, nil
+}
+
+func (owner *pid1StartGateOwner) guardAccept() (PID1StartGateDecision, error) {
+	switch owner.phase {
+	case pid1StartGatePhaseReleased:
+		return owner.stop(ErrPID1StartGateReleased)
+	case pid1StartGatePhaseStopped:
+		return PID1StartGateDecisionStopVM, ErrPID1StartGateTerminal
+	default:
+		return 0, nil
+	}
+}
+
+func (owner *pid1StartGateOwner) stop(err error) (PID1StartGateDecision, error) {
+	owner.phase = pid1StartGatePhaseStopped
+	owner.helper = ProcessDescriptor{}
+	owner.helperWire = nil
+	owner.client = ProcessDescriptor{}
+	owner.clientWire = nil
+	owner.composition = CompositionDescriptor{}
+	return PID1StartGateDecisionStopVM, err
+}
+
+func canonicalStartGateDescriptor(descriptor ProcessDescriptor, role ProcessRole, digest [32]byte) (ProcessDescriptor, []byte, error) {
+	if descriptor.Role != role {
+		return ProcessDescriptor{}, nil, ErrPID1StartGateRole
+	}
+	encoded, err := EncodeProcessDescriptor(descriptor)
+	if err != nil {
+		return ProcessDescriptor{}, nil, err
+	}
+	decoded, err := DecodeProcessDescriptor(encoded)
+	if err != nil {
+		return ProcessDescriptor{}, nil, err
+	}
+	reencoded, err := EncodeProcessDescriptor(decoded)
+	if err != nil || !bytes.Equal(encoded, reencoded) {
+		return ProcessDescriptor{}, nil, ErrProcessDescriptorContract
+	}
+	if sha256.Sum256(encoded) != digest {
+		return ProcessDescriptor{}, nil, ErrPID1StartGateDigestMismatch
+	}
+	return cloneAgentSupervisorDescriptor(decoded), append([]byte(nil), encoded...), nil
+}
+
+func pid1StartGateFormat(state fmt.State, name string) { _, _ = state.Write([]byte(name)) }
+
+func (PID1StartGateDecision) Format(state fmt.State, _ rune) {
+	pid1StartGateFormat(state, "PID1StartGateDecision")
+}
+func (PID1StartGateExpected) Format(state fmt.State, _ rune) {
+	pid1StartGateFormat(state, "PID1StartGateExpected")
+}
+func (PID1StartGateState) Format(state fmt.State, _ rune) {
+	pid1StartGateFormat(state, "PID1StartGateState")
+}
+
+func (PID1StartGateDecision) String() string   { return "PID1StartGateDecision" }
+func (PID1StartGateDecision) GoString() string { return "PID1StartGateDecision" }
+func (PID1StartGateExpected) String() string   { return "PID1StartGateExpected" }
+func (PID1StartGateExpected) GoString() string { return "PID1StartGateExpected" }
+func (PID1StartGateState) String() string      { return "PID1StartGateState" }
+func (PID1StartGateState) GoString() string    { return "PID1StartGateState" }
+
+func pid1StartGateMarshalDenied() ([]byte, error) { return nil, ErrPID1StartGateSerialization }
+func pid1StartGateUnmarshalDenied([]byte) error   { return ErrPID1StartGateSerialization }
+
+func (PID1StartGateDecision) MarshalJSON() ([]byte, error) { return pid1StartGateMarshalDenied() }
+func (PID1StartGateDecision) MarshalText() ([]byte, error) { return pid1StartGateMarshalDenied() }
+func (PID1StartGateDecision) MarshalBinary() ([]byte, error) {
+	return pid1StartGateMarshalDenied()
+}
+func (*PID1StartGateDecision) UnmarshalJSON(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+func (*PID1StartGateDecision) UnmarshalText(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+func (*PID1StartGateDecision) UnmarshalBinary(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+
+func (PID1StartGateExpected) MarshalJSON() ([]byte, error) { return pid1StartGateMarshalDenied() }
+func (PID1StartGateExpected) MarshalText() ([]byte, error) { return pid1StartGateMarshalDenied() }
+func (PID1StartGateExpected) MarshalBinary() ([]byte, error) {
+	return pid1StartGateMarshalDenied()
+}
+func (*PID1StartGateExpected) UnmarshalJSON(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+func (*PID1StartGateExpected) UnmarshalText(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+func (*PID1StartGateExpected) UnmarshalBinary(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+
+func (PID1StartGateState) MarshalJSON() ([]byte, error) { return pid1StartGateMarshalDenied() }
+func (PID1StartGateState) MarshalText() ([]byte, error) { return pid1StartGateMarshalDenied() }
+func (PID1StartGateState) MarshalBinary() ([]byte, error) {
+	return pid1StartGateMarshalDenied()
+}
+func (*PID1StartGateState) UnmarshalJSON(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+func (*PID1StartGateState) UnmarshalText(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}
+func (*PID1StartGateState) UnmarshalBinary(value []byte) error {
+	return pid1StartGateUnmarshalDenied(value)
+}

--- a/internal/sandboxruntime/microvm/guestagent/l8composition/pid1_start_gate_import_boundary_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/l8composition/pid1_start_gate_import_boundary_test.go
@@ -1,0 +1,158 @@
+package l8composition
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPID1StartGateExactPureImportBoundary(t *testing.T) {
+	t.Parallel()
+
+	const source = "pid1_start_gate.go"
+	file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed := []string{
+		"bytes",
+		"crypto/sha256",
+		"errors",
+		"fmt",
+		"sync",
+	}
+	if len(file.Imports) != len(allowed) {
+		t.Fatalf("imports = %d, want exact %d", len(file.Imports), len(allowed))
+	}
+	for index, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if imported.Name != nil || path != allowed[index] {
+			t.Errorf("import %d = %q, want exact %q without alias", index, path, allowed[index])
+		}
+	}
+}
+
+func TestPID1StartGateHasNoLiveGenericDurableOrMutableGlobalSurface(t *testing.T) {
+	t.Parallel()
+
+	const source = "pid1_start_gate.go"
+	file, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, declaration := range file.Decls {
+		switch typed := declaration.(type) {
+		case *ast.FuncDecl:
+			if typed.Name.Name == "init" {
+				t.Error("PID1 start gate declares init")
+			}
+			if typed.Type.TypeParams != nil && len(typed.Type.TypeParams.List) != 0 {
+				t.Errorf("PID1 start gate declares generic function %s", typed.Name)
+			}
+		case *ast.GenDecl:
+			if typed.Tok == token.TYPE {
+				for _, specification := range typed.Specs {
+					typeSpecification := specification.(*ast.TypeSpec)
+					if typeSpecification.TypeParams != nil && len(typeSpecification.TypeParams.List) != 0 {
+						t.Errorf("PID1 start gate declares generic type %s", typeSpecification.Name)
+					}
+				}
+			}
+			if typed.Tok == token.VAR {
+				for _, specification := range typed.Specs {
+					valueSpecification := specification.(*ast.ValueSpec)
+					for _, value := range valueSpecification.Values {
+						call, ok := value.(*ast.CallExpr)
+						if !ok || len(call.Args) != 1 {
+							t.Error("PID1 start gate has mutable package-global state")
+							continue
+						}
+						selector, ok := call.Fun.(*ast.SelectorExpr)
+						packageName, packageOK := selector.X.(*ast.Ident)
+						if !ok || !packageOK || packageName.Name != "errors" || selector.Sel.Name != "New" {
+							t.Error("PID1 start gate globals must be stable errors only")
+						}
+					}
+				}
+			}
+		}
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.MapType:
+			t.Errorf("PID1 start gate declares map at %d", typed.Pos())
+		case *ast.InterfaceType:
+			t.Errorf("PID1 start gate declares interface/any at %d", typed.Pos())
+		case *ast.StructType:
+			for _, field := range typed.Fields.List {
+				if field.Tag != nil {
+					t.Errorf("PID1 start gate field has durable tag %s", field.Tag.Value)
+				}
+				for _, name := range field.Names {
+					if name.IsExported() && (name.Name == "Body" || name.Name == "Raw" || name.Name == "Bytes" || name.Name == "FD") {
+						t.Errorf("PID1 start gate exposes generic/live field %s", name.Name)
+					}
+				}
+			}
+		}
+		return true
+	})
+}
+
+func TestPID1StartGateSourceOwnsDescriptorValidationWithoutProcessConstructors(t *testing.T) {
+	t.Parallel()
+
+	file, err := parser.ParseFile(token.NewFileSet(), "pid1_start_gate.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validateCalls := 0
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		identifier, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch identifier.Name {
+		case "ValidateProcessDescriptors":
+			validateCalls++
+		case "NewHelper", "NewClient", "NewAgent":
+			t.Errorf("PID1 start gate constructs process-local object via %s", identifier.Name)
+		}
+		return true
+	})
+	if validateCalls != 1 {
+		t.Fatalf("ValidateProcessDescriptors calls = %d, want 1", validateCalls)
+	}
+
+	source, err := os.ReadFile("pid1_start_gate.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		"NewHelper(",
+		"NewClient(",
+		"NewAgent(",
+		"sshrelay",
+		"credentialhelper",
+		"credentialclient",
+		"syscall",
+		"unsafe",
+		"os/exec",
+		"net.Listen",
+	} {
+		if strings.Contains(string(source), forbidden) {
+			t.Errorf("PID1 start gate contains forbidden authority marker %q", forbidden)
+		}
+	}
+}

--- a/internal/sandboxruntime/microvm/guestagent/l8composition/pid1_start_gate_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/l8composition/pid1_start_gate_test.go
@@ -1,0 +1,411 @@
+package l8composition
+
+import (
+	"crypto/sha256"
+	"encoding"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
+)
+
+func TestPID1StartGateReleasesOnlyAfterCanonicalHelperThenClientValidation(t *testing.T) {
+	t.Parallel()
+
+	fixture := pid1StartGateFixture(t)
+	state := newPID1StartGateState(t, fixture.expected)
+	if composition, ok := state.Composition(); ok || composition != (CompositionDescriptor{}) || state.Decision() != PID1StartGateDecisionContinue {
+		t.Fatalf("new start gate composition = (%#v, %t) decision = %v", composition, ok, state.Decision())
+	}
+
+	helper := cloneProcessDescriptor(fixture.helper)
+	decision, err := state.AcceptHelperDescriptor(helper)
+	if err != nil || decision != PID1StartGateDecisionContinue || state.Decision() != PID1StartGateDecisionContinue {
+		t.Fatalf("AcceptHelperDescriptor() = %v, %v", decision, err)
+	}
+	helper.Extensions[0].Modes[0] = credentialprotocol.DeliveryModeHTTPProxy
+	if composition, ok := state.Composition(); ok || composition != (CompositionDescriptor{}) {
+		t.Fatal("helper-only start gate released composition")
+	}
+
+	client := cloneProcessDescriptor(fixture.client)
+	decision, err = state.AcceptClientDescriptor(client)
+	if err != nil || decision != PID1StartGateDecisionRelease || state.Decision() != PID1StartGateDecisionRelease {
+		t.Fatalf("AcceptClientDescriptor() = %v, %v", decision, err)
+	}
+	client.Extensions[0].Modes[0] = credentialprotocol.DeliveryModeFileTmpfs
+
+	composition, ok := state.Composition()
+	if !ok || composition != fixture.composition {
+		t.Fatalf("Composition() = %#v, %t, want exact canonical composition", composition, ok)
+	}
+	state.owner.mu.Lock()
+	helperBody := state.owner.helper
+	helperWire := append([]byte(nil), state.owner.helperWire...)
+	clientBody := state.owner.client
+	clientWire := append([]byte(nil), state.owner.clientWire...)
+	state.owner.mu.Unlock()
+	if helperBody.ContractVersion != "" || helperBody.Role != 0 || len(helperBody.Extensions) != 0 ||
+		clientBody.ContractVersion != "" || clientBody.Role != 0 || len(clientBody.Extensions) != 0 ||
+		len(helperWire) != 0 || len(clientWire) != 0 {
+		t.Fatal("PID1 start gate retained descriptor bodies after release")
+	}
+
+	copyValue := *state
+	decision, err = copyValue.AcceptHelperDescriptor(fixture.helper)
+	if decision != PID1StartGateDecisionStopVM || !errors.Is(err, ErrPID1StartGateReleased) || state.Decision() != PID1StartGateDecisionStopVM {
+		t.Fatalf("packet after release = %v, %v", decision, err)
+	}
+}
+
+func TestPID1StartGateConstructorRejectsZeroAndAliasedSealedDigests(t *testing.T) {
+	t.Parallel()
+
+	fixture := pid1StartGateFixture(t)
+	tests := []struct {
+		name   string
+		mutate func(*PID1StartGateExpected)
+		want   error
+	}{
+		{name: "zero helper", mutate: func(expected *PID1StartGateExpected) { expected.HelperDescriptorSHA256 = [32]byte{} }, want: ErrPID1StartGateDigestZero},
+		{name: "zero client", mutate: func(expected *PID1StartGateExpected) { expected.ClientDescriptorSHA256 = [32]byte{} }, want: ErrPID1StartGateDigestZero},
+		{name: "zero composition", mutate: func(expected *PID1StartGateExpected) { expected.CompositionSHA256 = [32]byte{} }, want: ErrPID1StartGateDigestZero},
+		{name: "helper aliases client", mutate: func(expected *PID1StartGateExpected) {
+			expected.HelperDescriptorSHA256 = expected.ClientDescriptorSHA256
+		}, want: ErrPID1StartGateDigestAlias},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			expected := fixture.expected
+			test.mutate(&expected)
+			state, err := NewPID1StartGateState(expected)
+			if state != nil || !errors.Is(err, test.want) {
+				t.Fatalf("NewPID1StartGateState() = (%v, %v), want nil/%v", state, err, test.want)
+			}
+		})
+	}
+}
+
+func TestPID1StartGateFailsClosedOnRoleOrderDuplicatesAndMismatches(t *testing.T) {
+	t.Parallel()
+
+	fixture := pid1StartGateFixture(t)
+	emptyHelper := canonicalDescriptor(t, ProcessRoleHelper, nil)
+	emptyClient := canonicalDescriptor(t, ProcessRoleClient, nil)
+	emptyComposition, err := ValidateProcessDescriptors(emptyHelper, emptyClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongPolicy := replacePolicy(fixture.helper, xorDigest(fixture.helper.PolicySHA256))
+	mismatchedClient := canonicalDescriptor(t, ProcessRoleClient, nil)
+	tests := []struct {
+		name    string
+		prepare func(*PID1StartGateState)
+		accept  func(*PID1StartGateState) (PID1StartGateDecision, error)
+		want    error
+	}{
+		{
+			name: "client before helper",
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(fixture.client)
+			},
+			want: ErrPID1StartGateRoleOrder,
+		},
+		{
+			name: "helper role is client",
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptHelperDescriptor(fixture.client)
+			},
+			want: ErrPID1StartGateRole,
+		},
+		{
+			name: "duplicate helper",
+			prepare: func(state *PID1StartGateState) {
+				mustAcceptPID1Helper(t, state, fixture.helper)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptHelperDescriptor(fixture.helper)
+			},
+			want: ErrPID1StartGateTransition,
+		},
+		{
+			name: "helper digest mismatch",
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptHelperDescriptor(wrongPolicy)
+			},
+			want: ErrPID1StartGateDigestMismatch,
+		},
+		{
+			name: "client role is helper",
+			prepare: func(state *PID1StartGateState) {
+				mustAcceptPID1Helper(t, state, fixture.helper)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(fixture.helper)
+			},
+			want: ErrPID1StartGateRole,
+		},
+		{
+			name: "client digest mismatch",
+			prepare: func(state *PID1StartGateState) {
+				mustAcceptPID1Helper(t, state, fixture.helper)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(mismatchedClient)
+			},
+			want: ErrPID1StartGateDigestMismatch,
+		},
+		{
+			name: "extension set mismatch after sealed digests",
+			prepare: func(state *PID1StartGateState) {
+				replaced := newPID1StartGateState(t, PID1StartGateExpected{
+					HelperDescriptorSHA256: digestProcessDescriptor(t, fixture.helper),
+					ClientDescriptorSHA256: digestProcessDescriptor(t, mismatchedClient),
+					CompositionSHA256:      fixture.composition.CompositionSHA256,
+				})
+				*state = *replaced
+				mustAcceptPID1Helper(t, state, fixture.helper)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(mismatchedClient)
+			},
+			want: credentialprotocol.ErrExtensionSetMismatch,
+		},
+		{
+			name: "policy mismatch after sealed digests",
+			prepare: func(state *PID1StartGateState) {
+				replaced := newPID1StartGateState(t, PID1StartGateExpected{
+					HelperDescriptorSHA256: digestProcessDescriptor(t, wrongPolicy),
+					ClientDescriptorSHA256: fixture.expected.ClientDescriptorSHA256,
+					CompositionSHA256:      fixture.composition.CompositionSHA256,
+				})
+				*state = *replaced
+				mustAcceptPID1Helper(t, state, wrongPolicy)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(fixture.client)
+			},
+			want: ErrProcessDescriptorPolicy,
+		},
+		{
+			name: "empty matching extensions are not production SSH",
+			prepare: func(state *PID1StartGateState) {
+				replaced := newPID1StartGateState(t, PID1StartGateExpected{
+					HelperDescriptorSHA256: emptyComposition.HelperSHA256,
+					ClientDescriptorSHA256: emptyComposition.ClientSHA256,
+					CompositionSHA256:      emptyComposition.CompositionSHA256,
+				})
+				*state = *replaced
+				mustAcceptPID1Helper(t, state, emptyHelper)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(emptyClient)
+			},
+			want: ErrPID1StartGateRegistration,
+		},
+		{
+			name: "sealed composition mismatch",
+			prepare: func(state *PID1StartGateState) {
+				expected := fixture.expected
+				expected.CompositionSHA256 = xorDigest(expected.CompositionSHA256)
+				replaced := newPID1StartGateState(t, expected)
+				*state = *replaced
+				mustAcceptPID1Helper(t, state, fixture.helper)
+			},
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptClientDescriptor(fixture.client)
+			},
+			want: ErrPID1StartGateCompositionMismatch,
+		},
+		{
+			name: "noncanonical helper contract",
+			accept: func(state *PID1StartGateState) (PID1StartGateDecision, error) {
+				return state.AcceptHelperDescriptor(replaceContract(fixture.helper, "secret-canary /tmp/private.sock"))
+			},
+			want: ErrProcessDescriptorContract,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			state := newPID1StartGateState(t, fixture.expected)
+			if test.prepare != nil {
+				test.prepare(state)
+			}
+			decision, err := test.accept(state)
+			if decision != PID1StartGateDecisionStopVM || !errors.Is(err, test.want) {
+				t.Fatalf("decision/error = %v, %v, want StopVM/%v", decision, err, test.want)
+			}
+			if state.Decision() != PID1StartGateDecisionStopVM {
+				t.Fatal("failed start gate did not latch stop-VM")
+			}
+			if composition, ok := state.Composition(); ok || composition != (CompositionDescriptor{}) {
+				t.Fatal("failed start gate published composition")
+			}
+			if strings.Contains(fmt.Sprint(err), "secret-canary") || strings.Contains(fmt.Sprint(err), "/tmp/private.sock") {
+				t.Fatalf("start-gate error leaked seeded material: %v", err)
+			}
+			decision, err = state.AcceptClientDescriptor(fixture.client)
+			if decision != PID1StartGateDecisionStopVM || !errors.Is(err, ErrPID1StartGateTerminal) {
+				t.Fatalf("retry after failure = %v, %v", decision, err)
+			}
+		})
+	}
+}
+
+func TestPID1StartGateNilLostAndDeniedSerializationStayFailClosed(t *testing.T) {
+	t.Parallel()
+
+	var state *PID1StartGateState
+	if decision, err := state.AcceptHelperDescriptor(ProcessDescriptor{}); decision != PID1StartGateDecisionStopVM || !errors.Is(err, ErrPID1StartGateTerminal) {
+		t.Fatalf("nil helper accept = %v, %v", decision, err)
+	}
+	if decision, err := state.AcceptClientDescriptor(ProcessDescriptor{}); decision != PID1StartGateDecisionStopVM || !errors.Is(err, ErrPID1StartGateTerminal) {
+		t.Fatalf("nil client accept = %v, %v", decision, err)
+	}
+	if state.Lost() != PID1StartGateDecisionStopVM || state.Decision() != PID1StartGateDecisionStopVM {
+		t.Fatal("nil Lost/Decision did not require stop-VM")
+	}
+
+	fixture := pid1StartGateFixture(t)
+	live := newPID1StartGateState(t, fixture.expected)
+	mustAcceptPID1Helper(t, live, fixture.helper)
+	if live.Lost() != PID1StartGateDecisionStopVM || live.Decision() != PID1StartGateDecisionStopVM {
+		t.Fatal("Lost did not permanently stop the start gate")
+	}
+	if composition, ok := live.Composition(); ok || composition != (CompositionDescriptor{}) {
+		t.Fatal("Lost published composition")
+	}
+
+	expected := fixture.expected
+	expected.HelperDescriptorSHA256[0] = 0x42
+	values := []any{
+		PID1StartGateDecisionContinue,
+		expected,
+		live,
+	}
+	for _, value := range values {
+		formatted := fmt.Sprintf("%v %#v %+v %s", value, value, value, value)
+		if strings.Contains(formatted, "secret-canary") || !strings.Contains(formatted, "PID1StartGate") {
+			t.Fatalf("%T formatting = %q, want opaque type name", value, formatted)
+		}
+		if _, err := json.Marshal(value); !errors.Is(err, ErrPID1StartGateSerialization) {
+			t.Fatalf("%T JSON = %v", value, err)
+		}
+		if marshaler, ok := value.(encoding.TextMarshaler); ok {
+			if _, err := marshaler.MarshalText(); !errors.Is(err, ErrPID1StartGateSerialization) {
+				t.Fatalf("%T text = %v", value, err)
+			}
+		}
+		if marshaler, ok := value.(encoding.BinaryMarshaler); ok {
+			if _, err := marshaler.MarshalBinary(); !errors.Is(err, ErrPID1StartGateSerialization) {
+				t.Fatalf("%T binary = %v", value, err)
+			}
+		}
+	}
+
+	before := live.Decision()
+	if err := json.Unmarshal([]byte(`{"CompositionSHA256":"seed"}`), live); !errors.Is(err, ErrPID1StartGateSerialization) {
+		t.Fatalf("state JSON unmarshal = %v", err)
+	}
+	if err := live.UnmarshalText([]byte("seed")); !errors.Is(err, ErrPID1StartGateSerialization) {
+		t.Fatalf("state text unmarshal = %v", err)
+	}
+	if err := live.UnmarshalBinary([]byte("seed")); !errors.Is(err, ErrPID1StartGateSerialization) {
+		t.Fatalf("state binary unmarshal = %v", err)
+	}
+	if live.Decision() != before {
+		t.Fatal("denied unmarshal mutated start-gate state")
+	}
+	if err := json.Unmarshal([]byte(`{"HelperDescriptorSHA256":"seed"}`), &expected); !errors.Is(err, ErrPID1StartGateSerialization) {
+		t.Fatalf("expected JSON unmarshal = %v", err)
+	}
+}
+
+func TestPID1StartGateCatalogAndClosedDecisionValuesAreExact(t *testing.T) {
+	t.Parallel()
+
+	if PID1StartGateDecisionContinue != 1 || PID1StartGateDecisionRelease != 2 || PID1StartGateDecisionStopVM != 3 {
+		t.Fatal("PID1 start-gate decision catalog changed")
+	}
+	expectedType := reflect.TypeOf(PID1StartGateExpected{})
+	if expectedType.NumField() != 3 {
+		t.Fatalf("PID1StartGateExpected fields = %d, want 3 sealed digests", expectedType.NumField())
+	}
+	want := []string{"HelperDescriptorSHA256", "ClientDescriptorSHA256", "CompositionSHA256"}
+	for index, name := range want {
+		field := expectedType.Field(index)
+		if field.Name != name || field.Type.String() != "[32]uint8" || field.Tag != "" {
+			t.Fatalf("field %d = %s %s %q", index, field.Name, field.Type, field.Tag)
+		}
+	}
+}
+
+type pid1StartGateTestFixture struct {
+	helper      ProcessDescriptor
+	client      ProcessDescriptor
+	composition CompositionDescriptor
+	expected    PID1StartGateExpected
+}
+
+func pid1StartGateFixture(t *testing.T) pid1StartGateTestFixture {
+	t.Helper()
+	ssh := []credentialprotocol.ExtensionDescriptor{credentialprotocol.SSHRelayV1ExtensionDescriptor()}
+	helper := canonicalDescriptor(t, ProcessRoleHelper, ssh)
+	client := canonicalDescriptor(t, ProcessRoleClient, ssh)
+	composition, err := ValidateProcessDescriptors(helper, client)
+	if err != nil {
+		t.Fatalf("ValidateProcessDescriptors() error = %v", err)
+	}
+	return pid1StartGateTestFixture{
+		helper:      helper,
+		client:      client,
+		composition: composition,
+		expected: PID1StartGateExpected{
+			HelperDescriptorSHA256: composition.HelperSHA256,
+			ClientDescriptorSHA256: composition.ClientSHA256,
+			CompositionSHA256:      composition.CompositionSHA256,
+		},
+	}
+}
+
+func newPID1StartGateState(t *testing.T, expected PID1StartGateExpected) *PID1StartGateState {
+	t.Helper()
+	state, err := NewPID1StartGateState(expected)
+	if err != nil {
+		t.Fatalf("NewPID1StartGateState() error = %v", err)
+	}
+	if state == nil {
+		t.Fatal("NewPID1StartGateState() returned nil state")
+	}
+	return state
+}
+
+func mustAcceptPID1Helper(t *testing.T, state *PID1StartGateState, descriptor ProcessDescriptor) {
+	t.Helper()
+	decision, err := state.AcceptHelperDescriptor(descriptor)
+	if err != nil || decision != PID1StartGateDecisionContinue {
+		t.Fatalf("AcceptHelperDescriptor() = %v, %v", decision, err)
+	}
+}
+
+func digestProcessDescriptor(t *testing.T, descriptor ProcessDescriptor) [32]byte {
+	t.Helper()
+	encoded, err := EncodeProcessDescriptor(descriptor)
+	if err != nil {
+		t.Fatalf("EncodeProcessDescriptor() error = %v", err)
+	}
+	return sha256.Sum256(encoded)
+}
+
+func xorDigest(value [32]byte) [32]byte {
+	value[0] ^= 0xff
+	return value
+}


### PR DESCRIPTION
## Summary

Stacked on `feature/sandbox-runtime-secure-default-v2` (`1926e937`).

Adds a default-off, fake-only PID1 start-gate coordinator in `l8composition`. Helper then client descriptors are attested against sealed image-profile digests, `ValidateProcessDescriptors` runs once, and the agent start gate releases only on exact composition agreement. Mismatch/loss requires whole-VM stop. No `NewHelper`/`NewClient`, no sockets, no `hal-guest-init` wiring, no cmd import-guard lift.

## Tests

```
go test ./internal/sandboxruntime/microvm/guestagent/l8composition -count=1
go test -race -count=5 ./internal/sandboxruntime/microvm/guestagent/l8composition -run 'TestPID1StartGate'
go vet ./internal/sandboxruntime/microvm/guestagent/l8composition
```

## Non-goals

- Host JobCredentialRuntime
- Worker prepare/renew
- Remaining credentialclient operations still `dependency_unaccepted`
- Live PID1 command wiring

Do not merge to `develop`.