### PR TITLE
feat: implement default-off Firecracker JobCredentialRuntime

### DIFF
--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
@@ -1,0 +1,204 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+	guestsession "github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/session"
+)
+
+const l8JobCredentialRuntimeValuePlaceholder = "[firecracker-l8-job-credential-runtime]"
+
+var (
+	ErrL8JobCredentialRuntimeUnavailable = errors.New("Firecracker L8 job credential runtime unavailable")
+	ErrL8JobCredentialRuntimeInvalid     = errors.New("Firecracker L8 job credential runtime invalid")
+	ErrL8JobCredentialRuntimeUnsupported = errors.New("Firecracker L8 job credential runtime unsupported")
+	ErrL8JobCredentialRuntimeSerialization = errors.New("Firecracker L8 job credential runtime serialization denied")
+	errL8JobCredentialRuntimeDependencyUnaccepted = errors.New("dependency_unaccepted")
+)
+
+type l8JobCredentialGuestSessionOpener interface {
+	Open(context.Context, sandboxruntime.JobCredentialIdentitySeed) (l8JobCredentialGuestSession, error)
+}
+
+type l8JobCredentialGuestSession interface {
+	GuestSessionGeneration() string
+	GuestHelperGeneration() string
+	SessionID() [32]byte
+	HardExpiry() time.Time
+	Prepare(context.Context, sandboxruntime.JobCredentialIdentity, time.Time, []l8JobCredentialGuestBindingManifest) (l8JobCredentialGuestPrepareResult, error)
+	Renew(context.Context, sandboxruntime.JobCredentialIdentity, uint64, time.Time, string) (string, error)
+	Revoke(context.Context, sandboxruntime.JobCredentialIdentity, uint64, sandboxruntime.JobCredentialRevokeReason) (string, error)
+	Loss() <-chan struct{}
+	Close() error
+}
+
+type l8JobCredentialGuestBindingManifest struct {
+	BindingID         string
+	Mode              sandboxruntime.JobCredentialDeliveryMode
+	ServiceID         string
+	TargetPath        string
+	DeclaredFileBytes uint32
+	FileSHA256        string
+	SSHPolicyID       string
+	SSHPolicyRevision uint64
+}
+
+type l8JobCredentialGuestPrepareResult struct {
+	ActiveProofID string
+	ExecBindingID string
+	BindingProofs []l8JobCredentialGuestBindingProof
+}
+
+type l8JobCredentialGuestBindingProof struct {
+	BindingID string
+	Mode      sandboxruntime.JobCredentialDeliveryMode
+	ProofID   string
+}
+
+type l8JobCredentialHTTPProxyActivator interface {
+	Activate(context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest, sandboxruntime.LiveSecretSource) (l8JobCredentialHTTPProxyHandle, error)
+}
+
+type l8JobCredentialHTTPProxyHandle interface {
+	ServiceID() string
+	Renew(context.Context) error
+	Revoke(context.Context) error
+}
+
+type l8JobCredentialFileTmpfsActivator interface {
+	Materialize(context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest, sandboxruntime.LiveSecretSource) (l8JobCredentialFileHandle, error)
+}
+
+type l8JobCredentialFileHandle interface {
+	TargetPath() string
+	DeclaredFileBytes() uint32
+	FileSHA256() string
+	Revoke(context.Context) error
+}
+
+type l8JobCredentialSSHRelayActivator interface {
+	Activate(context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest) (l8JobCredentialSSHRelayHandle, error)
+}
+
+type l8JobCredentialSSHRelayHandle interface {
+	PolicyID() string
+	PolicyRevision() uint64
+	Renew(context.Context) error
+	Revoke(context.Context) error
+}
+
+type l8JobCredentialRuntimeDependencies struct {
+	GuestSession l8JobCredentialGuestSessionOpener
+	HTTPProxy    l8JobCredentialHTTPProxyActivator
+	FileTmpfs    l8JobCredentialFileTmpfsActivator
+	SSHRelay     l8JobCredentialSSHRelayActivator
+	Now          func() time.Time
+	Random       io.Reader
+}
+
+// L8JobCredentialRuntime is the default-off Firecracker host implementation of
+// sandboxruntime.JobCredentialRuntime. Callers must inject it explicitly.
+type L8JobCredentialRuntime struct {
+	mu         sync.Mutex
+	deps       l8JobCredentialRuntimeDependencies
+	attempted  bool
+	production bool
+}
+
+// NewProductionL8JobCredentialRuntime constructs the explicit Firecracker host
+// credential runtime. It is never invoked by default backend, sandboxd, worker,
+// or command paths.
+func NewProductionL8JobCredentialRuntime(deps l8JobCredentialRuntimeDependencies) (*L8JobCredentialRuntime, error) {
+	if !l8JobCredentialRuntimePlatformSupported() {
+		return nil, ErrL8JobCredentialRuntimeUnsupported
+	}
+	return newL8JobCredentialRuntime(deps, true)
+}
+
+func newL8JobCredentialRuntime(deps l8JobCredentialRuntimeDependencies, production bool) (*L8JobCredentialRuntime, error) {
+	if l8JobCredentialRuntimeValueIsNil(deps.GuestSession) || deps.Now == nil || l8JobCredentialRuntimeValueIsNil(deps.Random) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	return &L8JobCredentialRuntime{deps: deps, production: production}, nil
+}
+
+func (runtime *L8JobCredentialRuntime) PreflightJobCredentials(ctx context.Context, seed sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimePreflight, error) {
+	return nil, ErrL8JobCredentialRuntimeUnavailable
+}
+
+func (runtime *L8JobCredentialRuntime) RecoverJobCredentials(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+	return sandboxruntime.JobCredentialCleanupProof{}, errL8JobCredentialRuntimeDependencyUnaccepted
+}
+
+func (*L8JobCredentialRuntime) String() string { return l8JobCredentialRuntimeValuePlaceholder }
+func (*L8JobCredentialRuntime) GoString() string {
+	return l8JobCredentialRuntimeValuePlaceholder
+}
+func (*L8JobCredentialRuntime) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialRuntimeValuePlaceholder)
+}
+func (*L8JobCredentialRuntime) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*L8JobCredentialRuntime) MarshalText() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*L8JobCredentialRuntime) MarshalBinary() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+
+func l8JobCredentialRuntimeValueIsNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}
+
+func sanitizeL8JobCredentialRuntimeError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch):
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	case errors.Is(err, sandboxruntime.ErrJobCredentialTransition):
+		return sandboxruntime.ErrJobCredentialTransition
+	case errors.Is(err, sandboxruntime.ErrJobCredentialReplayRejected):
+		return sandboxruntime.ErrJobCredentialReplayRejected
+	case errors.Is(err, sandboxruntime.ErrJobCredentialRevisionStale):
+		return sandboxruntime.ErrJobCredentialRevisionStale
+	case errors.Is(err, sandboxruntime.ErrJobCredentialExpired):
+		return sandboxruntime.ErrJobCredentialExpired
+	case errors.Is(err, sandboxruntime.ErrJobCredentialProofInvalid):
+		return sandboxruntime.ErrJobCredentialProofInvalid
+	case errors.Is(err, sandboxruntime.ErrJobCredentialProofStale):
+		return sandboxruntime.ErrJobCredentialProofStale
+	case errors.Is(err, ErrL8JobCredentialRuntimeUnsupported):
+		return ErrL8JobCredentialRuntimeUnsupported
+	case errors.Is(err, ErrL8JobCredentialRuntimeInvalid):
+		return ErrL8JobCredentialRuntimeInvalid
+	case errors.Is(err, errL8JobCredentialRuntimeDependencyUnaccepted):
+		return errL8JobCredentialRuntimeDependencyUnaccepted
+	default:
+		return ErrL8JobCredentialRuntimeUnavailable
+	}
+}
+
+var (
+	_ sandboxruntime.JobCredentialRuntime = (*L8JobCredentialRuntime)(nil)
+	_ fmt.Stringer                        = (*L8JobCredentialRuntime)(nil)
+)
+
+const l8JobCredentialRuntimeSessionLifetime = guestsession.MaxGuestCredentialSessionLifetime

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
@@ -153,22 +153,33 @@ func (runtime *L8JobCredentialRuntime) PreflightJobCredentials(ctx context.Conte
 	session, openErr := callL8JobCredentialGuestSessionOpener(deps.GuestSession, ctx, cloned)
 	if openErr != nil || l8JobCredentialRuntimeValueIsNil(session) {
 		if !l8JobCredentialRuntimeValueIsNil(session) {
-			_ = session.Close()
+			_ = callL8JobCredentialGuestClose(session)
 		}
 		if openErr != nil {
 			return nil, sanitizeL8JobCredentialRuntimeError(openErr)
 		}
 		return nil, ErrL8JobCredentialRuntimeInvalid
 	}
-	identity, err := sandboxruntime.CompleteJobCredentialIdentity(cloned, session.GuestSessionGeneration(), session.GuestHelperGeneration())
+	sessionGeneration, helperGeneration, generationErr := callL8JobCredentialGuestGenerations(session)
+	if generationErr != nil {
+		_ = callL8JobCredentialGuestClose(session)
+		return nil, sanitizeL8JobCredentialRuntimeError(generationErr)
+	}
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(cloned, sessionGeneration, helperGeneration)
 	if err != nil {
-		_ = session.Close()
+		_ = callL8JobCredentialGuestClose(session)
 		return nil, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	guestLoss, lossErr := callL8JobCredentialGuestLoss(session)
+	if lossErr != nil {
+		_ = callL8JobCredentialGuestClose(session)
+		return nil, sanitizeL8JobCredentialRuntimeError(lossErr)
 	}
 	preflight := &l8JobCredentialRuntimePreflight{
 		deps:      deps,
 		identity:  cloneL8JobCredentialIdentity(identity),
 		session:   session,
+		guestLoss: guestLoss,
 		loss:      make(chan sandboxruntime.JobCredentialLoss, 1),
 		stopWatch: make(chan struct{}),
 		watchDone: make(chan struct{}),
@@ -192,10 +203,12 @@ const (
 )
 
 type l8JobCredentialRuntimePreflight struct {
+	opMu            sync.Mutex
 	mu              sync.Mutex
 	deps            l8JobCredentialRuntimeDependencies
 	identity        sandboxruntime.JobCredentialIdentity
 	session         l8JobCredentialGuestSession
+	guestLoss       <-chan struct{}
 	loss            chan sandboxruntime.JobCredentialLoss
 	stopWatch       chan struct{}
 	watchDone       chan struct{}
@@ -203,15 +216,14 @@ type l8JobCredentialRuntimePreflight struct {
 	lossLatched     bool
 	lossOnce        sync.Once
 	stopOnce        sync.Once
-	abortOnce       sync.Once
 	cleanupProof    sandboxruntime.JobCredentialCleanupProof
-	abortErr        error
 	resources       *l8JobCredentialPreparedResources
 	owned           *l8JobCredentialRuntimeSession
 	currentRevision uint64
 }
 
 type l8JobCredentialRuntimeSession struct {
+	opMu         sync.Mutex
 	mu           sync.Mutex
 	preflight    *l8JobCredentialRuntimePreflight
 	identity     sandboxruntime.JobCredentialIdentity
@@ -223,6 +235,7 @@ type l8JobCredentialRuntimeSession struct {
 	guestProofID string
 	execBinding  l8JobCredentialExecBinding
 	resources    *l8JobCredentialPreparedResources
+	revoking     bool
 	revoked      bool
 }
 
@@ -257,8 +270,10 @@ func (preflight *l8JobCredentialRuntimePreflight) PrepareJobCredentials(ctx cont
 	if preflight == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
 		return nil, ErrL8JobCredentialRuntimeInvalid
 	}
+	preflight.opMu.Lock()
+	defer preflight.opMu.Unlock()
 	preflight.mu.Lock()
-	if preflight.state != l8JobCredentialPreflightOpen || preflight.lossLatched {
+	if preflight.state != l8JobCredentialPreflightOpen || preflight.lossLatched || preflight.resources != nil {
 		preflight.mu.Unlock()
 		return nil, sandboxruntime.ErrJobCredentialTransition
 	}
@@ -274,21 +289,22 @@ func (preflight *l8JobCredentialRuntimePreflight) PrepareJobCredentials(ctx cont
 	}
 	resources, err := activateL8JobCredentialBindings(ctx, deps, identity, request)
 	if err != nil {
-		revokeL8JobCredentialResources(ctx, resources)
-		preflight.revertPrepare()
+		preflight.finishFailedPrepare(ctx, resources)
 		return nil, sanitizeL8JobCredentialRuntimeError(err)
 	}
-	now := deps.Now().UTC()
+	now, err := callL8JobCredentialNow(deps.Now)
+	if err != nil {
+		preflight.finishFailedPrepare(ctx, resources)
+		return nil, sanitizeL8JobCredentialRuntimeError(err)
+	}
 	expiresAt, err := l8JobCredentialRuntimeExpiry(identity, session, now, time.Time{})
 	if err != nil {
-		revokeL8JobCredentialResources(ctx, resources)
-		preflight.revertPrepare()
+		preflight.finishFailedPrepare(ctx, resources)
 		return nil, err
 	}
 	guestResult, err := callL8JobCredentialGuestPrepare(session, ctx, identity, expiresAt, resources.manifests)
-	if err != nil || guestResult.ActiveProofID == "" || guestResult.ExecBindingID == "" {
-		revokeL8JobCredentialResources(ctx, resources)
-		preflight.revertPrepare()
+	if err != nil || validateL8JobCredentialGuestPrepareResult(guestResult, resources.manifests) != nil {
+		preflight.finishFailedPrepare(ctx, resources)
 		if err != nil {
 			return nil, sanitizeL8JobCredentialRuntimeError(err)
 		}
@@ -298,18 +314,14 @@ func (preflight *l8JobCredentialRuntimePreflight) PrepareJobCredentials(ctx cont
 		ProofID: "active-1", Identity: identity, Revision: 1, IssuedAt: now, ExpiresAt: expiresAt,
 	})
 	if err != nil {
-		revokeL8JobCredentialResources(ctx, resources)
-		preflight.revertPrepare()
+		preflight.finishFailedPrepare(ctx, resources)
 		return nil, sandboxruntime.ErrJobCredentialProofInvalid
 	}
 
 	preflight.mu.Lock()
 	if preflight.state != l8JobCredentialPreflightPreparing || preflight.lossLatched {
-		if preflight.state == l8JobCredentialPreflightPreparing {
-			preflight.state = l8JobCredentialPreflightOpen
-		}
 		preflight.mu.Unlock()
-		revokeL8JobCredentialResources(ctx, resources)
+		preflight.finishFailedPrepare(ctx, resources)
 		return nil, sandboxruntime.ErrJobCredentialTransition
 	}
 	owned := &l8JobCredentialRuntimeSession{
@@ -335,49 +347,52 @@ func (preflight *l8JobCredentialRuntimePreflight) Abort(ctx context.Context) (sa
 	if preflight == nil {
 		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
 	}
-	preflight.abortOnce.Do(func() {
-		preflight.mu.Lock()
-		if preflight.state == l8JobCredentialPreflightTransferred {
-			preflight.mu.Unlock()
-			preflight.abortErr = sandboxruntime.ErrJobCredentialTransition
-			return
-		}
-		preflight.state = l8JobCredentialPreflightAborted
-		session := preflight.session
-		resources := preflight.resources
-		preflight.resources = nil
-		nowFn := preflight.deps.Now
-		identity := cloneL8JobCredentialIdentity(preflight.identity)
-		preflight.mu.Unlock()
-
-		preflight.stopLossWatch()
-		revokeL8JobCredentialResources(ctx, resources)
-		if !l8JobCredentialRuntimeValueIsNil(session) {
-			_ = session.Close()
-		}
-		observed := nowFn().UTC()
-		if observed.Before(identity.IssuedAt) {
-			observed = identity.IssuedAt
-		}
-		proof, err := sandboxruntime.NewJobCredentialCleanupProof(sandboxruntime.JobCredentialCleanupProofInput{
-			ProofID: "cleanup-2", Identity: identity, Revision: 2,
-			RevokedAt: observed, AbsenceInspectedAt: observed,
-			AuthorityAbsent: true, ResourcesAbsent: true,
-		})
-		preflight.mu.Lock()
-		preflight.cleanupProof = proof
-		preflight.abortErr = err
-		if err != nil {
-			preflight.abortErr = sandboxruntime.ErrJobCredentialProofInvalid
-		}
-		preflight.mu.Unlock()
-	})
+	preflight.opMu.Lock()
+	defer preflight.opMu.Unlock()
 	preflight.mu.Lock()
-	defer preflight.mu.Unlock()
-	if preflight.state == l8JobCredentialPreflightTransferred && preflight.abortErr == nil {
+	if preflight.state == l8JobCredentialPreflightTransferred {
+		preflight.mu.Unlock()
 		return sandboxruntime.JobCredentialCleanupProof{}, sandboxruntime.ErrJobCredentialTransition
 	}
-	return preflight.cleanupProof, preflight.abortErr
+	if sandboxruntime.CleanupProofKind(preflight.cleanupProof) != "" {
+		proof := preflight.cleanupProof
+		preflight.mu.Unlock()
+		return proof, nil
+	}
+	preflight.state = l8JobCredentialPreflightAborted
+	session := preflight.session
+	resources := preflight.resources
+	nowFn := preflight.deps.Now
+	identity := cloneL8JobCredentialIdentity(preflight.identity)
+	preflight.mu.Unlock()
+
+	if err := revokeL8JobCredentialResources(ctx, resources); err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
+	if err := callL8JobCredentialGuestClose(session); err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
+	preflight.stopLossWatch()
+	observed, err := callL8JobCredentialNow(nowFn)
+	if err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
+	if observed.Before(identity.IssuedAt) {
+		observed = identity.IssuedAt
+	}
+	proof, err := sandboxruntime.NewJobCredentialCleanupProof(sandboxruntime.JobCredentialCleanupProofInput{
+		ProofID: "cleanup-2", Identity: identity, Revision: 2,
+		RevokedAt: observed, AbsenceInspectedAt: observed,
+		AuthorityAbsent: true, ResourcesAbsent: true,
+	})
+	if err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sandboxruntime.ErrJobCredentialProofInvalid
+	}
+	preflight.mu.Lock()
+	preflight.resources = nil
+	preflight.cleanupProof = proof
+	preflight.mu.Unlock()
+	return proof, nil
 }
 
 func (preflight *l8JobCredentialRuntimePreflight) revertPrepare() {
@@ -388,13 +403,25 @@ func (preflight *l8JobCredentialRuntimePreflight) revertPrepare() {
 	}
 }
 
+func (preflight *l8JobCredentialRuntimePreflight) finishFailedPrepare(ctx context.Context, resources *l8JobCredentialPreparedResources) {
+	cleanupErr := revokeL8JobCredentialResources(ctx, resources)
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	if cleanupErr != nil {
+		preflight.resources = resources
+	}
+	if preflight.state == l8JobCredentialPreflightPreparing {
+		preflight.state = l8JobCredentialPreflightOpen
+	}
+}
+
 func (preflight *l8JobCredentialRuntimePreflight) watchLoss() {
 	defer close(preflight.watchDone)
-	if preflight.session == nil {
+	if preflight.guestLoss == nil {
 		return
 	}
 	select {
-	case <-preflight.session.Loss():
+	case <-preflight.guestLoss:
 		preflight.emitLoss(sandboxruntime.JobCredentialFailureGuestHelperUnavailable)
 	case <-preflight.stopWatch:
 	}
@@ -432,6 +459,9 @@ func (session *l8JobCredentialRuntimeSession) ExecBinding() sandboxruntime.JobCr
 	}
 	session.mu.Lock()
 	defer session.mu.Unlock()
+	if session.revoking || session.revoked {
+		return nil
+	}
 	return session.execBinding
 }
 
@@ -441,6 +471,9 @@ func (session *l8JobCredentialRuntimeSession) ActiveProof() sandboxruntime.JobCr
 	}
 	session.mu.Lock()
 	defer session.mu.Unlock()
+	if session.revoking || session.revoked {
+		return sandboxruntime.JobCredentialActiveProof{}
+	}
 	return session.activeProof
 }
 
@@ -455,8 +488,10 @@ func (session *l8JobCredentialRuntimeSession) Renew(ctx context.Context) (sandbo
 	if session == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
 		return sandboxruntime.JobCredentialActiveProof{}, ErrL8JobCredentialRuntimeInvalid
 	}
+	session.opMu.Lock()
+	defer session.opMu.Unlock()
 	session.mu.Lock()
-	if session.revoked || sandboxruntime.ActiveProofKind(session.activeProof) == "" {
+	if session.revoking || session.revoked || sandboxruntime.ActiveProofKind(session.activeProof) == "" {
 		session.mu.Unlock()
 		return sandboxruntime.JobCredentialActiveProof{}, sandboxruntime.ErrJobCredentialTransition
 	}
@@ -470,7 +505,10 @@ func (session *l8JobCredentialRuntimeSession) Renew(ctx context.Context) (sandbo
 	nowFn := session.preflight.deps.Now
 	session.mu.Unlock()
 
-	now := nowFn().UTC()
+	now, err := callL8JobCredentialNow(nowFn)
+	if err != nil {
+		return sandboxruntime.JobCredentialActiveProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
 	if err := sandboxruntime.ValidateJobCredentialActiveProof(session.ActiveProof(), identity, revision, now); err != nil {
 		return sandboxruntime.JobCredentialActiveProof{}, err
 	}
@@ -500,7 +538,7 @@ func (session *l8JobCredentialRuntimeSession) Renew(ctx context.Context) (sandbo
 	}
 
 	session.mu.Lock()
-	if session.revoked || session.revision != revision {
+	if session.revoking || session.revoked || session.revision != revision {
 		session.mu.Unlock()
 		return sandboxruntime.JobCredentialActiveProof{}, sandboxruntime.ErrJobCredentialTransition
 	}
@@ -520,6 +558,8 @@ func (session *l8JobCredentialRuntimeSession) Revoke(ctx context.Context, reason
 	if session == nil {
 		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
 	}
+	session.opMu.Lock()
+	defer session.opMu.Unlock()
 	session.mu.Lock()
 	if session.revoked {
 		proof := session.cleanupProof
@@ -531,22 +571,33 @@ func (session *l8JobCredentialRuntimeSession) Revoke(ctx context.Context, reason
 	guest := session.preflight.session
 	resources := session.resources
 	nowFn := session.preflight.deps.Now
+	session.revoking = true
+	session.activeProof = sandboxruntime.JobCredentialActiveProof{}
 	session.mu.Unlock()
 
 	if l8JobCredentialRuntimeValueIsNil(ctx) {
 		ctx = context.Background()
 	}
 	if !l8JobCredentialRuntimeValueIsNil(guest) {
-		if _, err := callL8JobCredentialGuestRevoke(guest, ctx, identity, revision, reason); err != nil {
+		guestProofID, err := callL8JobCredentialGuestRevoke(guest, ctx, identity, revision, reason)
+		if err != nil {
 			return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
 		}
+		if !validL8JobCredentialRuntimeToken(guestProofID) {
+			return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
+		}
 	}
-	revokeL8JobCredentialResources(ctx, resources)
-	if !l8JobCredentialRuntimeValueIsNil(guest) {
-		_ = guest.Close()
+	if err := revokeL8JobCredentialResources(ctx, resources); err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
+	if err := callL8JobCredentialGuestClose(guest); err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
 	}
 	session.preflight.stopLossWatch()
-	observed := nowFn().UTC()
+	observed, err := callL8JobCredentialNow(nowFn)
+	if err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
 	if observed.Before(identity.IssuedAt) {
 		observed = identity.IssuedAt
 	}
@@ -560,7 +611,6 @@ func (session *l8JobCredentialRuntimeSession) Revoke(ctx context.Context, reason
 	}
 	session.mu.Lock()
 	session.revoked = true
-	session.activeProof = sandboxruntime.JobCredentialActiveProof{}
 	session.cleanupProof = proof
 	session.mu.Unlock()
 	return proof, nil
@@ -708,6 +758,179 @@ func callL8JobCredentialGuestRevoke(session l8JobCredentialGuestSession, ctx con
 	return session.Revoke(ctx, identity, revision, reason)
 }
 
+func callL8JobCredentialGuestGenerations(session l8JobCredentialGuestSession) (sessionGeneration, helperGeneration string, err error) {
+	defer func() {
+		if recover() != nil {
+			sessionGeneration, helperGeneration = "", ""
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return "", "", ErrL8JobCredentialRuntimeInvalid
+	}
+	return session.GuestSessionGeneration(), session.GuestHelperGeneration(), nil
+}
+
+func callL8JobCredentialGuestHardExpiry(session l8JobCredentialGuestSession) (hardExpiry time.Time, err error) {
+	defer func() {
+		if recover() != nil {
+			hardExpiry = time.Time{}
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return time.Time{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	return session.HardExpiry(), nil
+}
+
+func callL8JobCredentialGuestLoss(session l8JobCredentialGuestSession) (loss <-chan struct{}, err error) {
+	defer func() {
+		if recover() != nil {
+			loss = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	loss = session.Loss()
+	if loss == nil {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	return loss, nil
+}
+
+func callL8JobCredentialGuestClose(session l8JobCredentialGuestSession) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return nil
+	}
+	return session.Close()
+}
+
+func callL8JobCredentialNow(now func() time.Time) (value time.Time, err error) {
+	defer func() {
+		if recover() != nil {
+			value = time.Time{}
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if now == nil {
+		return time.Time{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	return now().UTC(), nil
+}
+
+func callL8JobCredentialHTTPActivate(activator l8JobCredentialHTTPProxyActivator, ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest, source sandboxruntime.LiveSecretSource) (handle l8JobCredentialHTTPProxyHandle, err error) {
+	defer func() {
+		if recover() != nil {
+			handle = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return activator.Activate(ctx, identity, binding, source)
+}
+
+func callL8JobCredentialHTTPServiceID(handle l8JobCredentialHTTPProxyHandle) (serviceID string, err error) {
+	defer func() {
+		if recover() != nil {
+			serviceID = ""
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.ServiceID(), nil
+}
+
+func callL8JobCredentialHTTPRenew(handle l8JobCredentialHTTPProxyHandle, ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.Renew(ctx)
+}
+
+func callL8JobCredentialHTTPRevoke(handle l8JobCredentialHTTPProxyHandle, ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.Revoke(ctx)
+}
+
+func callL8JobCredentialFileMaterialize(activator l8JobCredentialFileTmpfsActivator, ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest, source sandboxruntime.LiveSecretSource) (handle l8JobCredentialFileHandle, err error) {
+	defer func() {
+		if recover() != nil {
+			handle = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return activator.Materialize(ctx, identity, binding, source)
+}
+
+func callL8JobCredentialFileMetadata(handle l8JobCredentialFileHandle) (targetPath string, declaredBytes uint32, digest string, err error) {
+	defer func() {
+		if recover() != nil {
+			targetPath, declaredBytes, digest = "", 0, ""
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.TargetPath(), handle.DeclaredFileBytes(), handle.FileSHA256(), nil
+}
+
+func callL8JobCredentialFileRevoke(handle l8JobCredentialFileHandle, ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.Revoke(ctx)
+}
+
+func callL8JobCredentialSSHActivate(activator l8JobCredentialSSHRelayActivator, ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest) (handle l8JobCredentialSSHRelayHandle, err error) {
+	defer func() {
+		if recover() != nil {
+			handle = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return activator.Activate(ctx, identity, binding)
+}
+
+func callL8JobCredentialSSHMetadata(handle l8JobCredentialSSHRelayHandle) (policyID string, revision uint64, err error) {
+	defer func() {
+		if recover() != nil {
+			policyID, revision = "", 0
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.PolicyID(), handle.PolicyRevision(), nil
+}
+
+func callL8JobCredentialSSHRenew(handle l8JobCredentialSSHRelayHandle, ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.Renew(ctx)
+}
+
+func callL8JobCredentialSSHRevoke(handle l8JobCredentialSSHRelayHandle, ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	return handle.Revoke(ctx)
+}
+
 func cloneL8JobCredentialIdentity(identity sandboxruntime.JobCredentialIdentity) sandboxruntime.JobCredentialIdentity {
 	identity.BindingIDs = append([]string(nil), identity.BindingIDs...)
 	identity.DeliveryModes = append([]sandboxruntime.JobCredentialDeliveryMode(nil), identity.DeliveryModes...)
@@ -735,7 +958,11 @@ func l8JobCredentialRuntimeExpiry(identity sandboxruntime.JobCredentialIdentity,
 	}
 	sessionCap := identity.IssuedAt.Add(l8JobCredentialRuntimeSessionLifetime)
 	if !l8JobCredentialRuntimeValueIsNil(session) {
-		if hard := session.HardExpiry(); !hard.IsZero() && hard.Before(sessionCap) {
+		hard, err := callL8JobCredentialGuestHardExpiry(session)
+		if err != nil {
+			return time.Time{}, sanitizeL8JobCredentialRuntimeError(err)
+		}
+		if !hard.IsZero() && hard.Before(sessionCap) {
 			sessionCap = hard
 		}
 	}
@@ -827,6 +1054,32 @@ func validL8JobCredentialProductionMode(mode sandboxruntime.JobCredentialDeliver
 	}
 }
 
+func validateL8JobCredentialGuestPrepareResult(result l8JobCredentialGuestPrepareResult, manifests []l8JobCredentialGuestBindingManifest) error {
+	if !validL8JobCredentialRuntimeToken(result.ActiveProofID) || !validL8JobCredentialRuntimeToken(result.ExecBindingID) || len(result.BindingProofs) != len(manifests) {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	for index, proof := range result.BindingProofs {
+		if proof.BindingID != manifests[index].BindingID || proof.Mode != manifests[index].Mode || !validL8JobCredentialRuntimeToken(proof.ProofID) {
+			return ErrL8JobCredentialRuntimeInvalid
+		}
+	}
+	return nil
+}
+
+func validL8JobCredentialRuntimeToken(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' ||
+			character == '-' || character == '_' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func activateL8JobCredentialBindings(ctx context.Context, deps l8JobCredentialRuntimeDependencies, identity sandboxruntime.JobCredentialIdentity, request sandboxruntime.JobCredentialPrepareRequest) (*l8JobCredentialPreparedResources, error) {
 	resources := &l8JobCredentialPreparedResources{}
 	sources := make(map[string]sandboxruntime.LiveSecretSource, len(request.AuthorizedSources))
@@ -840,47 +1093,65 @@ func activateL8JobCredentialBindings(ctx context.Context, deps l8JobCredentialRu
 			if l8JobCredentialRuntimeValueIsNil(deps.HTTPProxy) {
 				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
-			handle, err := deps.HTTPProxy.Activate(ctx, identity, binding, sources[binding.SourceReferenceID])
+			handle, err := callL8JobCredentialHTTPActivate(deps.HTTPProxy, ctx, identity, binding, sources[binding.SourceReferenceID])
+			if !l8JobCredentialRuntimeValueIsNil(handle) {
+				resources.http = append(resources.http, handle)
+			}
 			if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
 				if err != nil {
 					return resources, err
 				}
 				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
-			resources.http = append(resources.http, handle)
-			manifest.ServiceID = handle.ServiceID()
-			if manifest.ServiceID == "" {
-				manifest.ServiceID = binding.ServiceID
+			manifest.ServiceID, err = callL8JobCredentialHTTPServiceID(handle)
+			if err != nil || !validL8JobCredentialRuntimeToken(manifest.ServiceID) {
+				if err != nil {
+					return resources, err
+				}
+				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
 		case sandboxruntime.JobCredentialDeliveryModeFileTmpfs:
 			if l8JobCredentialRuntimeValueIsNil(deps.FileTmpfs) {
 				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
-			handle, err := deps.FileTmpfs.Materialize(ctx, identity, binding, sources[binding.SourceReferenceID])
+			handle, err := callL8JobCredentialFileMaterialize(deps.FileTmpfs, ctx, identity, binding, sources[binding.SourceReferenceID])
+			if !l8JobCredentialRuntimeValueIsNil(handle) {
+				resources.files = append(resources.files, handle)
+			}
 			if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
 				if err != nil {
 					return resources, err
 				}
 				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
-			resources.files = append(resources.files, handle)
-			manifest.TargetPath = handle.TargetPath()
-			manifest.DeclaredFileBytes = handle.DeclaredFileBytes()
-			manifest.FileSHA256 = handle.FileSHA256()
+			manifest.TargetPath, manifest.DeclaredFileBytes, manifest.FileSHA256, err = callL8JobCredentialFileMetadata(handle)
+			if err != nil || manifest.TargetPath == "" || len(manifest.FileSHA256) != 64 {
+				if err != nil {
+					return resources, err
+				}
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
 		case sandboxruntime.JobCredentialDeliveryModeSSHAgent:
 			if l8JobCredentialRuntimeValueIsNil(deps.SSHRelay) {
 				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
-			handle, err := deps.SSHRelay.Activate(ctx, identity, binding)
+			handle, err := callL8JobCredentialSSHActivate(deps.SSHRelay, ctx, identity, binding)
+			if !l8JobCredentialRuntimeValueIsNil(handle) {
+				resources.ssh = append(resources.ssh, handle)
+			}
 			if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
 				if err != nil {
 					return resources, err
 				}
 				return resources, ErrL8JobCredentialRuntimeInvalid
 			}
-			resources.ssh = append(resources.ssh, handle)
-			manifest.SSHPolicyID = handle.PolicyID()
-			manifest.SSHPolicyRevision = handle.PolicyRevision()
+			manifest.SSHPolicyID, manifest.SSHPolicyRevision, err = callL8JobCredentialSSHMetadata(handle)
+			if err != nil || !validL8JobCredentialRuntimeToken(manifest.SSHPolicyID) || manifest.SSHPolicyRevision == 0 {
+				if err != nil {
+					return resources, err
+				}
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
 		default:
 			return resources, ErrL8JobCredentialRuntimeInvalid
 		}
@@ -894,36 +1165,44 @@ func renewL8JobCredentialResources(ctx context.Context, resources *l8JobCredenti
 		return nil
 	}
 	for _, handle := range resources.http {
-		if err := handle.Renew(ctx); err != nil {
+		if err := callL8JobCredentialHTTPRenew(handle, ctx); err != nil {
 			return err
 		}
 	}
 	for _, handle := range resources.ssh {
-		if err := handle.Renew(ctx); err != nil {
+		if err := callL8JobCredentialSSHRenew(handle, ctx); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func revokeL8JobCredentialResources(ctx context.Context, resources *l8JobCredentialPreparedResources) {
+func revokeL8JobCredentialResources(ctx context.Context, resources *l8JobCredentialPreparedResources) error {
 	if resources == nil {
-		return
+		return nil
 	}
 	if l8JobCredentialRuntimeValueIsNil(ctx) {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 	}
+	var cleanupErr error
 	for index := len(resources.http) - 1; index >= 0; index-- {
-		_ = resources.http[index].Revoke(ctx)
+		if err := callL8JobCredentialHTTPRevoke(resources.http[index], ctx); err != nil {
+			cleanupErr = ErrL8JobCredentialRuntimeUnavailable
+		}
 	}
 	for index := len(resources.files) - 1; index >= 0; index-- {
-		_ = resources.files[index].Revoke(ctx)
+		if err := callL8JobCredentialFileRevoke(resources.files[index], ctx); err != nil {
+			cleanupErr = ErrL8JobCredentialRuntimeUnavailable
+		}
 	}
 	for index := len(resources.ssh) - 1; index >= 0; index-- {
-		_ = resources.ssh[index].Revoke(ctx)
+		if err := callL8JobCredentialSSHRevoke(resources.ssh[index], ctx); err != nil {
+			cleanupErr = ErrL8JobCredentialRuntimeUnavailable
+		}
 	}
+	return cleanupErr
 }
 
 var (

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
@@ -16,10 +16,10 @@ import (
 const l8JobCredentialRuntimeValuePlaceholder = "[firecracker-l8-job-credential-runtime]"
 
 var (
-	ErrL8JobCredentialRuntimeUnavailable = errors.New("Firecracker L8 job credential runtime unavailable")
-	ErrL8JobCredentialRuntimeInvalid     = errors.New("Firecracker L8 job credential runtime invalid")
-	ErrL8JobCredentialRuntimeUnsupported = errors.New("Firecracker L8 job credential runtime unsupported")
-	ErrL8JobCredentialRuntimeSerialization = errors.New("Firecracker L8 job credential runtime serialization denied")
+	ErrL8JobCredentialRuntimeUnavailable          = errors.New("Firecracker L8 job credential runtime unavailable")
+	ErrL8JobCredentialRuntimeInvalid              = errors.New("Firecracker L8 job credential runtime invalid")
+	ErrL8JobCredentialRuntimeUnsupported          = errors.New("Firecracker L8 job credential runtime unsupported")
+	ErrL8JobCredentialRuntimeSerialization        = errors.New("Firecracker L8 job credential runtime serialization denied")
 	errL8JobCredentialRuntimeDependencyUnaccepted = errors.New("dependency_unaccepted")
 )
 
@@ -130,11 +130,469 @@ func newL8JobCredentialRuntime(deps l8JobCredentialRuntimeDependencies, producti
 }
 
 func (runtime *L8JobCredentialRuntime) PreflightJobCredentials(ctx context.Context, seed sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimePreflight, error) {
-	return nil, ErrL8JobCredentialRuntimeUnavailable
+	if runtime == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if runtime.production && !l8JobCredentialRuntimePlatformSupported() {
+		return nil, ErrL8JobCredentialRuntimeUnsupported
+	}
+	cloned, err := sandboxruntime.CloneJobCredentialIdentitySeed(seed)
+	if err != nil {
+		return nil, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+
+	runtime.mu.Lock()
+	if runtime.attempted {
+		runtime.mu.Unlock()
+		return nil, sandboxruntime.ErrJobCredentialTransition
+	}
+	runtime.attempted = true
+	deps := runtime.deps
+	runtime.mu.Unlock()
+
+	session, openErr := callL8JobCredentialGuestSessionOpener(deps.GuestSession, ctx, cloned)
+	if openErr != nil || l8JobCredentialRuntimeValueIsNil(session) {
+		if !l8JobCredentialRuntimeValueIsNil(session) {
+			_ = session.Close()
+		}
+		if openErr != nil {
+			return nil, sanitizeL8JobCredentialRuntimeError(openErr)
+		}
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(cloned, session.GuestSessionGeneration(), session.GuestHelperGeneration())
+	if err != nil {
+		_ = session.Close()
+		return nil, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	preflight := &l8JobCredentialRuntimePreflight{
+		deps:      deps,
+		identity:  cloneL8JobCredentialIdentity(identity),
+		session:   session,
+		loss:      make(chan sandboxruntime.JobCredentialLoss, 1),
+		stopWatch: make(chan struct{}),
+		watchDone: make(chan struct{}),
+		state:     l8JobCredentialPreflightOpen,
+	}
+	go preflight.watchLoss()
+	return preflight, nil
 }
 
 func (runtime *L8JobCredentialRuntime) RecoverJobCredentials(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
 	return sandboxruntime.JobCredentialCleanupProof{}, errL8JobCredentialRuntimeDependencyUnaccepted
+}
+
+type l8JobCredentialPreflightState uint8
+
+const (
+	l8JobCredentialPreflightOpen l8JobCredentialPreflightState = iota + 1
+	l8JobCredentialPreflightPreparing
+	l8JobCredentialPreflightTransferred
+	l8JobCredentialPreflightAborted
+)
+
+type l8JobCredentialRuntimePreflight struct {
+	mu              sync.Mutex
+	deps            l8JobCredentialRuntimeDependencies
+	identity        sandboxruntime.JobCredentialIdentity
+	session         l8JobCredentialGuestSession
+	loss            chan sandboxruntime.JobCredentialLoss
+	stopWatch       chan struct{}
+	watchDone       chan struct{}
+	state           l8JobCredentialPreflightState
+	lossLatched     bool
+	lossOnce        sync.Once
+	stopOnce        sync.Once
+	abortOnce       sync.Once
+	cleanupProof    sandboxruntime.JobCredentialCleanupProof
+	abortErr        error
+	resources       *l8JobCredentialPreparedResources
+	owned           *l8JobCredentialRuntimeSession
+	currentRevision uint64
+}
+
+type l8JobCredentialRuntimeSession struct {
+	mu           sync.Mutex
+	preflight    *l8JobCredentialRuntimePreflight
+	identity     sandboxruntime.JobCredentialIdentity
+	activeProof  sandboxruntime.JobCredentialActiveProof
+	cleanupProof sandboxruntime.JobCredentialCleanupProof
+	issuedAt     time.Time
+	expiresAt    time.Time
+	revision     uint64
+	guestProofID string
+	execBinding  l8JobCredentialExecBinding
+	resources    *l8JobCredentialPreparedResources
+	revoked      bool
+}
+
+type l8JobCredentialExecBinding struct {
+	id string
+}
+
+type l8JobCredentialPreparedResources struct {
+	http      []l8JobCredentialHTTPProxyHandle
+	files     []l8JobCredentialFileHandle
+	ssh       []l8JobCredentialSSHRelayHandle
+	manifests []l8JobCredentialGuestBindingManifest
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) Identity() sandboxruntime.JobCredentialIdentity {
+	if preflight == nil {
+		return sandboxruntime.JobCredentialIdentity{}
+	}
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	return cloneL8JobCredentialIdentity(preflight.identity)
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) Loss() <-chan sandboxruntime.JobCredentialLoss {
+	if preflight == nil {
+		return nil
+	}
+	return preflight.loss
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) PrepareJobCredentials(ctx context.Context, request sandboxruntime.JobCredentialPrepareRequest) (sandboxruntime.JobCredentialSession, error) {
+	if preflight == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	preflight.mu.Lock()
+	if preflight.state != l8JobCredentialPreflightOpen || preflight.lossLatched {
+		preflight.mu.Unlock()
+		return nil, sandboxruntime.ErrJobCredentialTransition
+	}
+	preflight.state = l8JobCredentialPreflightPreparing
+	identity := cloneL8JobCredentialIdentity(preflight.identity)
+	session := preflight.session
+	deps := preflight.deps
+	preflight.mu.Unlock()
+
+	if err := validateL8JobCredentialPrepareRequest(identity, request); err != nil {
+		preflight.revertPrepare()
+		return nil, err
+	}
+	resources, err := activateL8JobCredentialBindings(ctx, deps, identity, request)
+	if err != nil {
+		revokeL8JobCredentialResources(ctx, resources)
+		preflight.revertPrepare()
+		return nil, sanitizeL8JobCredentialRuntimeError(err)
+	}
+	now := deps.Now().UTC()
+	expiresAt, err := l8JobCredentialRuntimeExpiry(identity, session, now, time.Time{})
+	if err != nil {
+		revokeL8JobCredentialResources(ctx, resources)
+		preflight.revertPrepare()
+		return nil, err
+	}
+	guestResult, err := callL8JobCredentialGuestPrepare(session, ctx, identity, expiresAt, resources.manifests)
+	if err != nil || guestResult.ActiveProofID == "" || guestResult.ExecBindingID == "" {
+		revokeL8JobCredentialResources(ctx, resources)
+		preflight.revertPrepare()
+		if err != nil {
+			return nil, sanitizeL8JobCredentialRuntimeError(err)
+		}
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	proof, err := sandboxruntime.NewJobCredentialActiveProof(sandboxruntime.JobCredentialActiveProofInput{
+		ProofID: "active-1", Identity: identity, Revision: 1, IssuedAt: now, ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		revokeL8JobCredentialResources(ctx, resources)
+		preflight.revertPrepare()
+		return nil, sandboxruntime.ErrJobCredentialProofInvalid
+	}
+
+	preflight.mu.Lock()
+	if preflight.state != l8JobCredentialPreflightPreparing || preflight.lossLatched {
+		if preflight.state == l8JobCredentialPreflightPreparing {
+			preflight.state = l8JobCredentialPreflightOpen
+		}
+		preflight.mu.Unlock()
+		revokeL8JobCredentialResources(ctx, resources)
+		return nil, sandboxruntime.ErrJobCredentialTransition
+	}
+	owned := &l8JobCredentialRuntimeSession{
+		preflight:    preflight,
+		identity:     cloneL8JobCredentialIdentity(identity),
+		activeProof:  proof,
+		issuedAt:     now,
+		expiresAt:    expiresAt,
+		revision:     1,
+		guestProofID: guestResult.ActiveProofID,
+		execBinding:  l8JobCredentialExecBinding{id: guestResult.ExecBindingID},
+		resources:    resources,
+	}
+	preflight.resources = resources
+	preflight.owned = owned
+	preflight.currentRevision = 1
+	preflight.state = l8JobCredentialPreflightTransferred
+	preflight.mu.Unlock()
+	return owned, nil
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) Abort(ctx context.Context) (sandboxruntime.JobCredentialCleanupProof, error) {
+	if preflight == nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	preflight.abortOnce.Do(func() {
+		preflight.mu.Lock()
+		if preflight.state == l8JobCredentialPreflightTransferred {
+			preflight.mu.Unlock()
+			preflight.abortErr = sandboxruntime.ErrJobCredentialTransition
+			return
+		}
+		preflight.state = l8JobCredentialPreflightAborted
+		session := preflight.session
+		resources := preflight.resources
+		preflight.resources = nil
+		nowFn := preflight.deps.Now
+		identity := cloneL8JobCredentialIdentity(preflight.identity)
+		preflight.mu.Unlock()
+
+		preflight.stopLossWatch()
+		revokeL8JobCredentialResources(ctx, resources)
+		if !l8JobCredentialRuntimeValueIsNil(session) {
+			_ = session.Close()
+		}
+		observed := nowFn().UTC()
+		if observed.Before(identity.IssuedAt) {
+			observed = identity.IssuedAt
+		}
+		proof, err := sandboxruntime.NewJobCredentialCleanupProof(sandboxruntime.JobCredentialCleanupProofInput{
+			ProofID: "cleanup-2", Identity: identity, Revision: 2,
+			RevokedAt: observed, AbsenceInspectedAt: observed,
+			AuthorityAbsent: true, ResourcesAbsent: true,
+		})
+		preflight.mu.Lock()
+		preflight.cleanupProof = proof
+		preflight.abortErr = err
+		if err != nil {
+			preflight.abortErr = sandboxruntime.ErrJobCredentialProofInvalid
+		}
+		preflight.mu.Unlock()
+	})
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	if preflight.state == l8JobCredentialPreflightTransferred && preflight.abortErr == nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sandboxruntime.ErrJobCredentialTransition
+	}
+	return preflight.cleanupProof, preflight.abortErr
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) revertPrepare() {
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	if preflight.state == l8JobCredentialPreflightPreparing {
+		preflight.state = l8JobCredentialPreflightOpen
+	}
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) watchLoss() {
+	defer close(preflight.watchDone)
+	if preflight.session == nil {
+		return
+	}
+	select {
+	case <-preflight.session.Loss():
+		preflight.emitLoss(sandboxruntime.JobCredentialFailureGuestHelperUnavailable)
+	case <-preflight.stopWatch:
+	}
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) emitLoss(code sandboxruntime.JobCredentialFailureCode) {
+	preflight.lossOnce.Do(func() {
+		preflight.mu.Lock()
+		preflight.lossLatched = true
+		identity := cloneL8JobCredentialIdentity(preflight.identity)
+		revision := preflight.currentRevision
+		if revision == 0 {
+			revision = 1
+		}
+		preflight.mu.Unlock()
+		preflight.loss <- sandboxruntime.JobCredentialLoss{Identity: identity, Revision: revision, Code: code}
+		close(preflight.loss)
+	})
+}
+
+func (preflight *l8JobCredentialRuntimePreflight) stopLossWatch() {
+	preflight.stopOnce.Do(func() {
+		if preflight.stopWatch != nil {
+			close(preflight.stopWatch)
+		}
+	})
+	if preflight.watchDone != nil {
+		<-preflight.watchDone
+	}
+}
+
+func (session *l8JobCredentialRuntimeSession) ExecBinding() sandboxruntime.JobCredentialExecBinding {
+	if session == nil {
+		return nil
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.execBinding
+}
+
+func (session *l8JobCredentialRuntimeSession) ActiveProof() sandboxruntime.JobCredentialActiveProof {
+	if session == nil {
+		return sandboxruntime.JobCredentialActiveProof{}
+	}
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.activeProof
+}
+
+func (session *l8JobCredentialRuntimeSession) Loss() <-chan sandboxruntime.JobCredentialLoss {
+	if session == nil || session.preflight == nil {
+		return nil
+	}
+	return session.preflight.Loss()
+}
+
+func (session *l8JobCredentialRuntimeSession) Renew(ctx context.Context) (sandboxruntime.JobCredentialActiveProof, error) {
+	if session == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return sandboxruntime.JobCredentialActiveProof{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	session.mu.Lock()
+	if session.revoked || sandboxruntime.ActiveProofKind(session.activeProof) == "" {
+		session.mu.Unlock()
+		return sandboxruntime.JobCredentialActiveProof{}, sandboxruntime.ErrJobCredentialTransition
+	}
+	identity := cloneL8JobCredentialIdentity(session.identity)
+	previousIssued := session.issuedAt
+	previousExpiry := session.expiresAt
+	revision := session.revision
+	guestProofID := session.guestProofID
+	resources := session.resources
+	guest := session.preflight.session
+	nowFn := session.preflight.deps.Now
+	session.mu.Unlock()
+
+	now := nowFn().UTC()
+	if err := sandboxruntime.ValidateJobCredentialActiveProof(session.ActiveProof(), identity, revision, now); err != nil {
+		return sandboxruntime.JobCredentialActiveProof{}, err
+	}
+	expiresAt, err := l8JobCredentialRuntimeExpiry(identity, guest, now, previousExpiry)
+	if err != nil {
+		return sandboxruntime.JobCredentialActiveProof{}, err
+	}
+	if !now.After(previousIssued) || !expiresAt.After(previousExpiry) {
+		return sandboxruntime.JobCredentialActiveProof{}, sandboxruntime.ErrJobCredentialRevisionStale
+	}
+	if err := renewL8JobCredentialResources(ctx, resources); err != nil {
+		return sandboxruntime.JobCredentialActiveProof{}, sanitizeL8JobCredentialRuntimeError(err)
+	}
+	replacement, err := callL8JobCredentialGuestRenew(guest, ctx, identity, revision, expiresAt, guestProofID)
+	if err != nil || replacement == "" {
+		if err != nil {
+			return sandboxruntime.JobCredentialActiveProof{}, sanitizeL8JobCredentialRuntimeError(err)
+		}
+		return sandboxruntime.JobCredentialActiveProof{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	proof, err := sandboxruntime.NewJobCredentialActiveProof(sandboxruntime.JobCredentialActiveProofInput{
+		ProofID: fmt.Sprintf("active-%d", revision+1), Identity: identity, Revision: revision + 1,
+		IssuedAt: now, ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		return sandboxruntime.JobCredentialActiveProof{}, sandboxruntime.ErrJobCredentialProofInvalid
+	}
+
+	session.mu.Lock()
+	if session.revoked || session.revision != revision {
+		session.mu.Unlock()
+		return sandboxruntime.JobCredentialActiveProof{}, sandboxruntime.ErrJobCredentialTransition
+	}
+	session.activeProof = proof
+	session.issuedAt = now
+	session.expiresAt = expiresAt
+	session.revision = revision + 1
+	session.guestProofID = replacement
+	session.mu.Unlock()
+	session.preflight.mu.Lock()
+	session.preflight.currentRevision = revision + 1
+	session.preflight.mu.Unlock()
+	return proof, nil
+}
+
+func (session *l8JobCredentialRuntimeSession) Revoke(ctx context.Context, reason sandboxruntime.JobCredentialRevokeReason) (sandboxruntime.JobCredentialCleanupProof, error) {
+	if session == nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	session.mu.Lock()
+	if session.revoked {
+		proof := session.cleanupProof
+		session.mu.Unlock()
+		return proof, nil
+	}
+	identity := cloneL8JobCredentialIdentity(session.identity)
+	revision := session.revision
+	guest := session.preflight.session
+	resources := session.resources
+	nowFn := session.preflight.deps.Now
+	session.mu.Unlock()
+
+	if l8JobCredentialRuntimeValueIsNil(ctx) {
+		ctx = context.Background()
+	}
+	if !l8JobCredentialRuntimeValueIsNil(guest) {
+		if _, err := callL8JobCredentialGuestRevoke(guest, ctx, identity, revision, reason); err != nil {
+			return sandboxruntime.JobCredentialCleanupProof{}, sanitizeL8JobCredentialRuntimeError(err)
+		}
+	}
+	revokeL8JobCredentialResources(ctx, resources)
+	if !l8JobCredentialRuntimeValueIsNil(guest) {
+		_ = guest.Close()
+	}
+	session.preflight.stopLossWatch()
+	observed := nowFn().UTC()
+	if observed.Before(identity.IssuedAt) {
+		observed = identity.IssuedAt
+	}
+	proof, err := sandboxruntime.NewJobCredentialCleanupProof(sandboxruntime.JobCredentialCleanupProofInput{
+		ProofID: fmt.Sprintf("cleanup-%d", revision+1), Identity: identity, Revision: revision + 1,
+		RevokedAt: observed, AbsenceInspectedAt: observed,
+		AuthorityAbsent: true, ResourcesAbsent: true,
+	})
+	if err != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sandboxruntime.ErrJobCredentialProofInvalid
+	}
+	session.mu.Lock()
+	session.revoked = true
+	session.activeProof = sandboxruntime.JobCredentialActiveProof{}
+	session.cleanupProof = proof
+	session.mu.Unlock()
+	return proof, nil
+}
+
+func (*l8JobCredentialRuntimePreflight) String() string {
+	return l8JobCredentialRuntimeValuePlaceholder
+}
+func (*l8JobCredentialRuntimePreflight) GoString() string {
+	return l8JobCredentialRuntimeValuePlaceholder
+}
+func (*l8JobCredentialRuntimePreflight) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialRuntimeValuePlaceholder)
+}
+func (*l8JobCredentialRuntimePreflight) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*l8JobCredentialRuntimeSession) String() string {
+	return l8JobCredentialRuntimeValuePlaceholder
+}
+func (*l8JobCredentialRuntimeSession) GoString() string {
+	return l8JobCredentialRuntimeValuePlaceholder
+}
+func (*l8JobCredentialRuntimeSession) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialRuntimeValuePlaceholder)
+}
+func (*l8JobCredentialRuntimeSession) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (l8JobCredentialExecBinding) String() string { return l8JobCredentialRuntimeValuePlaceholder }
+func (l8JobCredentialExecBinding) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
 }
 
 func (*L8JobCredentialRuntime) String() string { return l8JobCredentialRuntimeValuePlaceholder }
@@ -191,14 +649,288 @@ func sanitizeL8JobCredentialRuntimeError(err error) error {
 		return ErrL8JobCredentialRuntimeInvalid
 	case errors.Is(err, errL8JobCredentialRuntimeDependencyUnaccepted):
 		return errL8JobCredentialRuntimeDependencyUnaccepted
+	case errors.Is(err, ErrL8JobCredentialRuntimeUnavailable):
+		return ErrL8JobCredentialRuntimeUnavailable
 	default:
 		return ErrL8JobCredentialRuntimeUnavailable
 	}
 }
 
+func callL8JobCredentialGuestSessionOpener(opener l8JobCredentialGuestSessionOpener, ctx context.Context, seed sandboxruntime.JobCredentialIdentitySeed) (session l8JobCredentialGuestSession, err error) {
+	defer func() {
+		if recover() != nil {
+			session = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(opener) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	return opener.Open(ctx, seed)
+}
+
+func callL8JobCredentialGuestPrepare(session l8JobCredentialGuestSession, ctx context.Context, identity sandboxruntime.JobCredentialIdentity, expiresAt time.Time, manifests []l8JobCredentialGuestBindingManifest) (result l8JobCredentialGuestPrepareResult, err error) {
+	defer func() {
+		if recover() != nil {
+			result = l8JobCredentialGuestPrepareResult{}
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return l8JobCredentialGuestPrepareResult{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	return session.Prepare(ctx, identity, expiresAt, manifests)
+}
+
+func callL8JobCredentialGuestRenew(session l8JobCredentialGuestSession, ctx context.Context, identity sandboxruntime.JobCredentialIdentity, revision uint64, expiresAt time.Time, priorProofID string) (replacement string, err error) {
+	defer func() {
+		if recover() != nil {
+			replacement = ""
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	return session.Renew(ctx, identity, revision, expiresAt, priorProofID)
+}
+
+func callL8JobCredentialGuestRevoke(session l8JobCredentialGuestSession, ctx context.Context, identity sandboxruntime.JobCredentialIdentity, revision uint64, reason sandboxruntime.JobCredentialRevokeReason) (proofID string, err error) {
+	defer func() {
+		if recover() != nil {
+			proofID = ""
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(session) {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	return session.Revoke(ctx, identity, revision, reason)
+}
+
+func cloneL8JobCredentialIdentity(identity sandboxruntime.JobCredentialIdentity) sandboxruntime.JobCredentialIdentity {
+	identity.BindingIDs = append([]string(nil), identity.BindingIDs...)
+	identity.DeliveryModes = append([]sandboxruntime.JobCredentialDeliveryMode(nil), identity.DeliveryModes...)
+	return identity
+}
+
+func sameL8JobCredentialIdentity(left, right sandboxruntime.JobCredentialIdentity) bool {
+	leftDigest, leftErr := sandboxruntime.JobCredentialIdentityDigest(left)
+	rightDigest, rightErr := sandboxruntime.JobCredentialIdentityDigest(right)
+	return leftErr == nil && rightErr == nil && leftDigest == rightDigest
+}
+
+func l8JobCredentialRuntimeExpiry(identity sandboxruntime.JobCredentialIdentity, session l8JobCredentialGuestSession, issuedAt, previousExpiry time.Time) (time.Time, error) {
+	if issuedAt.IsZero() || issuedAt.Before(identity.IssuedAt) {
+		return time.Time{}, sandboxruntime.ErrJobCredentialProofInvalid
+	}
+	lifetime := 20 * time.Minute
+	if !previousExpiry.IsZero() {
+		lifetime = 30 * time.Minute
+	}
+	expiresAt := issuedAt.Add(lifetime)
+	maxExpiry := identity.IssuedAt.Add(sandboxruntime.MaxJobCredentialLifetime)
+	if expiresAt.After(maxExpiry) {
+		expiresAt = maxExpiry
+	}
+	sessionCap := identity.IssuedAt.Add(l8JobCredentialRuntimeSessionLifetime)
+	if !l8JobCredentialRuntimeValueIsNil(session) {
+		if hard := session.HardExpiry(); !hard.IsZero() && hard.Before(sessionCap) {
+			sessionCap = hard
+		}
+	}
+	if expiresAt.After(sessionCap) {
+		expiresAt = sessionCap
+	}
+	if !expiresAt.After(issuedAt) || expiresAt.Sub(identity.IssuedAt) > sandboxruntime.MaxJobCredentialLifetime {
+		return time.Time{}, sandboxruntime.ErrJobCredentialProofInvalid
+	}
+	if !previousExpiry.IsZero() && !expiresAt.After(previousExpiry) {
+		return time.Time{}, sandboxruntime.ErrJobCredentialRevisionStale
+	}
+	return expiresAt, nil
+}
+
+func validateL8JobCredentialPrepareRequest(identity sandboxruntime.JobCredentialIdentity, request sandboxruntime.JobCredentialPrepareRequest) error {
+	if sandboxruntime.ValidateJobCredentialIdentity(request.Identity) != nil || !sameL8JobCredentialIdentity(identity, request.Identity) {
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	if l8JobCredentialRuntimeValueIsNil(request.Authorization) {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	admission := request.Admission
+	if admission.GrantID != identity.AdmissionGrantID || admission.GrantRevision != identity.AdmissionGrantRevision ||
+		admission.PlanID != identity.PlanID || admission.TemplatePolicyID != identity.TemplatePolicyID ||
+		admission.WorkspacePolicyID != identity.WorkspacePolicyID ||
+		!sameL8JobCredentialAdmissionIdentity(identity, admission.Identity) {
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	if len(admission.Bindings) != len(identity.BindingIDs) {
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	needed := make(map[string]struct{}, len(identity.BindingIDs))
+	for index, binding := range admission.Bindings {
+		if binding.ID != identity.BindingIDs[index] {
+			return sandboxruntime.ErrJobCredentialIdentityMismatch
+		}
+		if !validL8JobCredentialProductionMode(binding.Mode) {
+			return ErrL8JobCredentialRuntimeInvalid
+		}
+		if binding.Mode != identity.DeliveryModes[index] {
+			return sandboxruntime.ErrJobCredentialIdentityMismatch
+		}
+		if binding.Mode != sandboxruntime.JobCredentialDeliveryModeSSHAgent {
+			if binding.SourceReferenceID == "" {
+				return ErrL8JobCredentialRuntimeInvalid
+			}
+			needed[binding.SourceReferenceID] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(request.AuthorizedSources))
+	for _, source := range request.AuthorizedSources {
+		if _, required := needed[source.ReferenceID]; !required || l8JobCredentialRuntimeValueIsNil(source.Source) {
+			return ErrL8JobCredentialRuntimeInvalid
+		}
+		if _, duplicate := seen[source.ReferenceID]; duplicate {
+			return ErrL8JobCredentialRuntimeInvalid
+		}
+		seen[source.ReferenceID] = struct{}{}
+	}
+	if len(seen) != len(needed) {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	return nil
+}
+
+func sameL8JobCredentialAdmissionIdentity(identity sandboxruntime.JobCredentialIdentity, admission sandboxruntime.JobCredentialAdmissionIdentity) bool {
+	return admission.SandboxID == identity.SandboxID && admission.ExecutionID == identity.ExecutionID &&
+		admission.WorkerID == identity.WorkerID && admission.HostID == identity.HostID &&
+		admission.RuntimeDriver == identity.RuntimeDriver && admission.RuntimeID == identity.RuntimeID &&
+		admission.RuntimeGeneration == identity.RuntimeGeneration &&
+		admission.FirecrackerProcessGeneration == identity.FirecrackerProcessGeneration &&
+		admission.VsockGeneration == identity.VsockGeneration && admission.WorkerJobID == identity.WorkerJobID &&
+		admission.SubmissionID == identity.SubmissionID && admission.PlanID == identity.PlanID &&
+		admission.ActivationGeneration == identity.ActivationGeneration &&
+		admission.CredentialGeneration == identity.CredentialGeneration &&
+		admission.NetworkPlanID == identity.NetworkPlanID && admission.PolicySnapshotID == identity.PolicySnapshotID &&
+		admission.ProxySessionID == identity.ProxySessionID && admission.ProxyGenerationID == identity.ProxyGenerationID &&
+		admission.TopologyGenerationID == identity.TopologyGenerationID &&
+		admission.RuleGenerationID == identity.RuleGenerationID && admission.IssuedAt.Equal(identity.IssuedAt)
+}
+
+func validL8JobCredentialProductionMode(mode sandboxruntime.JobCredentialDeliveryMode) bool {
+	switch mode {
+	case sandboxruntime.JobCredentialDeliveryModeHTTPProxy, sandboxruntime.JobCredentialDeliveryModeFileTmpfs, sandboxruntime.JobCredentialDeliveryModeSSHAgent:
+		return true
+	default:
+		return false
+	}
+}
+
+func activateL8JobCredentialBindings(ctx context.Context, deps l8JobCredentialRuntimeDependencies, identity sandboxruntime.JobCredentialIdentity, request sandboxruntime.JobCredentialPrepareRequest) (*l8JobCredentialPreparedResources, error) {
+	resources := &l8JobCredentialPreparedResources{}
+	sources := make(map[string]sandboxruntime.LiveSecretSource, len(request.AuthorizedSources))
+	for _, source := range request.AuthorizedSources {
+		sources[source.ReferenceID] = source.Source
+	}
+	for _, binding := range request.Admission.Bindings {
+		manifest := l8JobCredentialGuestBindingManifest{BindingID: binding.ID, Mode: binding.Mode}
+		switch binding.Mode {
+		case sandboxruntime.JobCredentialDeliveryModeHTTPProxy:
+			if l8JobCredentialRuntimeValueIsNil(deps.HTTPProxy) {
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
+			handle, err := deps.HTTPProxy.Activate(ctx, identity, binding, sources[binding.SourceReferenceID])
+			if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+				if err != nil {
+					return resources, err
+				}
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
+			resources.http = append(resources.http, handle)
+			manifest.ServiceID = handle.ServiceID()
+			if manifest.ServiceID == "" {
+				manifest.ServiceID = binding.ServiceID
+			}
+		case sandboxruntime.JobCredentialDeliveryModeFileTmpfs:
+			if l8JobCredentialRuntimeValueIsNil(deps.FileTmpfs) {
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
+			handle, err := deps.FileTmpfs.Materialize(ctx, identity, binding, sources[binding.SourceReferenceID])
+			if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+				if err != nil {
+					return resources, err
+				}
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
+			resources.files = append(resources.files, handle)
+			manifest.TargetPath = handle.TargetPath()
+			manifest.DeclaredFileBytes = handle.DeclaredFileBytes()
+			manifest.FileSHA256 = handle.FileSHA256()
+		case sandboxruntime.JobCredentialDeliveryModeSSHAgent:
+			if l8JobCredentialRuntimeValueIsNil(deps.SSHRelay) {
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
+			handle, err := deps.SSHRelay.Activate(ctx, identity, binding)
+			if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+				if err != nil {
+					return resources, err
+				}
+				return resources, ErrL8JobCredentialRuntimeInvalid
+			}
+			resources.ssh = append(resources.ssh, handle)
+			manifest.SSHPolicyID = handle.PolicyID()
+			manifest.SSHPolicyRevision = handle.PolicyRevision()
+		default:
+			return resources, ErrL8JobCredentialRuntimeInvalid
+		}
+		resources.manifests = append(resources.manifests, manifest)
+	}
+	return resources, nil
+}
+
+func renewL8JobCredentialResources(ctx context.Context, resources *l8JobCredentialPreparedResources) error {
+	if resources == nil {
+		return nil
+	}
+	for _, handle := range resources.http {
+		if err := handle.Renew(ctx); err != nil {
+			return err
+		}
+	}
+	for _, handle := range resources.ssh {
+		if err := handle.Renew(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func revokeL8JobCredentialResources(ctx context.Context, resources *l8JobCredentialPreparedResources) {
+	if resources == nil {
+		return
+	}
+	if l8JobCredentialRuntimeValueIsNil(ctx) {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+	}
+	for index := len(resources.http) - 1; index >= 0; index-- {
+		_ = resources.http[index].Revoke(ctx)
+	}
+	for index := len(resources.files) - 1; index >= 0; index-- {
+		_ = resources.files[index].Revoke(ctx)
+	}
+	for index := len(resources.ssh) - 1; index >= 0; index-- {
+		_ = resources.ssh[index].Revoke(ctx)
+	}
+}
+
 var (
-	_ sandboxruntime.JobCredentialRuntime = (*L8JobCredentialRuntime)(nil)
-	_ fmt.Stringer                        = (*L8JobCredentialRuntime)(nil)
+	_ sandboxruntime.JobCredentialRuntime          = (*L8JobCredentialRuntime)(nil)
+	_ sandboxruntime.JobCredentialRuntimePreflight = (*l8JobCredentialRuntimePreflight)(nil)
+	_ sandboxruntime.JobCredentialSession          = (*l8JobCredentialRuntimeSession)(nil)
+	_ fmt.Stringer                                 = (*L8JobCredentialRuntime)(nil)
 )
 
 const l8JobCredentialRuntimeSessionLifetime = guestsession.MaxGuestCredentialSessionLifetime

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_linux.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package firecrackerhost
+
+func l8JobCredentialRuntimePlatformSupported() bool { return true }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_linux_test.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"testing"
+	"time"
+)
+
+func TestL8JobCredentialRuntimeLinuxProductionConstructorAcceptsInjectedFakes(t *testing.T) {
+	now := time.Date(2026, time.August, 28, 4, 5, 6, 0, time.UTC)
+	runtime, err := NewProductionL8JobCredentialRuntime(l8JobCredentialRuntimeTestDeps(t, now, nil, nil, nil, nil))
+	if err != nil || runtime == nil || !runtime.production {
+		t.Fatalf("NewProductionL8JobCredentialRuntime = %#v, %v", runtime, err)
+	}
+}
+
+func TestL8JobCredentialRuntimeLinuxPlatformIsSupported(t *testing.T) {
+	if !l8JobCredentialRuntimePlatformSupported() {
+		t.Fatal("linux job credential runtime reported unsupported")
+	}
+	if ErrL8JobCredentialRuntimeUnsupported == nil {
+		t.Fatal("unsupported sentinel missing")
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_other.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package firecrackerhost
+
+func l8JobCredentialRuntimePlatformSupported() bool { return false }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_other_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_other_test.go
@@ -1,0 +1,48 @@
+//go:build !linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8JobCredentialRuntimeNonLinuxFailsClosedBeforeSession(t *testing.T) {
+	if l8JobCredentialRuntimePlatformSupported() {
+		t.Fatal("non-Linux job credential runtime reported support")
+	}
+	now := time.Date(2026, time.August, 28, 4, 5, 6, 0, time.UTC)
+	opener := &l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}
+	runtime, err := NewProductionL8JobCredentialRuntime(l8JobCredentialRuntimeDependencies{
+		GuestSession: opener,
+		Now:          func() time.Time { return now },
+		Random:       bytesReaderForTest(),
+	})
+	if runtime != nil || !errors.Is(err, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("production constructor = %#v, %v", runtime, err)
+	}
+	if opener.calls != 0 {
+		t.Fatalf("non-Linux constructor opened a guest session: calls=%d", opener.calls)
+	}
+
+	production := &L8JobCredentialRuntime{
+		deps: l8JobCredentialRuntimeDependencies{
+			GuestSession: opener,
+			Now:          func() time.Time { return now },
+			Random:       bytesReaderForTest(),
+		},
+		production: true,
+	}
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	preflight, preflightErr := production.PreflightJobCredentials(context.Background(), seed)
+	if preflight != nil || !errors.Is(preflightErr, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("non-Linux production preflight = %#v, %v", preflight, preflightErr)
+	}
+	if opener.calls != 0 {
+		t.Fatalf("non-Linux production preflight opened a guest session: calls=%d", opener.calls)
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_review_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_review_test.go
@@ -1,0 +1,190 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8JobCredentialRuntimeDoesNotProveCleanupWhenResourceRevokeFails(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now,
+		&l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)},
+		&l8JobCredentialHTTPProxyFake{}, &l8JobCredentialFileTmpfsFake{payload: []byte("file")}, nil,
+	)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionValue, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := sessionValue.(*l8JobCredentialRuntimeSession)
+	failing := &l8JobCredentialReviewHTTPHandle{revokeErr: errors.New("secret cleanup failure")}
+	session.resources.http = append(session.resources.http, failing)
+
+	proof, err := session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested"))
+	if sandboxruntime.CleanupProofKind(proof) != "" || !errors.Is(err, ErrL8JobCredentialRuntimeUnavailable) {
+		t.Fatalf("cleanup failure returned proof=%#v err=%v", proof, err)
+	}
+	if sandboxruntime.ActiveProofKind(session.ActiveProof()) == "" {
+		t.Fatal("cleanup failure discarded the still-owned active proof")
+	}
+	if failing.revokes != 1 {
+		t.Fatalf("failing revoke calls=%d, want 1", failing.revokes)
+	}
+
+	failing.revokeErr = nil
+	proof, err = session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialCleanupProof(proof, identity, 2, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("retry cleanup proof: %v", err)
+	}
+}
+
+func TestL8JobCredentialRuntimeReclaimsValuePlusErrorActivationHandle(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeHTTPProxy})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8JobCredentialRuntimePrepareRequest(t, identity)
+	handle := &l8JobCredentialReviewHTTPHandle{serviceID: request.Admission.Bindings[0].ServiceID}
+	activator := &l8JobCredentialReviewHTTPActivator{handle: handle, err: errors.New("private activation failure")}
+	runtime := l8JobCredentialRuntimeForTest(t, now,
+		&l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}, activator, nil, nil,
+	)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if !l8JobCredentialRuntimeValueIsNil(result) || !errors.Is(err, ErrL8JobCredentialRuntimeUnavailable) {
+		t.Fatalf("prepare value+error = %#v, %v", result, err)
+	}
+	if handle.revokes != 1 {
+		t.Fatalf("returned activation handle revokes=%d, want 1", handle.revokes)
+	}
+}
+
+func TestL8JobCredentialRuntimeRejectsIncompleteGuestBindingProofs(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, _, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := &l8JobCredentialReviewGuestSession{
+		l8JobCredentialGuestSessionFake: l8JobCredentialGuestSessionFakeForTest(t, now),
+		prepareResult: l8JobCredentialGuestPrepareResult{
+			ActiveProofID: "guest-active-1",
+			ExecBindingID: "exec-binding-1",
+		},
+	}
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest},
+		&l8JobCredentialHTTPProxyFake{}, &l8JobCredentialFileTmpfsFake{payload: []byte("file")}, nil,
+	)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if !l8JobCredentialRuntimeValueIsNil(session) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("prepare without binding proofs = %#v, %v", session, err)
+	}
+}
+
+func TestL8JobCredentialRuntimeAbortWaitsForInFlightPrepareOwnership(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeHTTPProxy})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8JobCredentialRuntimePrepareRequest(t, identity)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	activator := &l8JobCredentialReviewHTTPActivator{entered: entered, release: release, handle: &l8JobCredentialReviewHTTPHandle{serviceID: request.Admission.Bindings[0].ServiceID}}
+	runtime := l8JobCredentialRuntimeForTest(t, now,
+		&l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}, activator, nil, nil,
+	)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepareDone := make(chan error, 1)
+	go func() {
+		_, prepareErr := preflight.PrepareJobCredentials(context.Background(), request)
+		prepareDone <- prepareErr
+	}()
+	<-entered
+	abortDone := make(chan struct {
+		proof sandboxruntime.JobCredentialCleanupProof
+		err   error
+	}, 1)
+	go func() {
+		proof, abortErr := preflight.Abort(context.Background())
+		abortDone <- struct {
+			proof sandboxruntime.JobCredentialCleanupProof
+			err   error
+		}{proof: proof, err: abortErr}
+	}()
+	select {
+	case result := <-abortDone:
+		t.Fatalf("abort returned before prepare ownership converged: proof=%#v err=%v", result.proof, result.err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	if err := <-prepareDone; err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	result := <-abortDone
+	if sandboxruntime.CleanupProofKind(result.proof) != "" || !errors.Is(result.err, sandboxruntime.ErrJobCredentialTransition) {
+		t.Fatalf("abort after transfer = %#v, %v", result.proof, result.err)
+	}
+}
+
+type l8JobCredentialReviewHTTPActivator struct {
+	handle  l8JobCredentialHTTPProxyHandle
+	err     error
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (value *l8JobCredentialReviewHTTPActivator) Activate(context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest, sandboxruntime.LiveSecretSource) (l8JobCredentialHTTPProxyHandle, error) {
+	if value.entered != nil {
+		close(value.entered)
+		<-value.release
+	}
+	return value.handle, value.err
+}
+
+type l8JobCredentialReviewHTTPHandle struct {
+	mu        sync.Mutex
+	serviceID string
+	revokeErr error
+	revokes   int
+}
+
+func (value *l8JobCredentialReviewHTTPHandle) ServiceID() string     { return value.serviceID }
+func (*l8JobCredentialReviewHTTPHandle) Renew(context.Context) error { return nil }
+func (value *l8JobCredentialReviewHTTPHandle) Revoke(context.Context) error {
+	value.mu.Lock()
+	defer value.mu.Unlock()
+	value.revokes++
+	return value.revokeErr
+}
+
+type l8JobCredentialReviewGuestSession struct {
+	*l8JobCredentialGuestSessionFake
+	prepareResult l8JobCredentialGuestPrepareResult
+}
+
+func (value *l8JobCredentialReviewGuestSession) Prepare(context.Context, sandboxruntime.JobCredentialIdentity, time.Time, []l8JobCredentialGuestBindingManifest) (l8JobCredentialGuestPrepareResult, error) {
+	return value.prepareResult, nil
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_review_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_review_test.go
@@ -33,8 +33,8 @@ func TestL8JobCredentialRuntimeDoesNotProveCleanupWhenResourceRevokeFails(t *tes
 	if sandboxruntime.CleanupProofKind(proof) != "" || !errors.Is(err, ErrL8JobCredentialRuntimeUnavailable) {
 		t.Fatalf("cleanup failure returned proof=%#v err=%v", proof, err)
 	}
-	if sandboxruntime.ActiveProofKind(session.ActiveProof()) == "" {
-		t.Fatal("cleanup failure discarded the still-owned active proof")
+	if sandboxruntime.ActiveProofKind(session.ActiveProof()) != "" {
+		t.Fatal("cleanup failure left revoking authority projected as active")
 	}
 	if failing.revokes != 1 {
 		t.Fatalf("failing revoke calls=%d, want 1", failing.revokes)

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_test.go
@@ -1,0 +1,936 @@
+package firecrackerhost
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecracker"
+)
+
+func TestL8JobCredentialRuntimePublicAPIIsExact(t *testing.T) {
+	constructor := reflect.TypeOf(NewProductionL8JobCredentialRuntime)
+	wantConstructor := reflect.TypeOf((func(l8JobCredentialRuntimeDependencies) (*L8JobCredentialRuntime, error))(nil))
+	if constructor != wantConstructor {
+		t.Fatalf("NewProductionL8JobCredentialRuntime type = %v, want %v", constructor, wantConstructor)
+	}
+	runtimeType := reflect.TypeOf((*L8JobCredentialRuntime)(nil))
+	l8D6AssertExactExportedMethodSet(t, runtimeType, map[string]reflect.Type{
+		"Format":                    reflect.TypeOf((func(*L8JobCredentialRuntime, fmt.State, rune))(nil)),
+		"GoString":                  reflect.TypeOf((func(*L8JobCredentialRuntime) string)(nil)),
+		"MarshalBinary":             reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
+		"MarshalJSON":               reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
+		"MarshalText":               reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
+		"PreflightJobCredentials":   reflect.TypeOf((func(*L8JobCredentialRuntime, context.Context, sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimePreflight, error))(nil)),
+		"RecoverJobCredentials":     reflect.TypeOf((func(*L8JobCredentialRuntime, context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error))(nil)),
+		"String":                    reflect.TypeOf((func(*L8JobCredentialRuntime) string)(nil)),
+	})
+	var _ sandboxruntime.JobCredentialRuntime = (*L8JobCredentialRuntime)(nil)
+}
+
+func TestL8JobCredentialRuntimePreflightCompletesIdentityAndOwnsSlices(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{
+		sandboxruntime.JobCredentialDeliveryModeHTTPProxy,
+		sandboxruntime.JobCredentialDeliveryModeFileTmpfs,
+	})
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	httpProxy := &l8JobCredentialHTTPProxyFake{}
+	tmpfs := &l8JobCredentialFileTmpfsFake{payload: []byte("tmpfs-canary")}
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, httpProxy, tmpfs, nil)
+
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(preflight) {
+		t.Fatalf("PreflightJobCredentials = %#v, %v", preflight, err)
+	}
+	identity := preflight.Identity()
+	if err := sandboxruntime.ValidateJobCredentialIdentityCompletion(seed, identity); err != nil {
+		t.Fatalf("preflight identity is not the seed completion: %v", err)
+	}
+	if identity.GuestSessionGeneration != guest.GuestSessionGeneration() || identity.GuestHelperGeneration != guest.GuestHelperGeneration() {
+		t.Fatalf("guest generations = %q/%q, want %q/%q", identity.GuestSessionGeneration, identity.GuestHelperGeneration, guest.GuestSessionGeneration(), guest.GuestHelperGeneration())
+	}
+	identity.BindingIDs[0] = "caller-mutated"
+	identity.DeliveryModes[0] = sandboxruntime.JobCredentialDeliveryModeSSHAgent
+	second := preflight.Identity()
+	if err := sandboxruntime.ValidateJobCredentialIdentityCompletion(seed, second); err != nil {
+		t.Fatalf("Identity retained caller-owned slices: %v", err)
+	}
+	if second.BindingIDs[0] != seed.BindingIDs[0] || second.DeliveryModes[0] != seed.DeliveryModes[0] {
+		t.Fatal("Identity did not return a defensive deep copy")
+	}
+	if httpProxy.activates != 0 || tmpfs.materializes != 0 {
+		t.Fatalf("preflight activated delivery adapters: http=%d tmpfs=%d", httpProxy.activates, tmpfs.materializes)
+	}
+}
+
+func TestL8JobCredentialRuntimePreflightRejectsPartialStaleAndCrossJobSeed(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	valid := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	opener := &l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}
+	runtime := l8JobCredentialRuntimeForTest(t, now, opener, nil, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+
+	partial := valid
+	partial.RuntimeGeneration = ""
+	if preflight, err := runtime.PreflightJobCredentials(context.Background(), partial); !l8JobCredentialRuntimeValueIsNil(preflight) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("partial seed = %#v, %v", preflight, err)
+	}
+	if opener.calls != 0 {
+		t.Fatal("partial seed opened a guest session")
+	}
+
+	neighbor := valid
+	neighbor.WorkerJobID = "job-neighbor"
+	runtime = l8JobCredentialRuntimeForTest(t, now, opener, nil, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+	if _, err := runtime.PreflightJobCredentials(context.Background(), neighbor); err != nil {
+		t.Fatalf("neighbor seed preflight setup: %v", err)
+	}
+}
+
+func TestL8JobCredentialRuntimePrepareTransfersSessionAndIssuesActiveProof(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	httpProxy := &l8JobCredentialHTTPProxyFake{}
+	tmpfs := &l8JobCredentialFileTmpfsFake{payload: []byte("file-bytes")}
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, httpProxy, tmpfs, nil)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(session) {
+		t.Fatalf("PrepareJobCredentials = %#v, %v", session, err)
+	}
+	if httpProxy.activates != 1 || tmpfs.materializes != 1 || guest.prepares != 1 {
+		t.Fatalf("prepare activations http=%d tmpfs=%d guest=%d", httpProxy.activates, tmpfs.materializes, guest.prepares)
+	}
+	proof := session.ActiveProof()
+	if err := sandboxruntime.ValidateJobCredentialActiveProof(proof, identity, 1, now.Add(time.Second)); err != nil {
+		t.Fatalf("active proof: %v", err)
+	}
+	if sandboxruntime.ActiveProofKind(proof) == "" {
+		t.Fatal("active proof kind is empty")
+	}
+	if l8JobCredentialRuntimeValueIsNil(session.ExecBinding()) {
+		t.Fatal("exec binding was nil")
+	}
+	if session.Loss() != preflight.Loss() {
+		t.Fatal("preflight and session do not expose the same loss latch")
+	}
+	if second, err := preflight.PrepareJobCredentials(context.Background(), request); !l8JobCredentialRuntimeValueIsNil(second) || !errors.Is(err, sandboxruntime.ErrJobCredentialTransition) {
+		t.Fatalf("second prepare = %#v, %v", second, err)
+	}
+	if proof, err := preflight.Abort(context.Background()); sandboxruntime.CleanupProofKind(proof) != "" || !errors.Is(err, sandboxruntime.ErrJobCredentialTransition) {
+		t.Fatalf("abort after transfer = %#v, %v", proof, err)
+	}
+}
+
+func TestL8JobCredentialRuntimePrepareRejectsEnvLegacyAndSimulatedModes(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, _, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	request.Admission.Bindings[0].Mode = "env"
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, &l8JobCredentialHTTPProxyFake{}, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, prepareErr := preflight.PrepareJobCredentials(context.Background(), request)
+	if !l8JobCredentialRuntimeValueIsNil(session) || prepareErr == nil {
+		t.Fatalf("env mode prepare = %#v, %v", session, prepareErr)
+	}
+	l8JobCredentialRuntimeAssertSafeError(t, prepareErr)
+	if guest.prepares != 0 {
+		t.Fatal("env/legacy prepare reached the guest session")
+	}
+	for _, mode := range []sandboxruntime.JobCredentialDeliveryMode{"legacy_auth_sync", "simulated"} {
+		request.Admission.Bindings[0].Mode = mode
+		if session, err := preflight.PrepareJobCredentials(context.Background(), request); !l8JobCredentialRuntimeValueIsNil(session) || err == nil {
+			t.Fatalf("mode %q prepare = %#v, %v", mode, session, err)
+		}
+	}
+}
+
+func TestL8JobCredentialRuntimeAbortIsIdempotentBeforeTransfer(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, &l8JobCredentialHTTPProxyFake{}, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := preflight.Abort(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := preflight.Abort(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("repeated abort did not return the identical cleanup proof")
+	}
+	if err := sandboxruntime.ValidateJobCredentialCleanupProof(first, identity, 2, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("abort cleanup proof: %v", err)
+	}
+	if session, err := preflight.PrepareJobCredentials(context.Background(), request); !l8JobCredentialRuntimeValueIsNil(session) || !errors.Is(err, sandboxruntime.ErrJobCredentialTransition) {
+		t.Fatalf("prepare after abort = %#v, %v", session, err)
+	}
+	if guest.closed != 1 {
+		t.Fatalf("guest session closes = %d, want 1", guest.closed)
+	}
+}
+
+func TestL8JobCredentialRuntimeSessionRenewRevokeAndReplay(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	clock := &l8JobCredentialRuntimeClock{now: now.Add(time.Second)}
+	seed, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	httpProxy := &l8JobCredentialHTTPProxyFake{}
+	tmpfs := &l8JobCredentialFileTmpfsFake{payload: []byte("file-bytes")}
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, httpProxy, tmpfs, nil)
+	runtime.deps.Now = clock.Now
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clock.now = now.Add(2 * time.Second)
+	renewed, err := session.Renew(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialActiveProof(renewed, identity, 2, clock.now); err != nil {
+		t.Fatalf("renewed proof: %v", err)
+	}
+	if session.ActiveProof() != renewed {
+		t.Fatal("session did not retain the renewed active proof")
+	}
+	if httpProxy.renews != 1 || guest.renews != 1 {
+		t.Fatalf("renew activations http=%d guest=%d", httpProxy.renews, guest.renews)
+	}
+
+	cleanup, err := session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialCleanupProof(cleanup, identity, 3, clock.now); err != nil {
+		t.Fatalf("revoke cleanup proof: %v", err)
+	}
+	if sandboxruntime.ActiveProofKind(session.ActiveProof()) != "" {
+		t.Fatal("revoked session retained an active proof")
+	}
+	if httpProxy.revokes != 1 || tmpfs.revokes != 1 || guest.revokes != 1 {
+		t.Fatalf("revoke activations http=%d tmpfs=%d guest=%d", httpProxy.revokes, tmpfs.revokes, guest.revokes)
+	}
+	again, err := session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again != cleanup {
+		t.Fatal("repeated revoke changed the durable cleanup proof")
+	}
+	if _, err := session.Renew(context.Background()); !errors.Is(err, sandboxruntime.ErrJobCredentialTransition) && !errors.Is(err, sandboxruntime.ErrJobCredentialReplayRejected) {
+		t.Fatalf("renew after revoke = %v", err)
+	}
+}
+
+func TestL8JobCredentialRuntimeFailClosedOnStaleCrossJobAndPartialIdentity(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, &l8JobCredentialHTTPProxyFake{}, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cross := request
+	cross.Identity.WorkerJobID = "job-neighbor"
+	if session, err := preflight.PrepareJobCredentials(context.Background(), cross); !l8JobCredentialRuntimeValueIsNil(session) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("cross-job prepare = %#v, %v", session, err)
+	}
+
+	partial := request
+	partial.Identity.AdmissionGrantID = ""
+	session, prepareErr := preflight.PrepareJobCredentials(context.Background(), partial)
+	if !l8JobCredentialRuntimeValueIsNil(session) || prepareErr == nil {
+		t.Fatalf("partial identity prepare = %#v, %v", session, prepareErr)
+	}
+	l8JobCredentialRuntimeAssertSafeError(t, prepareErr)
+
+	stale := request
+	stale.Identity.RuntimeGeneration = "runtime-generation-stale"
+	if session, err := preflight.PrepareJobCredentials(context.Background(), stale); !l8JobCredentialRuntimeValueIsNil(session) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("stale generation prepare = %#v, %v", session, err)
+	}
+	if guest.prepares != 0 {
+		t.Fatal("invalid prepare reached the guest session")
+	}
+
+	session, err = preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialActiveProof(session.ActiveProof(), identity, 1, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestL8JobCredentialRuntimeLossEmitsOneValueThenCloses(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, &l8JobCredentialHTTPProxyFake{}, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guest.emitLoss()
+	got, ok := <-session.Loss()
+	if !ok || got.Revision != 1 || got.Code != sandboxruntime.JobCredentialFailureGuestHelperUnavailable {
+		t.Fatalf("loss = %#v, %t", got, ok)
+	}
+	if digest, err := sandboxruntime.JobCredentialIdentityDigest(got.Identity); err != nil {
+		t.Fatal(err)
+	} else if want, err := sandboxruntime.JobCredentialIdentityDigest(identity); err != nil || digest != want {
+		t.Fatalf("loss identity digest mismatch: %v", err)
+	}
+	if _, ok := <-session.Loss(); ok {
+		t.Fatal("loss channel emitted more than one value")
+	}
+}
+
+func TestL8JobCredentialRuntimeRecoverIsDependencyUnaccepted(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}, nil, nil, nil)
+	proof, err := runtime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{})
+	if sandboxruntime.CleanupProofKind(proof) != "" || !errors.Is(err, errL8JobCredentialRuntimeDependencyUnaccepted) {
+		t.Fatalf("RecoverJobCredentials = %#v, %v", proof, err)
+	}
+	if err.Error() != "dependency_unaccepted" {
+		t.Fatalf("recover error = %q, want dependency_unaccepted", err)
+	}
+	source, err := os.ReadFile("l8_job_credential_runtime.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(source, []byte("NewJobCredentialRuntimeAbsenceProof")) {
+		t.Fatal("job credential runtime issued a runtime absence proof")
+	}
+}
+
+func TestL8JobCredentialRuntimeSanitizeErrorsAndDenySerialization(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	canary := "/private/runtime.sock OPENAI_API_KEY=sk_live_canary"
+	opener := &l8JobCredentialGuestSessionOpenerFake{err: errors.New(canary)}
+	runtime := l8JobCredentialRuntimeForTest(t, now, opener, nil, nil, nil)
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if !l8JobCredentialRuntimeValueIsNil(preflight) || err == nil {
+		t.Fatalf("canary preflight = %#v, %v", preflight, err)
+	}
+	l8JobCredentialRuntimeAssertSafeError(t, err)
+	if strings.Contains(err.Error(), canary) || strings.Contains(err.Error(), "sk_live") || strings.Contains(err.Error(), "/private/") {
+		t.Fatalf("preflight leaked canary: %v", err)
+	}
+
+	values := []any{runtime, &L8JobCredentialRuntime{}}
+	for _, value := range values {
+		if encoded, marshalErr := json.Marshal(value); marshalErr == nil || encoded != nil || !errors.Is(marshalErr, ErrL8JobCredentialRuntimeSerialization) {
+			t.Fatalf("json.Marshal(%T) = %q, %v", value, encoded, marshalErr)
+		}
+		for _, rendered := range []string{fmt.Sprint(value), fmt.Sprintf("%#v", value), fmt.Sprintf("%+v", value)} {
+			if rendered != l8JobCredentialRuntimeValuePlaceholder {
+				t.Fatalf("format %T = %q", value, rendered)
+			}
+		}
+	}
+}
+
+func TestL8JobCredentialRuntimeRemainsDefaultOff(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	set := token.NewFileSet()
+	callers := 0
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if strings.HasSuffix(filepath.ToSlash(path), "microvm/firecrackerhost/l8_job_credential_runtime.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(set, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch function := call.Fun.(type) {
+			case *ast.Ident:
+				name = function.Name
+			case *ast.SelectorExpr:
+				name = function.Sel.Name
+			}
+			if name == "NewProductionL8JobCredentialRuntime" {
+				callers++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callers != 0 {
+		t.Fatalf("production NewProductionL8JobCredentialRuntime callers = %d, want zero", callers)
+	}
+
+	for _, name := range []string{"adapter.go", "live_driver.go", "l7_live_composition.go"} {
+		source, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, forbidden := range []string{"NewProductionL8JobCredentialRuntime", "L8JobCredentialRuntime", "PreflightJobCredentials"} {
+			if bytes.Contains(source, []byte(forbidden)) {
+				t.Fatalf("%s wires job credential runtime marker %q", name, forbidden)
+			}
+		}
+	}
+	if firecracker.BackendID == "" {
+		t.Fatal("firecracker backend id missing")
+	}
+}
+
+func TestL8JobCredentialRuntimeComposesInjectedGuestHTTPTmpfsAndSSH(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{
+		sandboxruntime.JobCredentialDeliveryModeHTTPProxy,
+		sandboxruntime.JobCredentialDeliveryModeFileTmpfs,
+		sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8JobCredentialRuntimePrepareRequest(t, identity)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	httpProxy := &l8JobCredentialHTTPProxyFake{}
+	tmpfs := &l8JobCredentialFileTmpfsFake{payload: []byte("file-bytes")}
+	ssh := &l8JobCredentialSSHRelayFake{policyID: "ssh-policy-1", policyRevision: 4}
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, httpProxy, tmpfs, ssh)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(session) {
+		t.Fatalf("mixed prepare = %#v, %v", session, err)
+	}
+	if httpProxy.activates != 1 || tmpfs.materializes != 1 || ssh.activates != 1 {
+		t.Fatalf("mixed activations http=%d tmpfs=%d ssh=%d", httpProxy.activates, tmpfs.materializes, ssh.activates)
+	}
+	if len(guest.lastManifests) != 3 {
+		t.Fatalf("guest manifests = %d, want 3", len(guest.lastManifests))
+	}
+	if _, err := session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested")); err != nil {
+		t.Fatal(err)
+	}
+	if httpProxy.revokes != 1 || tmpfs.revokes != 1 || ssh.revokes != 1 {
+		t.Fatalf("mixed revokes http=%d tmpfs=%d ssh=%d", httpProxy.revokes, tmpfs.revokes, ssh.revokes)
+	}
+}
+
+func TestL8JobCredentialRuntimePreflightReturnMatrix(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	raw := errors.New("token=provider-secret path=/private/provider.sock")
+	var typedNil *l8JobCredentialGuestSessionFake
+	tests := []struct {
+		name    string
+		opener  *l8JobCredentialGuestSessionOpenerFake
+		wantErr error
+	}{
+		{name: "nil success", opener: &l8JobCredentialGuestSessionOpenerFake{}, wantErr: ErrL8JobCredentialRuntimeInvalid},
+		{name: "typed nil success", opener: &l8JobCredentialGuestSessionOpenerFake{session: typedNil}, wantErr: ErrL8JobCredentialRuntimeInvalid},
+		{name: "nil error", opener: &l8JobCredentialGuestSessionOpenerFake{err: raw}, wantErr: ErrL8JobCredentialRuntimeUnavailable},
+		{name: "value plus error", opener: &l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now), err: raw}, wantErr: ErrL8JobCredentialRuntimeUnavailable},
+		{name: "panic", opener: &l8JobCredentialGuestSessionOpenerFake{panicValue: raw}, wantErr: ErrL8JobCredentialRuntimeUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runtime := l8JobCredentialRuntimeForTest(t, now, tt.opener, nil, &l8JobCredentialFileTmpfsFake{payload: []byte("x")}, nil)
+			preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+			if !l8JobCredentialRuntimeValueIsNil(preflight) || !errors.Is(err, tt.wantErr) {
+				t.Fatalf("preflight = %#v, %v, want %v", preflight, err, tt.wantErr)
+			}
+			l8JobCredentialRuntimeAssertSafeError(t, err)
+			if tt.opener.session != nil && !l8JobCredentialRuntimeValueIsNil(tt.opener.session) && tt.opener.err != nil {
+				if fake, ok := tt.opener.session.(*l8JobCredentialGuestSessionFake); ok && fake.closed == 0 {
+					t.Fatal("value-plus-error did not close the attempted guest session")
+				}
+			}
+		})
+	}
+}
+
+func l8JobCredentialRuntimeForTest(
+	t *testing.T,
+	now time.Time,
+	opener l8JobCredentialGuestSessionOpener,
+	httpProxy l8JobCredentialHTTPProxyActivator,
+	tmpfs l8JobCredentialFileTmpfsActivator,
+	ssh l8JobCredentialSSHRelayActivator,
+) *L8JobCredentialRuntime {
+	t.Helper()
+	runtime, err := newL8JobCredentialRuntime(l8JobCredentialRuntimeTestDeps(t, now, opener, httpProxy, tmpfs, ssh), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return runtime
+}
+
+func l8JobCredentialRuntimeTestDeps(
+	t *testing.T,
+	now time.Time,
+	opener l8JobCredentialGuestSessionOpener,
+	httpProxy l8JobCredentialHTTPProxyActivator,
+	tmpfs l8JobCredentialFileTmpfsActivator,
+	ssh l8JobCredentialSSHRelayActivator,
+) l8JobCredentialRuntimeDependencies {
+	t.Helper()
+	if opener == nil {
+		opener = &l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}
+	}
+	return l8JobCredentialRuntimeDependencies{
+		GuestSession: opener,
+		HTTPProxy:    httpProxy,
+		FileTmpfs:    tmpfs,
+		SSHRelay:     ssh,
+		Now:          func() time.Time { return now.Add(time.Second) },
+		Random:       bytesReaderForTest(),
+	}
+}
+
+func l8JobCredentialRuntimeNow() time.Time {
+	return time.Date(2026, time.August, 28, 1, 2, 3, 0, time.UTC)
+}
+
+func l8JobCredentialRuntimeGuestSessionGeneration() string {
+	return base64.RawURLEncoding.EncodeToString(bytes.Repeat([]byte{0x7a}, 32))
+}
+
+func l8JobCredentialRuntimeSeed(t *testing.T, now time.Time, modes []sandboxruntime.JobCredentialDeliveryMode) sandboxruntime.JobCredentialIdentitySeed {
+	t.Helper()
+	bindingIDs := make([]string, len(modes))
+	for index := range modes {
+		bindingIDs[index] = fmt.Sprintf("binding-%d", index+1)
+	}
+	seed := sandboxruntime.JobCredentialIdentitySeed{
+		SandboxID: "sandbox-runtime", ExecutionID: "execution-runtime", WorkerID: "worker-runtime", HostID: "host-runtime",
+		RuntimeDriver: "microvm", RuntimeID: "runtime-1", RuntimeGeneration: "runtime-generation-1",
+		FirecrackerProcessGeneration: "process-generation-1", VsockGeneration: "vsock-generation-1",
+		WorkerJobID: "job-runtime", SubmissionID: "submission-runtime", PlanID: "plan-runtime",
+		ActivationGeneration: "activation-runtime", CredentialGeneration: "credential-runtime",
+		AdmissionGrantID: "grant-runtime", PrincipalID: "principal-runtime",
+		TemplatePolicyID: "template-runtime", WorkspacePolicyID: "workspace-runtime",
+		ControllerKeyGeneration: "controller-key-runtime", GuestBootGeneration: "guest-boot-runtime",
+		GuestImageGeneration: "guest-image-runtime", GuestImageDigest: "sha256-" + strings.Repeat("ab", 32),
+		AdmissionGrantRevision: 2, BindingIDs: bindingIDs, DeliveryModes: append([]sandboxruntime.JobCredentialDeliveryMode(nil), modes...),
+		IssuedAt: now,
+	}
+	for _, mode := range modes {
+		if mode == sandboxruntime.JobCredentialDeliveryModeHTTPProxy {
+			seed.NetworkPlanID = "network-plan-runtime"
+			seed.PolicySnapshotID = "policy-snapshot-runtime"
+			seed.ProxySessionID = "proxy-session-runtime"
+			seed.ProxyGenerationID = "proxy-generation-runtime"
+			seed.TopologyGenerationID = "topology-generation-runtime"
+			seed.RuleGenerationID = "rule-generation-runtime"
+			break
+		}
+	}
+	if err := sandboxruntime.ValidateJobCredentialIdentitySeed(seed); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+	return seed
+}
+
+func l8JobCredentialRuntimePrepareFixture(t *testing.T, now time.Time) (sandboxruntime.JobCredentialIdentitySeed, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialPrepareRequest) {
+	t.Helper()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{
+		sandboxruntime.JobCredentialDeliveryModeHTTPProxy,
+		sandboxruntime.JobCredentialDeliveryModeFileTmpfs,
+	})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return seed, identity, l8JobCredentialRuntimePrepareRequest(t, identity)
+}
+
+func l8JobCredentialRuntimePrepareRequest(t *testing.T, identity sandboxruntime.JobCredentialIdentity) sandboxruntime.JobCredentialPrepareRequest {
+	t.Helper()
+	bindings := make([]sandboxruntime.JobCredentialBindingRequest, len(identity.BindingIDs))
+	sources := make([]sandboxruntime.JobCredentialAuthorizedSource, 0, len(identity.BindingIDs))
+	sourceIDs := make([]string, 0, len(identity.BindingIDs))
+	for index, bindingID := range identity.BindingIDs {
+		binding := sandboxruntime.JobCredentialBindingRequest{
+			ID: bindingID, Mode: identity.DeliveryModes[index], SourceReferenceID: "source-" + bindingID,
+		}
+		if identity.DeliveryModes[index] == sandboxruntime.JobCredentialDeliveryModeHTTPProxy {
+			binding.ServiceID = "azure-openai-responses-v1"
+		}
+		bindings[index] = binding
+		if identity.DeliveryModes[index] != sandboxruntime.JobCredentialDeliveryModeSSHAgent {
+			sourceIDs = append(sourceIDs, binding.SourceReferenceID)
+			sources = append(sources, sandboxruntime.JobCredentialAuthorizedSource{
+				ReferenceID: binding.SourceReferenceID,
+				Source:      l8JobCredentialRuntimeSecretSource{payload: []byte("secret-bytes-" + bindingID)},
+			})
+		}
+	}
+	return sandboxruntime.JobCredentialPrepareRequest{
+		Identity: identity,
+		Admission: sandboxruntime.JobCredentialAdmissionRequest{
+			Identity: sandboxruntime.JobCredentialAdmissionIdentity{
+				SandboxID: identity.SandboxID, ExecutionID: identity.ExecutionID, WorkerID: identity.WorkerID, HostID: identity.HostID,
+				RuntimeDriver: identity.RuntimeDriver, RuntimeID: identity.RuntimeID, RuntimeGeneration: identity.RuntimeGeneration,
+				FirecrackerProcessGeneration: identity.FirecrackerProcessGeneration, VsockGeneration: identity.VsockGeneration,
+				WorkerJobID: identity.WorkerJobID, SubmissionID: identity.SubmissionID, PlanID: identity.PlanID,
+				ActivationGeneration: identity.ActivationGeneration, CredentialGeneration: identity.CredentialGeneration,
+				NetworkPlanID: identity.NetworkPlanID, PolicySnapshotID: identity.PolicySnapshotID,
+				ProxySessionID: identity.ProxySessionID, ProxyGenerationID: identity.ProxyGenerationID,
+				TopologyGenerationID: identity.TopologyGenerationID, RuleGenerationID: identity.RuleGenerationID,
+				IssuedAt: identity.IssuedAt,
+			},
+			GrantID: identity.AdmissionGrantID, GrantRevision: identity.AdmissionGrantRevision, PlanID: identity.PlanID,
+			TemplatePolicyID: identity.TemplatePolicyID, WorkspacePolicyID: identity.WorkspacePolicyID,
+			SourceReferenceIDs: sourceIDs, Bindings: bindings,
+		},
+		Authorization:     l8JobCredentialRuntimeTestAuthorization{},
+		AuthorizedSources: sources,
+	}
+}
+
+func l8JobCredentialRuntimeAssertSafeError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	text := err.Error()
+	for _, forbidden := range []string{
+		"sk_live", "OPENAI_API_KEY", "/private/", "secret-bytes", "tmpfs-canary",
+		"provider-secret", "helper-generation-runtime",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("error leaked %q: %v", forbidden, err)
+		}
+	}
+}
+
+func bytesReaderForTest() io.Reader {
+	return bytes.NewReader(bytes.Repeat([]byte{0x11}, 512))
+}
+
+type l8JobCredentialRuntimeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *l8JobCredentialRuntimeClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+type l8JobCredentialRuntimeTestAuthorization struct{}
+
+type l8JobCredentialRuntimeSecretSource struct{ payload []byte }
+
+func (source l8JobCredentialRuntimeSecretSource) FillSecret(_ context.Context, sink sandboxruntime.JobCredentialSecretSink) error {
+	if len(source.payload) > sink.MaxCredentialBytes() {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	return sink.WriteCredential(source.payload)
+}
+
+type l8JobCredentialGuestSessionOpenerFake struct {
+	session    l8JobCredentialGuestSession
+	err        error
+	panicValue any
+	calls      int
+}
+
+func (opener *l8JobCredentialGuestSessionOpenerFake) Open(_ context.Context, _ sandboxruntime.JobCredentialIdentitySeed) (l8JobCredentialGuestSession, error) {
+	opener.calls++
+	if opener.panicValue != nil {
+		panic(opener.panicValue)
+	}
+	return opener.session, opener.err
+}
+
+type l8JobCredentialGuestSessionFake struct {
+	sessionGeneration string
+	helperGeneration  string
+	sessionID         [32]byte
+	hardExpiry        time.Time
+	loss              chan struct{}
+	lossOnce          sync.Once
+
+	mu            sync.Mutex
+	prepares      int
+	renews        int
+	revokes       int
+	closed        int
+	lastManifests []l8JobCredentialGuestBindingManifest
+	prepareErr    error
+	renewErr      error
+	revokeErr     error
+}
+
+func l8JobCredentialGuestSessionFakeForTest(t *testing.T, now time.Time) *l8JobCredentialGuestSessionFake {
+	t.Helper()
+	var sessionID [32]byte
+	copy(sessionID[:], bytes.Repeat([]byte{0x7a}, 32))
+	return &l8JobCredentialGuestSessionFake{
+		sessionGeneration: l8JobCredentialRuntimeGuestSessionGeneration(),
+		helperGeneration:  "helper-generation-runtime",
+		sessionID:         sessionID,
+		hardExpiry:        now.Add(30 * time.Minute),
+		loss:              make(chan struct{}),
+	}
+}
+
+func (session *l8JobCredentialGuestSessionFake) GuestSessionGeneration() string {
+	return session.sessionGeneration
+}
+func (session *l8JobCredentialGuestSessionFake) GuestHelperGeneration() string {
+	return session.helperGeneration
+}
+func (session *l8JobCredentialGuestSessionFake) SessionID() [32]byte { return session.sessionID }
+func (session *l8JobCredentialGuestSessionFake) HardExpiry() time.Time {
+	return session.hardExpiry
+}
+func (session *l8JobCredentialGuestSessionFake) Prepare(_ context.Context, _ sandboxruntime.JobCredentialIdentity, _ time.Time, manifests []l8JobCredentialGuestBindingManifest) (l8JobCredentialGuestPrepareResult, error) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	session.prepares++
+	session.lastManifests = append([]l8JobCredentialGuestBindingManifest(nil), manifests...)
+	if session.prepareErr != nil {
+		return l8JobCredentialGuestPrepareResult{}, session.prepareErr
+	}
+	proofs := make([]l8JobCredentialGuestBindingProof, len(manifests))
+	for index, manifest := range manifests {
+		proofs[index] = l8JobCredentialGuestBindingProof{BindingID: manifest.BindingID, Mode: manifest.Mode, ProofID: "guest-" + manifest.BindingID}
+	}
+	return l8JobCredentialGuestPrepareResult{ActiveProofID: "guest-active-1", ExecBindingID: "exec-binding-1", BindingProofs: proofs}, nil
+}
+func (session *l8JobCredentialGuestSessionFake) Renew(context.Context, sandboxruntime.JobCredentialIdentity, uint64, time.Time, string) (string, error) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	session.renews++
+	if session.renewErr != nil {
+		return "", session.renewErr
+	}
+	return "guest-active-2", nil
+}
+func (session *l8JobCredentialGuestSessionFake) Revoke(context.Context, sandboxruntime.JobCredentialIdentity, uint64, sandboxruntime.JobCredentialRevokeReason) (string, error) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	session.revokes++
+	if session.revokeErr != nil {
+		return "", session.revokeErr
+	}
+	return "guest-cleanup-1", nil
+}
+func (session *l8JobCredentialGuestSessionFake) Loss() <-chan struct{} { return session.loss }
+func (session *l8JobCredentialGuestSessionFake) Close() error {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	session.closed++
+	return nil
+}
+func (session *l8JobCredentialGuestSessionFake) emitLoss() {
+	session.lossOnce.Do(func() { close(session.loss) })
+}
+
+type l8JobCredentialHTTPProxyFake struct {
+	mu        sync.Mutex
+	activates int
+	renews    int
+	revokes   int
+	err       error
+}
+
+func (fake *l8JobCredentialHTTPProxyFake) Activate(_ context.Context, _ sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest, _ sandboxruntime.LiveSecretSource) (l8JobCredentialHTTPProxyHandle, error) {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	fake.activates++
+	if fake.err != nil {
+		return nil, fake.err
+	}
+	return &l8JobCredentialHTTPProxyHandleFake{parent: fake, serviceID: binding.ServiceID}, nil
+}
+
+type l8JobCredentialHTTPProxyHandleFake struct {
+	parent    *l8JobCredentialHTTPProxyFake
+	serviceID string
+}
+
+func (handle *l8JobCredentialHTTPProxyHandleFake) ServiceID() string { return handle.serviceID }
+func (handle *l8JobCredentialHTTPProxyHandleFake) Renew(context.Context) error {
+	handle.parent.mu.Lock()
+	defer handle.parent.mu.Unlock()
+	handle.parent.renews++
+	return nil
+}
+func (handle *l8JobCredentialHTTPProxyHandleFake) Revoke(context.Context) error {
+	handle.parent.mu.Lock()
+	defer handle.parent.mu.Unlock()
+	handle.parent.revokes++
+	return nil
+}
+
+type l8JobCredentialFileTmpfsFake struct {
+	mu           sync.Mutex
+	payload      []byte
+	materializes int
+	revokes      int
+	err          error
+}
+
+func (fake *l8JobCredentialFileTmpfsFake) Materialize(ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest, source sandboxruntime.LiveSecretSource) (l8JobCredentialFileHandle, error) {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	fake.materializes++
+	if fake.err != nil {
+		return nil, fake.err
+	}
+	payload := fake.payload
+	if source != nil {
+		sink := &l8JobCredentialRuntimeTestSink{max: 64 * 1024}
+		if err := source.FillSecret(ctx, sink); err != nil {
+			return nil, err
+		}
+		if len(sink.written) > 0 {
+			payload = append([]byte(nil), sink.written...)
+		}
+	}
+	sum := sha256.Sum256(payload)
+	_ = identity
+	return &l8JobCredentialFileHandleFake{
+		parent: fake, targetPath: binding.ID, size: uint32(len(payload)), digest: hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+type l8JobCredentialFileHandleFake struct {
+	parent     *l8JobCredentialFileTmpfsFake
+	targetPath string
+	size       uint32
+	digest     string
+}
+
+func (handle *l8JobCredentialFileHandleFake) TargetPath() string        { return handle.targetPath }
+func (handle *l8JobCredentialFileHandleFake) DeclaredFileBytes() uint32 { return handle.size }
+func (handle *l8JobCredentialFileHandleFake) FileSHA256() string        { return handle.digest }
+func (handle *l8JobCredentialFileHandleFake) Revoke(context.Context) error {
+	handle.parent.mu.Lock()
+	defer handle.parent.mu.Unlock()
+	handle.parent.revokes++
+	return nil
+}
+
+type l8JobCredentialSSHRelayFake struct {
+	mu             sync.Mutex
+	policyID       string
+	policyRevision uint64
+	activates      int
+	renews         int
+	revokes        int
+	err            error
+}
+
+func (fake *l8JobCredentialSSHRelayFake) Activate(context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest) (l8JobCredentialSSHRelayHandle, error) {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	fake.activates++
+	if fake.err != nil {
+		return nil, fake.err
+	}
+	return &l8JobCredentialSSHRelayHandleFake{parent: fake, policyID: fake.policyID, policyRevision: fake.policyRevision}, nil
+}
+
+type l8JobCredentialSSHRelayHandleFake struct {
+	parent         *l8JobCredentialSSHRelayFake
+	policyID       string
+	policyRevision uint64
+}
+
+func (handle *l8JobCredentialSSHRelayHandleFake) PolicyID() string     { return handle.policyID }
+func (handle *l8JobCredentialSSHRelayHandleFake) PolicyRevision() uint64 {
+	return handle.policyRevision
+}
+func (handle *l8JobCredentialSSHRelayHandleFake) Renew(context.Context) error {
+	handle.parent.mu.Lock()
+	defer handle.parent.mu.Unlock()
+	handle.parent.renews++
+	return nil
+}
+func (handle *l8JobCredentialSSHRelayHandleFake) Revoke(context.Context) error {
+	handle.parent.mu.Lock()
+	defer handle.parent.mu.Unlock()
+	handle.parent.revokes++
+	return nil
+}
+
+type l8JobCredentialRuntimeTestSink struct {
+	max     int
+	written []byte
+}
+
+func (sink *l8JobCredentialRuntimeTestSink) MaxCredentialBytes() int { return sink.max }
+func (sink *l8JobCredentialRuntimeTestSink) WriteCredential(value []byte) error {
+	sink.written = append([]byte(nil), value...)
+	return nil
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_test.go
@@ -33,14 +33,14 @@ func TestL8JobCredentialRuntimePublicAPIIsExact(t *testing.T) {
 	}
 	runtimeType := reflect.TypeOf((*L8JobCredentialRuntime)(nil))
 	l8D6AssertExactExportedMethodSet(t, runtimeType, map[string]reflect.Type{
-		"Format":                    reflect.TypeOf((func(*L8JobCredentialRuntime, fmt.State, rune))(nil)),
-		"GoString":                  reflect.TypeOf((func(*L8JobCredentialRuntime) string)(nil)),
-		"MarshalBinary":             reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
-		"MarshalJSON":               reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
-		"MarshalText":               reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
-		"PreflightJobCredentials":   reflect.TypeOf((func(*L8JobCredentialRuntime, context.Context, sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimePreflight, error))(nil)),
-		"RecoverJobCredentials":     reflect.TypeOf((func(*L8JobCredentialRuntime, context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error))(nil)),
-		"String":                    reflect.TypeOf((func(*L8JobCredentialRuntime) string)(nil)),
+		"Format":                  reflect.TypeOf((func(*L8JobCredentialRuntime, fmt.State, rune))(nil)),
+		"GoString":                reflect.TypeOf((func(*L8JobCredentialRuntime) string)(nil)),
+		"MarshalBinary":           reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
+		"MarshalJSON":             reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
+		"MarshalText":             reflect.TypeOf((func(*L8JobCredentialRuntime) ([]byte, error))(nil)),
+		"PreflightJobCredentials": reflect.TypeOf((func(*L8JobCredentialRuntime, context.Context, sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimePreflight, error))(nil)),
+		"RecoverJobCredentials":   reflect.TypeOf((func(*L8JobCredentialRuntime, context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error))(nil)),
+		"String":                  reflect.TypeOf((func(*L8JobCredentialRuntime) string)(nil)),
 	})
 	var _ sandboxruntime.JobCredentialRuntime = (*L8JobCredentialRuntime)(nil)
 }
@@ -907,7 +907,7 @@ type l8JobCredentialSSHRelayHandleFake struct {
 	policyRevision uint64
 }
 
-func (handle *l8JobCredentialSSHRelayHandleFake) PolicyID() string     { return handle.policyID }
+func (handle *l8JobCredentialSSHRelayHandleFake) PolicyID() string { return handle.policyID }
 func (handle *l8JobCredentialSSHRelayHandleFake) PolicyRevision() uint64 {
 	return handle.policyRevision
 }


### PR DESCRIPTION
## Summary

Stacked on `feature/sandbox-runtime-secure-default-v2` (`1926e937`).

Default-off Firecracker host `JobCredentialRuntime`: Preflight → Prepare → Session (ActiveProof/Renew/Revoke/Loss/Abort) with injectable guest/HTTP/tmpfs/SSH adapters. RED-first (`bf30fd5f`) then GREEN (`02814eed`).

`RecoverJobCredentials` stays `dependency_unaccepted`. No production `NewJobCredentialRuntimeAbsenceProof` (owned by the recovery-binding sibling). Not wired into `NewBackend`, sandboxd, worker, cmd, L10, or L11.

## Tests

```
go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'TestL8JobCredentialRuntime' -count=1
go vet ./internal/sandboxruntime/microvm/firecrackerhost
```

Author also reported count=20 and race count=5.

## Queue

Behind https://github.com/j-yw/hal/pull/42. Do not merge to `develop`.