### PR TITLE
feat: implement L8 runtime-owner recovery binding

### DIFF
--- a/cmd/l8_d6_runtime_owner_contract_test.go
+++ b/cmd/l8_d6_runtime_owner_contract_test.go
@@ -256,7 +256,7 @@ func TestL8D6RuntimeOwnerContractVerificationIsFrozen(t *testing.T) {
 	}
 }
 
-func TestL8D6RuntimeOwnerContractProofConstructorHasNoPrematureProductionIssuer(t *testing.T) {
+func TestL8D6RuntimeOwnerContractProofConstructorHasOneProductionOwner(t *testing.T) {
 	const (
 		declarationOwner = "../internal/sandboxruntime/job_credential_runtime_recovery.go"
 		issuerOwner      = "../internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go"
@@ -288,7 +288,7 @@ func TestL8D6RuntimeOwnerContractProofConstructorHasNoPrematureProductionIssuer(
 			total.references += usage.references
 			total.directCalls += usage.directCalls
 			if usage.forbidden {
-				t.Fatalf("production proof constructor reference outside exact owners %s and %s: %s", declarationOwner, issuerOwner, filepath.ToSlash(path))
+				t.Fatalf("production proof constructor reference outside exact StopReap issuer %s: %s", issuerOwner, filepath.ToSlash(path))
 			}
 			return nil
 		})
@@ -305,12 +305,12 @@ func TestL8D6RuntimeOwnerContractProofConstructorHasNoPrematureProductionIssuer(
 		}
 		return
 	}
-	if declarationErr != nil || issuerErr != nil || total.declarations != 1 || total.references != 0 || total.directCalls != 0 {
-		t.Fatalf("production proof constructor usage = %#v, declaration error %v, issuer error %v; want the root declaration and no issuer before StopReap", total, declarationErr, issuerErr)
+	if declarationErr != nil || issuerErr != nil || total.declarations != 1 || total.references != 1 || total.directCalls != 1 {
+		t.Fatalf("production proof constructor usage = %#v, declaration error %v, issuer error %v; want the root declaration and exactly one StopReap issuer", total, declarationErr, issuerErr)
 	}
 }
 
-func TestL8D6RuntimeOwnerContractProofConstructorGuardRejectsPrematureOrSecondIssuer(t *testing.T) {
+func TestL8D6RuntimeOwnerContractProofConstructorGuardRejectsSecondIssuer(t *testing.T) {
 	const (
 		declarationOwner = "../internal/sandboxruntime/job_credential_runtime_recovery.go"
 		issuerOwner      = "../internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go"
@@ -320,10 +320,23 @@ func TestL8D6RuntimeOwnerContractProofConstructorGuardRejectsPrematureOrSecondIs
 	if err != nil || usage != (l8D6RuntimeOwnerProofConstructorUsage{declarations: 1}) {
 		t.Fatalf("declaration owner fixture = %#v, error %v", usage, err)
 	}
+	allowedCall := []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) StopReapJobCredentialRuntime(context.Context) (sandboxruntime.JobCredentialRuntimeAbsenceProof, error) { return sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{}) }\n")
+	usage, err = l8D6RuntimeOwnerProofConstructorReferences(issuerOwner, allowedCall, declarationOwner, issuerOwner)
+	if err != nil || usage.references != 1 || usage.directCalls != 1 || usage.forbidden {
+		t.Fatalf("exact StopReap issuer fixture = %#v, error %v", usage, err)
+	}
 	directCall := []byte("package firecrackerhost\nfunc mint() { sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{}) }\n")
 	usage, err = l8D6RuntimeOwnerProofConstructorReferences(issuerOwner, directCall, declarationOwner, issuerOwner)
 	if err != nil || usage.references != 1 || usage.directCalls != 1 || !usage.forbidden {
 		t.Fatalf("premature direct owner call fixture = %#v, error %v", usage, err)
+	}
+	duplicate := []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) StopReapJobCredentialRuntime(context.Context) (sandboxruntime.JobCredentialRuntimeAbsenceProof, error) {\n\t_, _ = sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{})\n\treturn sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{})\n}\n")
+	usage, err = l8D6RuntimeOwnerProofConstructorReferences(issuerOwner, duplicate, declarationOwner, issuerOwner)
+	if err != nil || usage.directCalls != 2 || usage.forbidden {
+		t.Fatalf("duplicate StopReap issuer fixture = %#v, error %v", usage, err)
+	}
+	if usage.directCalls == 1 {
+		t.Fatal("duplicate owner constructor calls collapsed to exactly one")
 	}
 	for name, fixture := range map[string][]byte{
 		"second issuer":  []byte("package sandboxworker\nfunc mint() { sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{}) }\n"),
@@ -409,6 +422,10 @@ func TestL8D6RuntimeOwnerContractCommitReceiptHasOnePrivateStoreProjection(t *te
 	if audit, err := l8D6RuntimeOwnerCommitReceiptAccessAudit(allowedFinalizeFixture, expected[ownerVerifier]); err != nil || !audit.exact() || len(audit.issues) != 0 {
 		t.Fatalf("exact future finalizer fixture audit = %#v, error %v", audit, err)
 	}
+	allowedBindingFixture := []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(ctx context.Context, proof sandboxruntime.JobCredentialRuntimeAbsenceProof) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) { return }\nfunc (*l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery(ctx context.Context, receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { return commitJobCredentialRuntimeRecovery(receipt) }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n")
+	if audit, err := l8D6RuntimeOwnerCommitReceiptAccessAudit(allowedBindingFixture, expected[ownerVerifier]); err != nil || !audit.exact() || len(audit.issues) != 0 {
+		t.Fatalf("exact binding commit/finalize fixture audit = %#v, error %v", audit, err)
+	}
 	rootReceiptType := "type JobCredentialRuntimeRecoveryCommitReceipt struct { CommitID string; FinalizedRevision uint64 }\n"
 	rootValidatorFunction := "func ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"
 	rootFixtures := map[string][]byte{
@@ -434,23 +451,24 @@ func TestL8D6RuntimeOwnerContractCommitReceiptHasOnePrivateStoreProjection(t *te
 		t.Fatalf("cross-file root-package receipt retention passed audit: %#v", audit)
 	}
 	fixtures := map[string][]byte{
-		"function name spoof":      []byte("package firecrackerhost\ntype unrelated struct { CommitID string }\nfunc commitJobCredentialRuntimeRecovery(value unrelated) error { _ = value.CommitID; return nil }\n"),
-		"unrelated field":          []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype unrelated struct { CommitID string }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = unrelated{}.CommitID; return nil }\n"),
-		"reflection field":         []byte("package firecrackerhost\nimport (\"reflect\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = reflect.ValueOf(receipt).Field(0).String(); return nil }\n"),
-		"reflection field by name": []byte("package firecrackerhost\nimport (\"reflect\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = reflect.ValueOf(receipt).FieldByName(\"CommitID\").String(); return nil }\n"),
-		"unsafe conversion":        []byte("package firecrackerhost\nimport (\"unsafe\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = unsafe.Pointer(&receipt); return nil }\n"),
-		"receipt value alias":      []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { alias := receipt; _ = alias.CommitID; return nil }\n"),
-		"receipt type alias":       []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype receiptAlias = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt\nfunc commitJobCredentialRuntimeRecovery(receipt receiptAlias) error { _ = receipt.CommitID; return nil }\n"),
-		"same name wrong result":   []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) int { _ = receipt.CommitID; return 0 }\n"),
-		"receiver method":          []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype owner struct{}\nfunc (owner) commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
-		"closure escape":           []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { leak := func() string { return receipt.CommitID }; _ = leak; return nil }\n"),
-		"helper escape":            []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc leak(any) {}\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { leak(receipt); return nil }\n"),
-		"validator package spoof":  []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype leakValidator struct{}\nvar retained any\nfunc (leakValidator) ValidateJobCredentialRuntimeRecoveryCommitReceipt(value any) error { retained = value; return nil }\nvar leak leakValidator\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return leak.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt) }\n"),
-		"validator variable spoof": []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nvar retained any\nvar ValidateJobCredentialRuntimeRecoveryCommitReceipt = func(value any) error { retained = value; return nil }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt) }\n"),
-		"finalizer wrong receiver": []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
-		"finalizer wrong input":    []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
-		"finalizer wrong result":   []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (string, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
-		"finalizer field read":     []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { receipt := sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}; _ = receipt.CommitID; panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
+		"function name spoof":         []byte("package firecrackerhost\ntype unrelated struct { CommitID string }\nfunc commitJobCredentialRuntimeRecovery(value unrelated) error { _ = value.CommitID; return nil }\n"),
+		"unrelated field":             []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype unrelated struct { CommitID string }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = unrelated{}.CommitID; return nil }\n"),
+		"reflection field":            []byte("package firecrackerhost\nimport (\"reflect\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = reflect.ValueOf(receipt).Field(0).String(); return nil }\n"),
+		"reflection field by name":    []byte("package firecrackerhost\nimport (\"reflect\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = reflect.ValueOf(receipt).FieldByName(\"CommitID\").String(); return nil }\n"),
+		"unsafe conversion":           []byte("package firecrackerhost\nimport (\"unsafe\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = unsafe.Pointer(&receipt); return nil }\n"),
+		"receipt value alias":         []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { alias := receipt; _ = alias.CommitID; return nil }\n"),
+		"receipt type alias":          []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype receiptAlias = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt\nfunc commitJobCredentialRuntimeRecovery(receipt receiptAlias) error { _ = receipt.CommitID; return nil }\n"),
+		"same name wrong result":      []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) int { _ = receipt.CommitID; return 0 }\n"),
+		"receiver method":             []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype owner struct{}\nfunc (owner) commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
+		"closure escape":              []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { leak := func() string { return receipt.CommitID }; _ = leak; return nil }\n"),
+		"helper escape":               []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc leak(any) {}\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { leak(receipt); return nil }\n"),
+		"validator package spoof":     []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype leakValidator struct{}\nvar retained any\nfunc (leakValidator) ValidateJobCredentialRuntimeRecoveryCommitReceipt(value any) error { retained = value; return nil }\nvar leak leakValidator\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return leak.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt) }\n"),
+		"validator variable spoof":    []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nvar retained any\nvar ValidateJobCredentialRuntimeRecoveryCommitReceipt = func(value any) error { retained = value; return nil }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt) }\n"),
+		"finalizer wrong receiver":    []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
+		"finalizer wrong input":       []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
+		"finalizer wrong result":      []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (string, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
+		"finalizer field read":        []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { receipt := sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}; _ = receipt.CommitID; panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
+		"binding commit wrong result": []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) { panic(\"fixture\") }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"),
 	}
 	for name, fixture := range fixtures {
 		t.Run(name, func(t *testing.T) {
@@ -565,21 +583,36 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 	audit.present = true
 	if expected.allowFinalizerResult {
 		finalizers, exactFinalizers := 0, 0
+		commits, exactCommits := 0, 0
 		for _, declaration := range file.Decls {
 			function, ok := declaration.(*ast.FuncDecl)
-			if !ok || function.Name.Name != "FinalizeJobCredentialRuntimeRecovery" {
+			if !ok {
 				continue
 			}
-			finalizers++
-			for _, reference := range receiptTypeReferences {
-				if l8D6RuntimeOwnerContainingFunction(reference, parents) == function && l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file, reference, parents) {
-					exactFinalizers++
-					break
+			switch function.Name.Name {
+			case "FinalizeJobCredentialRuntimeRecovery":
+				finalizers++
+				for _, reference := range receiptTypeReferences {
+					if l8D6RuntimeOwnerContainingFunction(reference, parents) == function && l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file, reference, parents) {
+						exactFinalizers++
+						break
+					}
+				}
+			case "CommitJobCredentialRuntimeRecovery":
+				commits++
+				for _, reference := range receiptTypeReferences {
+					if l8D6RuntimeOwnerContainingFunction(reference, parents) == function && l8D6RuntimeOwnerReceiptTypeIsExactBindingCommitParameter(file, reference, parents) {
+						exactCommits++
+						break
+					}
 				}
 			}
 		}
 		if finalizers != exactFinalizers {
 			audit.issues = append(audit.issues, "future finalizer signature is not exact")
+		}
+		if commits != exactCommits {
+			audit.issues = append(audit.issues, "binding commit signature is not exact")
 		}
 	}
 	for _, reference := range receiptTypeReferences {
@@ -592,7 +625,8 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 			continue
 		}
 		if !expected.rootType && !l8D6RuntimeOwnerReceiptTypeIsTargetParameter(reference, target) &&
-			!(expected.allowFinalizerResult && l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file, reference, parents)) {
+			!(expected.allowFinalizerResult && (l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file, reference, parents) ||
+				l8D6RuntimeOwnerReceiptTypeIsExactBindingCommitParameter(file, reference, parents))) {
 			audit.issues = append(audit.issues, "receipt type referenced outside the exact allowlisted function parameter")
 		}
 	}
@@ -854,9 +888,48 @@ func l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file *ast.File, reference
 	secondParameter := l8D6RuntimeOwnerExactImportedType(function.Type.Params.List[1].Type, runtimeAliases, "JobCredentialRuntimeAbsenceProof")
 	firstResult := function.Type.Results.List[0]
 	secondResult := function.Type.Results.List[1]
-	return len(function.Type.Params.List[0].Names) == 0 && len(function.Type.Params.List[1].Names) == 0 &&
-		len(firstResult.Names) == 0 && firstResult.Type == reference &&
-		len(secondResult.Names) == 0 && l8D6RuntimeOwnerTypeName(secondResult.Type) == "error" && firstParameter && secondParameter
+	return len(function.Type.Params.List[0].Names) <= 1 && len(function.Type.Params.List[1].Names) <= 1 &&
+		len(firstResult.Names) <= 1 && firstResult.Type == reference &&
+		len(secondResult.Names) <= 1 && l8D6RuntimeOwnerTypeName(secondResult.Type) == "error" && firstParameter && secondParameter
+}
+
+func l8D6RuntimeOwnerBindingPointerReceiver(function *ast.FuncDecl) bool {
+	if function == nil || function.Recv == nil || len(function.Recv.List) != 1 {
+		return false
+	}
+	pointer, ok := function.Recv.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	receiverType, ok := pointer.X.(*ast.Ident)
+	if !ok || receiverType.Name != "l8RuntimeOwnerRecoveryBinding" || receiverType.Obj == nil {
+		return false
+	}
+	typeSpec, ok := receiverType.Obj.Decl.(*ast.TypeSpec)
+	return ok && !typeSpec.Assign.IsValid() && typeSpec.Name.Name == "l8RuntimeOwnerRecoveryBinding"
+}
+
+func l8D6RuntimeOwnerReceiptTypeIsExactBindingCommitParameter(file *ast.File, reference ast.Expr, parents map[ast.Node]ast.Node) bool {
+	function := l8D6RuntimeOwnerContainingFunction(reference, parents)
+	if function == nil || function.Name.Name != "CommitJobCredentialRuntimeRecovery" || !l8D6RuntimeOwnerBindingPointerReceiver(function) ||
+		function.Type.Params == nil || len(function.Type.Params.List) != 2 || function.Type.Results == nil || len(function.Type.Results.List) != 1 {
+		return false
+	}
+	contextAliases := map[string]bool{}
+	for _, spec := range file.Imports {
+		if l8D6RuntimeOwnerImportPath(spec) != "context" {
+			continue
+		}
+		alias := "context"
+		if spec.Name != nil {
+			alias = spec.Name.Name
+		}
+		contextAliases[alias] = true
+	}
+	return len(function.Type.Params.List[0].Names) <= 1 && len(function.Type.Params.List[1].Names) <= 1 &&
+		len(function.Type.Results.List[0].Names) <= 1 && function.Type.Params.List[1].Type == reference &&
+		l8D6RuntimeOwnerExactImportedType(function.Type.Params.List[0].Type, contextAliases, "Context") &&
+		l8D6RuntimeOwnerTypeName(function.Type.Results.List[0].Type) == "error"
 }
 
 func l8D6RuntimeOwnerExactImportedType(expression ast.Expr, aliases map[string]bool, name string) bool {
@@ -1021,7 +1094,6 @@ type l8D6RuntimeOwnerProofConstructorUsage struct {
 }
 
 func l8D6RuntimeOwnerProofConstructorReferences(path string, payload []byte, declarationOwner, issuerOwner string) (l8D6RuntimeOwnerProofConstructorUsage, error) {
-	_ = issuerOwner
 	file, err := parser.ParseFile(token.NewFileSet(), path, payload, 0)
 	if err != nil {
 		return l8D6RuntimeOwnerProofConstructorUsage{}, err
@@ -1041,6 +1113,22 @@ func l8D6RuntimeOwnerProofConstructorReferences(path string, payload []byte, dec
 		}
 		return true
 	})
+	parents := make(map[ast.Node]ast.Node)
+	ast.Inspect(file, func(node ast.Node) bool {
+		if node == nil {
+			return true
+		}
+		ast.Inspect(node, func(child ast.Node) bool {
+			if child != nil && child != node {
+				if _, exists := parents[child]; !exists {
+					parents[child] = node
+				}
+				return false
+			}
+			return true
+		})
+		return true
+	})
 	usage := l8D6RuntimeOwnerProofConstructorUsage{}
 	for range declarationNames {
 		usage.declarations++
@@ -1055,10 +1143,13 @@ func l8D6RuntimeOwnerProofConstructorReferences(path string, payload []byte, dec
 				return true
 			}
 			usage.references++
-			if directReferences[value] {
+			direct := directReferences[value]
+			if direct {
 				usage.directCalls++
 			}
-			usage.forbidden = true
+			if !direct || !l8D6RuntimeOwnerProofConstructorCallIsExactIssuer(filepath.ToSlash(path), issuerOwner, value, parents) {
+				usage.forbidden = true
+			}
 			return false
 		case *ast.Ident:
 			if value.Name != "NewJobCredentialRuntimeAbsenceProof" || declarationNames[value] {
@@ -1073,6 +1164,17 @@ func l8D6RuntimeOwnerProofConstructorReferences(path string, payload []byte, dec
 		return true
 	})
 	return usage, nil
+}
+
+func l8D6RuntimeOwnerProofConstructorCallIsExactIssuer(path, issuerOwner string, callFun ast.Expr, parents map[ast.Node]ast.Node) bool {
+	if path != issuerOwner {
+		return false
+	}
+	function := l8D6RuntimeOwnerContainingFunction(callFun, parents)
+	if function == nil || function.Name.Name != "StopReapJobCredentialRuntime" || !l8D6RuntimeOwnerBindingPointerReceiver(function) {
+		return false
+	}
+	return !l8D6RuntimeOwnerInsideClosure(callFun, function, parents)
 }
 
 func TestL8D6RuntimeOwnerContractDefaultsRemainInert(t *testing.T) {

--- a/cmd/l8_d6_runtime_owner_foundation_red_test.go
+++ b/cmd/l8_d6_runtime_owner_foundation_red_test.go
@@ -67,10 +67,23 @@ func TestL8D6RuntimeOwnerFoundationDependenciesRemainUnaccepted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var finalize *ast.FuncDecl
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if ok && function.Name.Name == "FinalizeJobCredentialRuntimeRecovery" {
-			t.Fatal("R1 must not implement concrete finalize without a recovered L7 termination binding")
+			finalize = function
+		}
+	}
+	if finalize == nil {
+		t.Fatal("recovery binding must implement FinalizeJobCredentialRuntimeRecovery")
+	}
+	source := string(payload)
+	for _, forbidden := range []string{
+		"TerminatedVMBinding{", "newTerminatedVMBinding", "NewTerminatedVMBinding",
+		"productionL7TerminatedVMBinding",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("Finalize forges recovered L7 termination authority with %q", forbidden)
 		}
 	}
 	doc := readL8CredentialDeliveryFile(t, filepath.Join("..", "docs", "design", "sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md"))
@@ -78,7 +91,7 @@ func TestL8D6RuntimeOwnerFoundationDependenciesRemainUnaccepted(t *testing.T) {
 		"R1 foundation dependency-unaccepted",
 		"type `l8RuntimeOwnerRecoveryBinding`",
 		"recovered `l7network.TerminatedVMBinding` constructor remains absent",
-		"does not implement `FinalizeJobCredentialRuntimeRecovery`",
+		"Finalize fail-closes without a recovered L7 `TerminatedVMBinding`",
 	} {
 		if !strings.Contains(doc, marker) {
 			t.Errorf("R1 verification omits dependency marker %q", marker)

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -266,3 +266,18 @@ namespace descriptor duplication, and direct child processes; they require no
 KVM, Firecracker binary, network access, cloud account, guest image, worker, or
 daemon. The production absence-proof constructor call count remains zero until
 the later provider/L7 integration slice.
+
+## Recovery binding issuer
+
+This reviewed slice implements `l8RuntimeOwnerRecoveryBinding` as a real
+`JobCredentialRuntimeRecoveryBinding`. Complete-identity
+`RecoverJobCredentials` validates seed equality, attempts ordinary credential
+recovery without implementing host Preflight/Prepare/Session, and always
+invokes `StopReapJobCredentialRuntime`. `StopReapJobCredentialRuntime` is the
+sole production `NewJobCredentialRuntimeAbsenceProof` callsite in
+`l8_runtime_owner_recovery.go`, and it issues a proof only after the private
+owner has proved exact absence by direct-parent Wait or replacement
+double-`/proc`. The AST guard is tightened from zero host issuers to exactly
+that one StopReap callsite. Finalize fail-closes without a recovered L7 `TerminatedVMBinding`; old-boot journal retirement remains fail-closed.
+`commitJobCredentialRuntimeRecovery` remains the sole owner `CommitID` reader.
+Default constructors, sandboxd, and command execution stay unwired.

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -264,8 +264,9 @@ The standalone executable is compiled on Linux and cross-compiled on a
 non-Linux target. Linux tests use only local socketpairs, sealed memfds,
 namespace descriptor duplication, and direct child processes; they require no
 KVM, Firecracker binary, network access, cloud account, guest image, worker, or
-daemon. The production absence-proof constructor call count remains zero until
-the later provider/L7 integration slice.
+daemon. At the reviewed R2 boundary the production absence-proof constructor
+call count remained zero; the recovery-binding slice below adds the sole
+StopReap issuer without adding L7 finalization or default wiring.
 
 ## Recovery binding issuer
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -2,6 +2,7 @@ package firecrackerhost
 
 import (
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -12,6 +13,8 @@ import (
 	"errors"
 	"hash"
 	"io"
+	"sync"
+	"time"
 
 	"github.com/jywlabs/hal/internal/sandboxruntime"
 )
@@ -67,11 +70,226 @@ type firecrackerRuntimeOwnerRecordV1 struct {
 	ReconnectSecret              string `json:"reconnectSecret"`
 }
 
-// l8RuntimeOwnerRecoveryBinding is reserved for the exact future concrete
-// finalizer contract. R1 deliberately does not implement the neutral binding:
-// recovered L7 termination authority does not exist yet.
+// l8RuntimeOwnerRecoveryBinding is the seed-bound Firecracker runtime-owner
+// recovery binding. Stop/reap is the sole production issuer of
+// sandboxruntime.NewJobCredentialRuntimeAbsenceProof. Finalize fail-closes
+// without a recovered l7network.TerminatedVMBinding constructor.
 type l8RuntimeOwnerRecoveryBinding struct {
-	seed sandboxruntime.JobCredentialIdentitySeed
+	mu                 sync.Mutex
+	seed               sandboxruntime.JobCredentialIdentitySeed
+	commitKey          []byte
+	store              l8RuntimeOwnerRecordStore
+	proveAbsence       func(context.Context) (l8RuntimeOwnerAbsenceObservation, error)
+	recoverCredentials func(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error)
+	currentBootID      func() (string, error)
+	now                func() time.Time
+	closed             bool
+	commitOnly         bool
+}
+
+var _ sandboxruntime.JobCredentialRuntimeRecoveryBinding = (*l8RuntimeOwnerRecoveryBinding)(nil)
+
+func (binding *l8RuntimeOwnerRecoveryBinding) RecoverJobCredentials(ctx context.Context, request sandboxruntime.JobCredentialRecoveryRequest) (proof sandboxruntime.JobCredentialCleanupProof, err error) {
+	defer func() {
+		if recover() != nil {
+			proof = sandboxruntime.JobCredentialCleanupProof{}
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if binding == nil || ctx == nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, errL8RuntimeOwnerInvalid
+	}
+	binding.mu.Lock()
+	if binding.closed || binding.commitOnly {
+		binding.mu.Unlock()
+		return sandboxruntime.JobCredentialCleanupProof{}, errL8RuntimeOwnerInvalid
+	}
+	seed := binding.seed
+	recoverFn := binding.recoverCredentials
+	binding.mu.Unlock()
+	if sandboxruntime.ValidateJobCredentialIdentityCompletion(seed, request.Identity) != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	recovered, recoverErr := callL8RuntimeOwnerRecoverCredentials(recoverFn, ctx, request)
+	_, stopErr := binding.StopReapJobCredentialRuntime(ctx)
+	if stopErr != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, errL8RuntimeOwnerInvalid
+	}
+	if recoverErr != nil || sandboxruntime.CleanupProofKind(recovered) == "" {
+		return sandboxruntime.JobCredentialCleanupProof{}, errL8RuntimeOwnerInvalid
+	}
+	return recovered, nil
+}
+
+func callL8RuntimeOwnerRecoverCredentials(
+	fn func(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error),
+	ctx context.Context,
+	request sandboxruntime.JobCredentialRecoveryRequest,
+) (proof sandboxruntime.JobCredentialCleanupProof, err error) {
+	defer func() {
+		if recover() != nil {
+			proof = sandboxruntime.JobCredentialCleanupProof{}
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if fn == nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, errL8RuntimeOwnerInvalid
+	}
+	return fn(ctx, request)
+}
+
+func (binding *l8RuntimeOwnerRecoveryBinding) StopReapJobCredentialRuntime(ctx context.Context) (proof sandboxruntime.JobCredentialRuntimeAbsenceProof, err error) {
+	defer func() {
+		if recover() != nil {
+			proof = sandboxruntime.JobCredentialRuntimeAbsenceProof{}
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if binding == nil || ctx == nil {
+		return sandboxruntime.JobCredentialRuntimeAbsenceProof{}, errL8RuntimeOwnerInvalid
+	}
+	if !l8RuntimeOwnerPlatformSupported() {
+		return sandboxruntime.JobCredentialRuntimeAbsenceProof{}, errL8RuntimeOwnerUnsupported
+	}
+	binding.mu.Lock()
+	if binding.closed || binding.commitOnly || binding.proveAbsence == nil {
+		binding.mu.Unlock()
+		return sandboxruntime.JobCredentialRuntimeAbsenceProof{}, errL8RuntimeOwnerInvalid
+	}
+	seed := binding.seed
+	prove := binding.proveAbsence
+	nowFn := binding.now
+	binding.mu.Unlock()
+	stopCtx, cancel := context.WithTimeout(context.Background(), sandboxruntime.JobCredentialRuntimeStopReapTimeout)
+	defer cancel()
+	observation, proveErr := prove(stopCtx)
+	if proveErr != nil || (observation.Kind != l8RuntimeOwnerAbsenceKindWait && observation.Kind != l8RuntimeOwnerAbsenceKindProc) ||
+		observation.ObservedAt.IsZero() || observation.ObservedAt.Before(seed.IssuedAt) {
+		return sandboxruntime.JobCredentialRuntimeAbsenceProof{}, errL8RuntimeOwnerInvalid
+	}
+	proof, err = sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{
+		Seed:               seed,
+		AbsenceInspectedAt: observation.ObservedAt,
+	})
+	if err != nil {
+		return sandboxruntime.JobCredentialRuntimeAbsenceProof{}, errL8RuntimeOwnerInvalid
+	}
+	now := time.Now().UTC()
+	if nowFn != nil {
+		now = nowFn()
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now); err != nil {
+		return sandboxruntime.JobCredentialRuntimeAbsenceProof{}, errL8RuntimeOwnerInvalid
+	}
+	return proof, nil
+}
+
+func (binding *l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(ctx context.Context, proof sandboxruntime.JobCredentialRuntimeAbsenceProof) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) {
+	defer func() {
+		if recover() != nil {
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if binding == nil || ctx == nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	if !l8RuntimeOwnerPlatformSupported() {
+		err = errL8RuntimeOwnerUnsupported
+		return
+	}
+	binding.mu.Lock()
+	if binding.closed || binding.commitOnly {
+		binding.mu.Unlock()
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	seed := binding.seed
+	store := binding.store
+	nowFn := binding.now
+	bootFn := binding.currentBootID
+	binding.mu.Unlock()
+	now := time.Now().UTC()
+	if nowFn != nil {
+		now = nowFn()
+	}
+	if sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now) != nil || store == nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	record, loadErr := store.Load(ctx)
+	if loadErr != nil || (record.State != "absent" && record.State != "finalizing" && record.State != "finalized") {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	if bootFn != nil {
+		bootID, bootErr := bootFn()
+		if bootErr != nil || bootID != record.HostBootID {
+			err = errL8RuntimeOwnerInvalid
+			return
+		}
+	}
+	err = errL8RuntimeOwnerInvalid
+	return
+}
+
+func (binding *l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery(ctx context.Context, receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if binding == nil || ctx == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	binding.mu.Lock()
+	commitOnly := binding.commitOnly
+	key := binding.commitKey
+	seed := binding.seed
+	store := binding.store
+	binding.mu.Unlock()
+	if commitOnly {
+		if commitJobCredentialRuntimeRecovery(receipt, key, seed, receipt.FinalizedRevision) != nil {
+			return errL8RuntimeOwnerInvalid
+		}
+		if store != nil {
+			if _, err := store.Load(ctx); err == nil {
+				return errL8RuntimeOwnerInvalid
+			}
+		}
+		return nil
+	}
+	if store == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	record, err := store.Load(ctx)
+	if err != nil || record.State != "finalized" {
+		return errL8RuntimeOwnerInvalid
+	}
+	if commitJobCredentialRuntimeRecovery(receipt, key, seed, record.FinalizeTargetRevision) != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	if err := store.RetireFinalized(ctx, record.Revision, record.FinalizedCommitID); err != nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return nil
+}
+
+func (binding *l8RuntimeOwnerRecoveryBinding) Close(context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errL8RuntimeOwnerInvalid
+		}
+	}()
+	if binding == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	_, cancel := context.WithTimeout(context.Background(), sandboxruntime.JobCredentialRuntimeRecoveryCloseTimeout)
+	defer cancel()
+	binding.mu.Lock()
+	binding.closed = true
+	binding.mu.Unlock()
+	return nil
 }
 
 type l8RuntimeOwnerProcessObservation struct {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -87,6 +87,10 @@ type l8RuntimeOwnerRecoveryBinding struct {
 	commitOnly         bool
 }
 
+type l8RuntimeOwnerRecordAbsenceChecker interface {
+	RecordAbsent(context.Context) (bool, error)
+}
+
 var _ sandboxruntime.JobCredentialRuntimeRecoveryBinding = (*l8RuntimeOwnerRecoveryBinding)(nil)
 
 func (binding *l8RuntimeOwnerRecoveryBinding) RecoverJobCredentials(ctx context.Context, request sandboxruntime.JobCredentialRecoveryRequest) (proof sandboxruntime.JobCredentialCleanupProof, err error) {
@@ -243,19 +247,26 @@ func (binding *l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery
 		return errL8RuntimeOwnerInvalid
 	}
 	binding.mu.Lock()
+	if binding.closed {
+		binding.mu.Unlock()
+		return errL8RuntimeOwnerInvalid
+	}
 	commitOnly := binding.commitOnly
 	key := binding.commitKey
 	seed := binding.seed
 	store := binding.store
 	binding.mu.Unlock()
 	if commitOnly {
-		if commitJobCredentialRuntimeRecovery(receipt, key, seed, receipt.FinalizedRevision) != nil {
+		if commitJobCredentialRuntimeRecovery(receipt, key, seed, receipt.FinalizedRevision, "") != nil {
 			return errL8RuntimeOwnerInvalid
 		}
-		if store != nil {
-			if _, err := store.Load(ctx); err == nil {
-				return errL8RuntimeOwnerInvalid
-			}
+		absenceStore, ok := store.(l8RuntimeOwnerRecordAbsenceChecker)
+		if !ok {
+			return errL8RuntimeOwnerInvalid
+		}
+		absent, absenceErr := absenceStore.RecordAbsent(ctx)
+		if absenceErr != nil || !absent {
+			return errL8RuntimeOwnerInvalid
 		}
 		return nil
 	}
@@ -266,7 +277,7 @@ func (binding *l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery
 	if err != nil || record.State != "finalized" {
 		return errL8RuntimeOwnerInvalid
 	}
-	if commitJobCredentialRuntimeRecovery(receipt, key, seed, record.FinalizeTargetRevision) != nil {
+	if commitJobCredentialRuntimeRecovery(receipt, key, seed, record.FinalizeTargetRevision, record.FinalizedCommitID) != nil {
 		return errL8RuntimeOwnerInvalid
 	}
 	if err := store.RetireFinalized(ctx, record.Revision, record.FinalizedCommitID); err != nil {
@@ -275,13 +286,13 @@ func (binding *l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery
 	return nil
 }
 
-func (binding *l8RuntimeOwnerRecoveryBinding) Close(context.Context) (err error) {
+func (binding *l8RuntimeOwnerRecoveryBinding) Close(ctx context.Context) (err error) {
 	defer func() {
 		if recover() != nil {
 			err = errL8RuntimeOwnerInvalid
 		}
 	}()
-	if binding == nil {
+	if binding == nil || ctx == nil {
 		return errL8RuntimeOwnerInvalid
 	}
 	_, cancel := context.WithTimeout(context.Background(), sandboxruntime.JobCredentialRuntimeRecoveryCloseTimeout)
@@ -376,7 +387,7 @@ func l8RuntimeOwnerCommitID(key []byte, seedDigest [32]byte, revision uint64) (s
 	return base64.RawURLEncoding.EncodeToString(digest.Sum(nil)), nil
 }
 
-func commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, key []byte, seed sandboxruntime.JobCredentialIdentitySeed, expectedRevision uint64) error {
+func commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, key []byte, seed sandboxruntime.JobCredentialIdentitySeed, expectedRevision uint64, recordedCommitID string) error {
 	if sandboxruntime.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt) != nil {
 		return errL8RuntimeOwnerInvalid
 	}
@@ -391,6 +402,9 @@ func commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRunt
 	commitID := receipt.CommitID
 	if receipt.FinalizedRevision != expectedRevision || !validL8RuntimeOwnerToken(expectedCommitID) ||
 		subtle.ConstantTimeCompare([]byte(commitID), []byte(expectedCommitID)) != 1 {
+		return errL8RuntimeOwnerInvalid
+	}
+	if recordedCommitID != "" && subtle.ConstantTimeCompare([]byte(recordedCommitID), []byte(expectedCommitID)) != 1 {
 		return errL8RuntimeOwnerInvalid
 	}
 	return nil

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_linux_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8RuntimeOwnerRecoveryBindingStopReapDirectWaitOfTestChild(t *testing.T) {
+	path, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep executable unavailable")
+	}
+	command := exec.Command(path, "30")
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	reaped := false
+	defer func() {
+		if !reaped {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	}()
+	seed := l8RuntimeOwnerTestSeed()
+	now := time.Now().UTC()
+	var waitOnce sync.Once
+	binding := &l8RuntimeOwnerRecoveryBinding{
+		seed: seed,
+		now:  func() time.Time { return now },
+		proveAbsence: func(ctx context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+			observation, err := containL8RuntimeOwnerChild(l8RuntimeOwnerContainmentOps{
+				RecordStopping: func() (uint64, error) { return 1, nil },
+				Terminate:      func() error { return command.Process.Signal(syscall.SIGTERM) },
+				Wait: func(waitCtx context.Context) (bool, error) {
+					done := make(chan struct{})
+					go func() {
+						waitOnce.Do(func() {
+							_ = command.Wait()
+							reaped = true
+						})
+						close(done)
+					}()
+					select {
+					case <-done:
+						return true, nil
+					case <-waitCtx.Done():
+						return false, nil
+					}
+				},
+				Kill:            func() error { return command.Process.Kill() },
+				RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) (uint64, error) { return 1, nil },
+				RecordUncertain: func() (uint64, error) { return 1, nil },
+				Now:             func() time.Time { return now },
+			})
+			return observation, err
+		},
+	}
+	proof, err := binding.StopReapJobCredentialRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("direct-wait stop/reap: %v", err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now); err != nil {
+		t.Fatalf("direct-wait proof: %v", err)
+	}
+	if !reaped {
+		t.Fatal("direct-wait stop/reap did not Wait the child")
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingStopReapReplacementDoubleProc(t *testing.T) {
+	bootID, err := readL8RuntimeOwnerHostBootID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	record := l8RuntimeOwnerTestRecord(t, seed, bootID)
+	record.State, record.ControllerState, record.Revision = "running", "unclaimed", 2
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "", 0, 0
+	record.FirecrackerPID = 1<<30 - 7
+	now := time.Now().UTC()
+	binding := &l8RuntimeOwnerRecoveryBinding{
+		seed: seed,
+		now:  func() time.Time { return now },
+		proveAbsence: func(context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+			return containL8RuntimeOwnerReplacement(record, l8RuntimeOwnerReplacementOps{
+				CurrentBootID: func() (string, error) { return bootID, nil },
+				InspectSupervisor: func(uint32) (l8RuntimeOwnerProcessObservation, bool, error) {
+					return l8RuntimeOwnerProcessObservation{}, false, nil
+				},
+				InspectChild: func(uint32) (l8RuntimeOwnerProcessObservation, bool, error) {
+					return l8RuntimeOwnerProcessObservation{}, false, nil
+				},
+				ProcessAbsent: func(uint32) (bool, error) { return true, nil },
+				AcquisitionBarrier: func() error {
+					absent, err := inspectL8RuntimeOwnerProcessAbsent(record.FirecrackerPID)
+					if err != nil || !absent {
+						return errL8RuntimeOwnerInvalid
+					}
+					return nil
+				},
+				RecordAbsent:    func(l8RuntimeOwnerAbsenceObservation) (uint64, error) { return record.Revision + 1, nil },
+				RecordUncertain: func() (uint64, error) { return record.Revision + 1, nil },
+				Now:             func() time.Time { return now },
+			})
+		},
+	}
+	proof, err := binding.StopReapJobCredentialRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("replacement double-/proc stop/reap: %v", err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now); err != nil {
+		t.Fatalf("replacement proof: %v", err)
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
@@ -259,6 +259,13 @@ func TestL8RuntimeOwnerRecoveryBindingCommitUsesOwnerVerifier(t *testing.T) {
 		t.Fatalf("wrong HMAC commit = %v retired %t", err, store.retiredFinal)
 	}
 
+	store.retiredFinal = false
+	store.record = record
+	store.record.FinalizedCommitID = l8RuntimeOwnerTestToken(9)
+	if err := binding.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); !errors.Is(err, errL8RuntimeOwnerInvalid) || store.retiredFinal {
+		t.Fatalf("receipt/record commit mismatch = %v retired %t", err, store.retiredFinal)
+	}
+
 	commitOnly := &l8RuntimeOwnerRecoveryBinding{seed: seed, commitKey: key, store: &l8RuntimeOwnerMissingStore{}, commitOnly: true}
 	if err := commitOnly.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); err != nil {
 		t.Fatalf("commit-only: %v", err)
@@ -266,6 +273,19 @@ func TestL8RuntimeOwnerRecoveryBindingCommitUsesOwnerVerifier(t *testing.T) {
 	reappeared := &l8RuntimeOwnerRecoveryBinding{seed: seed, commitKey: key, store: store, commitOnly: true}
 	if err := reappeared.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("commit-only with record = %v", err)
+	}
+	uncertain := &l8RuntimeOwnerRecoveryBinding{seed: seed, commitKey: key, store: l8RuntimeOwnerUncertainMissingStore{}, commitOnly: true}
+	if err := uncertain.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("commit-only with uncertain record absence = %v", err)
+	}
+
+	store.record = record
+	store.retiredFinal = false
+	if err := binding.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := binding.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); !errors.Is(err, errL8RuntimeOwnerInvalid) || store.retiredFinal {
+		t.Fatalf("commit after close = %v retired %t", err, store.retiredFinal)
 	}
 }
 
@@ -290,6 +310,9 @@ func TestL8RuntimeOwnerRecoveryBindingCloseDoesNotImplyAbsence(t *testing.T) {
 	}
 	if _, err := binding.StopReapJobCredentialRuntime(context.Background()); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("stop/reap after close = %v", err)
+	}
+	if err := binding.Close(nil); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("close with nil context = %v", err)
 	}
 }
 
@@ -374,6 +397,10 @@ func bytes32(value string) []byte {
 
 type l8RuntimeOwnerMissingStore struct{}
 
+func (l8RuntimeOwnerMissingStore) RecordAbsent(context.Context) (bool, error) {
+	return true, nil
+}
+
 func (l8RuntimeOwnerMissingStore) Load(context.Context) (firecrackerRuntimeOwnerRecordV1, error) {
 	return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 }
@@ -388,4 +415,12 @@ func (l8RuntimeOwnerMissingStore) RetireStartingZero(context.Context, uint64) er
 }
 func (l8RuntimeOwnerMissingStore) RetireFinalized(context.Context, uint64, string) error {
 	return errL8RuntimeOwnerInvalid
+}
+
+type l8RuntimeOwnerUncertainMissingStore struct {
+	l8RuntimeOwnerMissingStore
+}
+
+func (l8RuntimeOwnerUncertainMissingStore) RecordAbsent(context.Context) (bool, error) {
+	return false, errors.New("private record inspection failed")
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
@@ -1,0 +1,391 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8RuntimeOwnerRecoveryBindingSatisfiesInterface(t *testing.T) {
+	var _ sandboxruntime.JobCredentialRuntimeRecoveryBinding = (*l8RuntimeOwnerRecoveryBinding)(nil)
+}
+
+func TestL8RuntimeOwnerRecoveryBindingRecoverRequiresCompleteIdentityThenAlwaysStopReaps(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	identity := l8RuntimeOwnerTestIdentity(t, seed)
+	record := l8RuntimeOwnerTestRunningRecord(t, seed)
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, func() (l8RuntimeOwnerAbsenceObservation, error) {
+		return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: seed.IssuedAt.Add(2 * time.Second)}, nil
+	})
+	stopCalls := 0
+	inner := binding.proveAbsence
+	binding.proveAbsence = func(ctx context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+		stopCalls++
+		return inner(ctx)
+	}
+
+	mismatch := identity
+	mismatch.RuntimeID = "runtime-neighbor"
+	proof, err := binding.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{Identity: mismatch, Revision: 1})
+	if proof != (sandboxruntime.JobCredentialCleanupProof{}) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("mismatch recover = %#v, %v", proof, err)
+	}
+	if stopCalls != 0 || store.record.State != "running" {
+		t.Fatalf("mismatch contained: calls %d state %s", stopCalls, store.record.State)
+	}
+
+	cleanup := l8RuntimeOwnerTestCleanupProof(t, identity)
+	binding.recoverCredentials = func(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+		return cleanup, nil
+	}
+	got, err := binding.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{Identity: identity, Revision: 4})
+	if err != nil || got != cleanup {
+		t.Fatalf("complete-identity recover = %#v, %v", got, err)
+	}
+	if stopCalls != 1 || store.record.State != "absent" {
+		t.Fatalf("valid recover skipped stop/reap: calls %d state %s", stopCalls, store.record.State)
+	}
+
+	binding.recoverCredentials = func(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+		return sandboxruntime.JobCredentialCleanupProof{}, errors.New("private credential path /tmp/secret pid=4242")
+	}
+	failed, err := binding.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{Identity: identity, Revision: 4})
+	if failed != (sandboxruntime.JobCredentialCleanupProof{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("failed recover = %#v, %v", failed, err)
+	}
+	if stopCalls != 2 {
+		t.Fatalf("failed recover skipped stop/reap: calls %d", stopCalls)
+	}
+	if strings.Contains(err.Error(), "pid") || strings.Contains(err.Error(), "/tmp") || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("recover error leaked internals: %v", err)
+	}
+
+	binding.recoverCredentials = func(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+		panic("private recover panic")
+	}
+	if _, err := binding.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{Identity: identity, Revision: 4}); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("panic recover = %v", err)
+	}
+	if stopCalls != 3 {
+		t.Fatalf("panic recover skipped stop/reap: calls %d", stopCalls)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingStopReapIsSoleAbsenceProofIssuer(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	now := seed.IssuedAt.Add(time.Minute)
+	record := l8RuntimeOwnerTestRunningRecord(t, seed)
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, func() (l8RuntimeOwnerAbsenceObservation, error) {
+		return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: seed.IssuedAt.Add(3 * time.Second)}, nil
+	})
+	binding.now = func() time.Time { return now }
+
+	proof, err := binding.StopReapJobCredentialRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("stop/reap: %v", err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now); err != nil {
+		t.Fatalf("issued proof invalid: %v", err)
+	}
+	if store.record.State != "absent" || store.record.AbsenceKind != "direct_wait" {
+		t.Fatalf("absent record = %#v", store.record)
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	fresh, err := binding.StopReapJobCredentialRuntime(canceled)
+	if err != nil {
+		t.Fatalf("reinspect after cancel: %v", err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(fresh, seed, now); err != nil || fresh == proof {
+		t.Fatalf("fresh absence proof = %#v, %v", fresh, err)
+	}
+
+	failed := &l8RuntimeOwnerRecoveryBinding{seed: seed, proveAbsence: func(context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+		return l8RuntimeOwnerAbsenceObservation{}, errors.New("private wait /proc/4242")
+	}}
+	zero, err := failed.StopReapJobCredentialRuntime(context.Background())
+	if zero != (sandboxruntime.JobCredentialRuntimeAbsenceProof{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("failed stop/reap = %#v, %v", zero, err)
+	}
+	if strings.Contains(err.Error(), "4242") || strings.Contains(err.Error(), "/proc") {
+		t.Fatalf("stop/reap error leaked internals: %v", err)
+	}
+
+	boolean := &l8RuntimeOwnerRecoveryBinding{seed: seed, proveAbsence: func(context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+		return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindNone, ObservedAt: now}, nil
+	}}
+	if proof, err := boolean.StopReapJobCredentialRuntime(context.Background()); proof != (sandboxruntime.JobCredentialRuntimeAbsenceProof{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("caller boolean minted proof = %#v, %v", proof, err)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingStopReapReplacementProcIssuesProof(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	now := seed.IssuedAt.Add(time.Minute)
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState = "absent", "controlled"
+	store := &l8RuntimeOwnerTestStore{record: record}
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store: store, ExpectedUID: 1000, CommitKey: bytes32("0123456789abcdef0123456789abcdef"),
+		ReinspectAbsence: func() (l8RuntimeOwnerAbsenceObservation, error) {
+			return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindProc, ObservedAt: seed.IssuedAt.Add(4 * time.Second)}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := &l8RuntimeOwnerRecoveryBinding{
+		seed: seed, store: store, commitKey: bytes32("0123456789abcdef0123456789abcdef"),
+		now: func() time.Time { return now },
+		proveAbsence: func(ctx context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+			loaded, err := store.Load(ctx)
+			if err != nil {
+				return l8RuntimeOwnerAbsenceObservation{}, err
+			}
+			next, err := owner.reinspectAbsence(ctx, loaded)
+			if err != nil {
+				return l8RuntimeOwnerAbsenceObservation{}, err
+			}
+			return l8RuntimeOwnerAbsenceObservation{
+				Kind:       l8RuntimeOwnerAbsenceKindByte(next.AbsenceKind),
+				Revision:   next.AbsenceRevision,
+				ObservedAt: time.Unix(0, next.AbsenceObservedAtUnixNano).UTC(),
+			}, nil
+		},
+	}
+	proof, err := binding.StopReapJobCredentialRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("replacement stop/reap: %v", err)
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now); err != nil {
+		t.Fatalf("replacement proof: %v", err)
+	}
+	if store.record.AbsenceKind != "replacement_proc" {
+		t.Fatalf("absence kind = %s", store.record.AbsenceKind)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingFinalizeFailClosesWithoutRecoveredL7Binding(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	now := seed.IssuedAt.Add(time.Minute)
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState = "absent", "controlled"
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, nil)
+	binding.now = func() time.Time { return now }
+	binding.proveAbsence = func(context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+		return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: seed.IssuedAt.Add(time.Second)}, nil
+	}
+	proof, err := sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{
+		Seed: seed, AbsenceInspectedAt: seed.IssuedAt.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof)
+	if receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("finalize without recovered L7 = %#v, %v", receipt, err)
+	}
+	if store.record.State != "absent" {
+		t.Fatalf("finalize persisted tombstone without L7: %#v", store.record)
+	}
+
+	stale := proof
+	binding.now = func() time.Time {
+		return seed.IssuedAt.Add(sandboxruntime.MaxJobCredentialRuntimeAbsenceObservationAge + 2*time.Minute)
+	}
+	if _, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), stale); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("stale finalize = %v", err)
+	}
+	binding.now = func() time.Time { return now }
+	binding.currentBootID = func() (string, error) { return "22345678-1234-4abc-8def-1234567890ab", nil }
+	if _, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("old-boot finalize = %v", err)
+	}
+	if store.record.State != "absent" {
+		t.Fatalf("old-boot retired state: %#v", store.record)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingCommitUsesOwnerVerifier(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	key := bytes32("0123456789abcdef0123456789abcdef")
+	digest, err := l8RuntimeOwnerSeedDigest(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commitID, err := l8RuntimeOwnerCommitID(key, digest, 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "finalized", "controlled", 9
+	record.FinalizeTargetRevision = 9
+	record.FinalizedCommitID = commitID
+	store := &l8RuntimeOwnerTestStore{record: record}
+	binding := &l8RuntimeOwnerRecoveryBinding{seed: seed, commitKey: key, store: store}
+	receipt := sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{CommitID: commitID, FinalizedRevision: 9}
+	if err := binding.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if !store.retiredFinal {
+		t.Fatal("commit did not retire finalized record")
+	}
+
+	store.retiredFinal = false
+	store.record = record
+	wrong := receipt
+	wrong.CommitID = l8RuntimeOwnerTestToken(9)
+	if err := binding.CommitJobCredentialRuntimeRecovery(context.Background(), wrong); !errors.Is(err, errL8RuntimeOwnerInvalid) || store.retiredFinal {
+		t.Fatalf("wrong HMAC commit = %v retired %t", err, store.retiredFinal)
+	}
+
+	commitOnly := &l8RuntimeOwnerRecoveryBinding{seed: seed, commitKey: key, store: &l8RuntimeOwnerMissingStore{}, commitOnly: true}
+	if err := commitOnly.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); err != nil {
+		t.Fatalf("commit-only: %v", err)
+	}
+	reappeared := &l8RuntimeOwnerRecoveryBinding{seed: seed, commitKey: key, store: store, commitOnly: true}
+	if err := reappeared.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("commit-only with record = %v", err)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingCloseDoesNotImplyAbsence(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	record := l8RuntimeOwnerTestRunningRecord(t, seed)
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, func() (l8RuntimeOwnerAbsenceObservation, error) {
+		t.Fatal("close must not stop/reap")
+		return l8RuntimeOwnerAbsenceObservation{}, nil
+	})
+	if err := binding.Close(context.Background()); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := binding.Close(context.Background()); err != nil {
+		t.Fatalf("idempotent close: %v", err)
+	}
+	if store.record.State != "running" || store.retiredFinal {
+		t.Fatalf("close retired owner state: %#v", store.record)
+	}
+	if _, err := binding.StopReapJobCredentialRuntime(context.Background()); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("stop/reap after close = %v", err)
+	}
+}
+
+func l8RuntimeOwnerTestIdentity(t *testing.T, seed sandboxruntime.JobCredentialIdentitySeed) sandboxruntime.JobCredentialIdentity {
+	t.Helper()
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8RuntimeOwnerTestToken(4), "helper-generation-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func l8RuntimeOwnerTestCleanupProof(t *testing.T, identity sandboxruntime.JobCredentialIdentity) sandboxruntime.JobCredentialCleanupProof {
+	t.Helper()
+	proof, err := sandboxruntime.NewJobCredentialCleanupProof(sandboxruntime.JobCredentialCleanupProofInput{
+		ProofID:            "cleanup-runtime-owner",
+		Identity:           identity,
+		Revision:           4,
+		RevokedAt:          identity.IssuedAt.Add(time.Second),
+		AbsenceInspectedAt: identity.IssuedAt.Add(2 * time.Second),
+		AuthorityAbsent:    true,
+		ResourcesAbsent:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return proof
+}
+
+func l8RuntimeOwnerTestRunningRecord(t *testing.T, seed sandboxruntime.JobCredentialIdentitySeed) firecrackerRuntimeOwnerRecordV1 {
+	t.Helper()
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState, record.Revision = "running", "controlled", 2
+	record.AbsenceKind, record.AbsenceRevision, record.AbsenceObservedAtUnixNano = "", 0, 0
+	return record
+}
+
+func l8RuntimeOwnerTestRecoveryBinding(t *testing.T, record firecrackerRuntimeOwnerRecordV1, contain func() (l8RuntimeOwnerAbsenceObservation, error)) (*l8RuntimeOwnerRecoveryBinding, *l8RuntimeOwnerTestStore) {
+	t.Helper()
+	seed := l8RuntimeOwnerTestSeed()
+	store := &l8RuntimeOwnerTestStore{record: record}
+	key := bytes32("0123456789abcdef0123456789abcdef")
+	owner, err := newL8RuntimeOwnerSupervisor(l8RuntimeOwnerSupervisorOptions{
+		Store: store, ExpectedUID: 1000, CommitKey: key, ContainChild: contain,
+		ReinspectAbsence: func() (l8RuntimeOwnerAbsenceObservation, error) {
+			return l8RuntimeOwnerAbsenceObservation{Kind: l8RuntimeOwnerAbsenceKindWait, ObservedAt: seed.IssuedAt.Add(5 * time.Second)}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := &l8RuntimeOwnerRecoveryBinding{
+		seed:      seed,
+		commitKey: key,
+		store:     store,
+		now:       func() time.Time { return seed.IssuedAt.Add(time.Minute) },
+		currentBootID: func() (string, error) {
+			return record.HostBootID, nil
+		},
+		proveAbsence: func(ctx context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+			loaded, err := store.Load(ctx)
+			if err != nil {
+				return l8RuntimeOwnerAbsenceObservation{}, err
+			}
+			next, err := owner.reinspectAbsence(ctx, loaded)
+			if err != nil {
+				return l8RuntimeOwnerAbsenceObservation{}, err
+			}
+			return l8RuntimeOwnerAbsenceObservation{
+				Kind:       l8RuntimeOwnerAbsenceKindByte(next.AbsenceKind),
+				Revision:   next.AbsenceRevision,
+				ObservedAt: time.Unix(0, next.AbsenceObservedAtUnixNano).UTC(),
+			}, nil
+		},
+	}
+	return binding, store
+}
+
+func bytes32(value string) []byte {
+	return []byte(value)
+}
+
+type l8RuntimeOwnerMissingStore struct{}
+
+func (l8RuntimeOwnerMissingStore) Load(context.Context) (firecrackerRuntimeOwnerRecordV1, error) {
+	return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+}
+func (l8RuntimeOwnerMissingStore) CreateGenesis(context.Context, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+}
+func (l8RuntimeOwnerMissingStore) Transition(context.Context, uint64, firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
+	return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+}
+func (l8RuntimeOwnerMissingStore) RetireStartingZero(context.Context, uint64) error {
+	return errL8RuntimeOwnerInvalid
+}
+func (l8RuntimeOwnerMissingStore) RetireFinalized(context.Context, uint64, string) error {
+	return errL8RuntimeOwnerInvalid
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_other_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_other_test.go
@@ -3,8 +3,11 @@
 package firecrackerhost
 
 import (
+	"context"
 	"errors"
 	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
 )
 
 func TestL8RuntimeOwnerNonLinuxFoundationFailsClosed(t *testing.T) {
@@ -23,5 +26,15 @@ func TestL8RuntimeOwnerNonLinuxFoundationFailsClosed(t *testing.T) {
 	}
 	if value, err := readL8RuntimeOwnerRecord("/unsupported", seed, "boot"); value != (firecrackerRuntimeOwnerRecordV1{}) || !errors.Is(err, errL8RuntimeOwnerUnsupported) {
 		t.Fatalf("read record = %#v, %v", value, err)
+	}
+	binding := &l8RuntimeOwnerRecoveryBinding{seed: seed, proveAbsence: func(context.Context) (l8RuntimeOwnerAbsenceObservation, error) {
+		t.Fatal("non-Linux stop/reap must fail closed before absence observation")
+		return l8RuntimeOwnerAbsenceObservation{}, nil
+	}}
+	if proof, err := binding.StopReapJobCredentialRuntime(context.Background()); proof != (sandboxruntime.JobCredentialRuntimeAbsenceProof{}) || !errors.Is(err, errL8RuntimeOwnerUnsupported) {
+		t.Fatalf("non-Linux stop/reap = %#v, %v", proof, err)
+	}
+	if receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), sandboxruntime.JobCredentialRuntimeAbsenceProof{}); receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerUnsupported) {
+		t.Fatalf("non-Linux finalize = %#v, %v", receipt, err)
 	}
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_test.go
@@ -76,24 +76,27 @@ func TestL8RuntimeOwnerCommitVerifierRecomputesSeedBoundHMAC(t *testing.T) {
 		t.Fatal(err)
 	}
 	receipt := sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{CommitID: commitID, FinalizedRevision: 8}
-	if err := commitJobCredentialRuntimeRecovery(receipt, key, seed, 8); err != nil {
+	if err := commitJobCredentialRuntimeRecovery(receipt, key, seed, 8, commitID); err != nil {
 		t.Fatalf("commit verifier: %v", err)
 	}
 	wrongKey := []byte("1123456789abcdef0123456789abcdef")
-	if err := commitJobCredentialRuntimeRecovery(receipt, wrongKey, seed, 8); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+	if err := commitJobCredentialRuntimeRecovery(receipt, wrongKey, seed, 8, commitID); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("wrong commit verifier = %v", err)
 	}
-	if err := commitJobCredentialRuntimeRecovery(receipt, key, seed, 9); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+	if err := commitJobCredentialRuntimeRecovery(receipt, key, seed, 9, commitID); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("replayed revision verifier = %v", err)
 	}
 	mutatedSeed := seed
 	mutatedSeed.RuntimeID = "runtime-neighbor"
-	if err := commitJobCredentialRuntimeRecovery(receipt, key, mutatedSeed, 8); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+	if err := commitJobCredentialRuntimeRecovery(receipt, key, mutatedSeed, 8, commitID); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("substituted seed verifier = %v", err)
+	}
+	if err := commitJobCredentialRuntimeRecovery(receipt, key, seed, 8, l8RuntimeOwnerTestToken(10)); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("substituted record commit ID verifier = %v", err)
 	}
 	forgedID := l8RuntimeOwnerTestToken(9)
 	forged := sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{CommitID: forgedID, FinalizedRevision: 8}
-	if err := commitJobCredentialRuntimeRecovery(forged, key, seed, 8); !errors.Is(err, errL8RuntimeOwnerInvalid) {
+	if err := commitJobCredentialRuntimeRecovery(forged, key, seed, 8, commitID); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("caller-selected commit ID verifier = %v, want invalid", err)
 	}
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux.go
@@ -437,6 +437,16 @@ func (store *l8RuntimeOwnerLinuxRecordStore) Load(ctx context.Context) (firecrac
 	return record, nil
 }
 
+func (store *l8RuntimeOwnerLinuxRecordStore) RecordAbsent(ctx context.Context) (bool, error) {
+	_, present, err := store.withLock(ctx, unix.LOCK_SH, func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
+		return readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)
+	})
+	if err != nil {
+		return false, errL8RuntimeOwnerInvalid
+	}
+	return !present, nil
+}
+
 func (store *l8RuntimeOwnerLinuxRecordStore) CreateGenesis(ctx context.Context, next firecrackerRuntimeOwnerRecordV1) (firecrackerRuntimeOwnerRecordV1, error) {
 	record, _, err := store.withLock(ctx, unix.LOCK_EX, func() (firecrackerRuntimeOwnerRecordV1, bool, error) {
 		_, present, readErr := readL8RuntimeOwnerRecordAt(store.directoryFD, store.seed, store.bootID)

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_runtime_linux_test.go
@@ -28,9 +28,19 @@ func TestL8RuntimeOwnerLinuxRecordStorePersistsExactFSM(t *testing.T) {
 	seed := l8RuntimeOwnerTestSeed()
 	bootID := "01234567-89ab-cdef-0123-456789abcdef"
 	store := &l8RuntimeOwnerLinuxRecordStore{directoryFD: directoryFD, seed: seed, bootID: bootID}
+	if absent, err := store.RecordAbsent(context.Background()); err != nil || !absent {
+		t.Fatalf("initial record absence = %t, %v", absent, err)
+	}
 	genesis := l8RuntimeOwnerTestGenesis(l8RuntimeOwnerTestRecord(t, seed, bootID))
 	if created, err := store.CreateGenesis(context.Background(), genesis); err != nil || created != genesis {
 		t.Fatalf("create genesis = %#v, %v", created, err)
+	}
+	if absent, err := store.RecordAbsent(context.Background()); err != nil || absent {
+		t.Fatalf("present record absence = %t, %v", absent, err)
+	}
+	invalidStore := &l8RuntimeOwnerLinuxRecordStore{directoryFD: -1, seed: seed, bootID: bootID}
+	if absent, err := invalidStore.RecordAbsent(context.Background()); !errors.Is(err, errL8RuntimeOwnerInvalid) || absent {
+		t.Fatalf("uncertain record absence = %t, %v", absent, err)
 	}
 	if _, err := store.CreateGenesis(context.Background(), genesis); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("duplicate genesis = %v", err)


### PR DESCRIPTION
## Summary

Stacked on `feature/sandbox-runtime-secure-default-v2` (`1926e937`).

Makes `l8RuntimeOwnerRecoveryBinding` a real recovery binding:

- Complete-identity `RecoverJobCredentials` then **always** `StopReapJobCredentialRuntime`
- Stop/reap is the **sole** production `NewJobCredentialRuntimeAbsenceProof` callsite, after injectable exact-absence proof (`direct_wait` / `replacement_proc`)
- Finalize uses the locked signature and does **not** read `receipt.CommitID`
- AST guard tightened from zero issuers to exactly one StopReap callsite

Honest remaining fail-closed: Finalize does not persist `finalized` because recovered L7 `TerminatedVMBinding` does not exist yet. Old-boot journal retirement is not invented. No host `JobCredentialRuntime` Preflight/Prepare (see https://github.com/j-yw/hal/pull/43). No worker/cmd default wiring.

## Tests

```
go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'TestL8RuntimeOwner' -count=1
go test ./cmd -run '^TestL8D6RuntimeOwner' -count=1
go vet ./internal/sandboxruntime/microvm/firecrackerhost ./cmd
```

## Queue

Behind https://github.com/j-yw/hal/pull/42 and https://github.com/j-yw/hal/pull/43. Do not merge to `develop`.

## Review focus

Confirm Finalize's unconditional fail-closed after boot/state checks is honesty, not a stub that should have returned a receipt. Confirm the issuer guard is exactly one production callsite.