### PR TITLE
feat: wire L8 worker credential prepare and recovery

### DIFF
--- a/cmd/l8_d6_runtime_owner_contract_test.go
+++ b/cmd/l8_d6_runtime_owner_contract_test.go
@@ -347,11 +347,13 @@ func TestL8D6RuntimeOwnerContractCommitReceiptHasOnePrivateStoreProjection(t *te
 		rootValidator = "../internal/sandboxruntime/job_credential_runtime_recovery.go"
 		ownerVerifier = "../internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go"
 		privateStore  = "../internal/sandboxworker/job_store_v2.go"
+		privateReplay = "../internal/sandboxworker/job_store_v2_recovery_receipt.go"
 	)
 	expected := map[string]l8D6RuntimeOwnerCommitReceiptFunction{
 		rootValidator: {name: "ValidateJobCredentialRuntimeRecoveryCommitReceipt", rootType: true, rootPackage: true, exactOneParameter: true},
 		ownerVerifier: {name: "commitJobCredentialRuntimeRecovery", allowFinalizerResult: true},
 		privateStore:  {name: "storedJobCredentialRuntimeRecoveryReceiptV1FromRuntime", storeConverter: true},
+		privateReplay: {name: "storedJobCredentialRuntimeRecoveryReceiptV1ToRuntime", storeDecoder: true},
 	}
 	audits := make(map[string]l8D6RuntimeOwnerCommitReceiptAudit)
 	err := filepath.WalkDir("..", func(path string, entry fs.DirEntry, walkErr error) error {
@@ -399,6 +401,8 @@ func TestL8D6RuntimeOwnerContractCommitReceiptHasOnePrivateStoreProjection(t *te
 		t.Fatalf("production commit receipt accesses = %#v, root API error %v; want exact root and owner functions", audits, err)
 	} else if private, ok := audits[privateStore]; ok && !private.exact() {
 		t.Fatalf("private-store commit receipt access = %#v, want absent or exact future converter", private)
+	} else if replay, ok := audits[privateReplay]; ok && !replay.exact() {
+		t.Fatalf("private-store commit receipt replay = %#v, want absent or exact replay decoder", replay)
 	}
 
 	validFixture := []byte("package firecrackerhost\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { commitID := receipt.CommitID; _ = commitID; return nil }\n")
@@ -493,6 +497,12 @@ func TestL8D6RuntimeOwnerContractCommitReceiptHasOnePrivateStoreProjection(t *te
 			}
 		})
 	}
+	decoderEscapeFixture := []byte("package sandboxworker\nimport sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\"\ntype storedJobCredentialRuntimeRecoveryReceiptV1 struct { ContractVersion string; CommitID string; FinalizedRevision uint64 }\nvar retained any\nfunc storedJobCredentialRuntimeRecoveryReceiptV1ToRuntime(stored storedJobCredentialRuntimeRecoveryReceiptV1) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) { receipt.CommitID = stored.CommitID; receipt.FinalizedRevision = stored.FinalizedRevision; retained = receipt; return receipt, nil }\n")
+	if audit, err := l8D6RuntimeOwnerCommitReceiptAccessAudit(decoderEscapeFixture, expected[privateReplay]); err != nil {
+		t.Fatal(err)
+	} else if audit.exact() && len(audit.issues) == 0 {
+		t.Fatalf("private replay receipt escape passed audit: %#v", audit)
+	}
 }
 
 type l8D6RuntimeOwnerCommitReceiptFunction struct {
@@ -501,6 +511,7 @@ type l8D6RuntimeOwnerCommitReceiptFunction struct {
 	rootPackage          bool
 	exactOneParameter    bool
 	storeConverter       bool
+	storeDecoder         bool
 	allowFinalizerResult bool
 }
 
@@ -592,6 +603,7 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 			continue
 		}
 		if !expected.rootType && !l8D6RuntimeOwnerReceiptTypeIsTargetParameter(reference, target) &&
+			!(expected.storeDecoder && l8D6RuntimeOwnerReceiptTypeIsStoreDecoderResult(reference, target, parents)) &&
 			!(expected.allowFinalizerResult && l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file, reference, parents)) {
 			audit.issues = append(audit.issues, "receipt type referenced outside the exact allowlisted function parameter")
 		}
@@ -603,6 +615,9 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 		audit.issues = append(audit.issues, "expected package function is a receiver method")
 	}
 	receiptObjects := l8D6RuntimeOwnerReceiptParameterObjects(file, target, expected.rootType)
+	if expected.storeDecoder {
+		receiptObjects = l8D6RuntimeOwnerStoredReceiptParameterObjects(target)
+	}
 	if len(receiptObjects) != 1 {
 		audit.issues = append(audit.issues, fmt.Sprintf("receipt-typed parameter count = %d", len(receiptObjects)))
 	}
@@ -611,12 +626,18 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 	}
 	if expected.storeConverter && !l8D6RuntimeOwnerReturnsStoredReceiptAndError(target) {
 		audit.issues = append(audit.issues, "private-store converter result signature is not exact")
-	} else if !expected.storeConverter && !l8D6RuntimeOwnerReturnsOnlyError(target) {
+	} else if expected.storeDecoder && !l8D6RuntimeOwnerReturnsRuntimeReceiptAndError(target) {
+		audit.issues = append(audit.issues, "private-store replay decoder result signature is not exact")
+	} else if !expected.storeConverter && !expected.storeDecoder && !l8D6RuntimeOwnerReturnsOnlyError(target) {
 		audit.issues = append(audit.issues, "expected function does not return only error")
 	}
 	receiptObject := (*ast.Object)(nil)
 	if len(receiptObjects) == 1 {
 		receiptObject = receiptObjects[0]
+	}
+	resultObject := (*ast.Object)(nil)
+	if expected.storeDecoder && target.Type.Results != nil && len(target.Type.Results.List) == 2 && len(target.Type.Results.List[0].Names) == 1 {
+		resultObject = target.Type.Results.List[0].Names[0].Obj
 	}
 	ast.Inspect(file, func(node ast.Node) bool {
 		selector, ok := node.(*ast.SelectorExpr)
@@ -625,6 +646,10 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 		}
 		owner := l8D6RuntimeOwnerContainingFunction(selector, parents)
 		identifier, direct := selector.X.(*ast.Ident)
+		if expected.storeDecoder && owner == target && direct && resultObject != nil && identifier.Obj == resultObject &&
+			(selector.Sel.Name == "CommitID" || selector.Sel.Name == "FinalizedRevision") && l8D6RuntimeOwnerSelectorIsDirectAssignmentTarget(selector, parents) {
+			return true
+		}
 		if owner != target || !direct || receiptObject == nil || identifier.Obj != receiptObject || l8D6RuntimeOwnerInsideClosure(selector, target, parents) {
 			audit.issues = append(audit.issues, "CommitID read is not the direct receipt parameter in the exact function")
 			return true
@@ -641,13 +666,38 @@ func l8D6RuntimeOwnerCommitReceiptAccessAudit(payload []byte, expected l8D6Runti
 			}
 			audit.receiptReferences++
 			parent := parents[identifier]
-			if selector, ok := parent.(*ast.SelectorExpr); ok && selector.X == identifier && (selector.Sel.Name == "CommitID" || selector.Sel.Name == "FinalizedRevision") && !l8D6RuntimeOwnerInsideClosure(selector, target, parents) {
+			if selector, ok := parent.(*ast.SelectorExpr); ok && selector.X == identifier &&
+				(selector.Sel.Name == "CommitID" || selector.Sel.Name == "FinalizedRevision" || expected.storeDecoder && selector.Sel.Name == "ContractVersion") &&
+				!l8D6RuntimeOwnerInsideClosure(selector, target, parents) {
 				return true
 			}
 			if call, ok := parent.(*ast.CallExpr); ok && l8D6RuntimeOwnerIsReceiptValidatorCall(call.Fun, runtimeAliases) && !expected.rootType {
 				return true
 			}
 			audit.issues = append(audit.issues, "receipt parameter escapes direct field validation")
+			return true
+		})
+	}
+	if expected.storeDecoder && resultObject != nil {
+		runtimeAliases := l8D6RuntimeOwnerImportAliases(file, "github.com/jywlabs/hal/internal/sandboxruntime")
+		ast.Inspect(target.Body, func(node ast.Node) bool {
+			identifier, ok := node.(*ast.Ident)
+			if !ok || identifier.Obj != resultObject {
+				return true
+			}
+			parent := parents[identifier]
+			if selector, ok := parent.(*ast.SelectorExpr); ok && selector.X == identifier &&
+				(selector.Sel.Name == "CommitID" || selector.Sel.Name == "FinalizedRevision") &&
+				l8D6RuntimeOwnerSelectorIsDirectAssignmentTarget(selector, parents) {
+				return true
+			}
+			if call, ok := parent.(*ast.CallExpr); ok && l8D6RuntimeOwnerIsReceiptValidatorCall(call.Fun, runtimeAliases) {
+				return true
+			}
+			if returned, ok := parent.(*ast.ReturnStmt); ok && len(returned.Results) == 2 && returned.Results[0] == identifier {
+				return true
+			}
+			audit.issues = append(audit.issues, "private replay receipt escapes the exact validator and return path")
 			return true
 		})
 	}
@@ -859,6 +909,14 @@ func l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file *ast.File, reference
 		len(secondResult.Names) == 0 && l8D6RuntimeOwnerTypeName(secondResult.Type) == "error" && firstParameter && secondParameter
 }
 
+func l8D6RuntimeOwnerReceiptTypeIsStoreDecoderResult(reference ast.Expr, function *ast.FuncDecl, parents map[ast.Node]ast.Node) bool {
+	if function == nil || l8D6RuntimeOwnerContainingFunction(reference, parents) != function || function.Type.Results == nil || len(function.Type.Results.List) != 2 {
+		return false
+	}
+	first := function.Type.Results.List[0]
+	return len(first.Names) == 1 && first.Names[0].Name == "receipt" && first.Type == reference
+}
+
 func l8D6RuntimeOwnerExactImportedType(expression ast.Expr, aliases map[string]bool, name string) bool {
 	selector, ok := expression.(*ast.SelectorExpr)
 	if !ok || selector.Sel.Name != name {
@@ -918,6 +976,18 @@ func l8D6RuntimeOwnerReceiptParameterObjects(file *ast.File, function *ast.FuncD
 	return objects
 }
 
+func l8D6RuntimeOwnerStoredReceiptParameterObjects(function *ast.FuncDecl) []*ast.Object {
+	if function == nil || function.Type.Params == nil || len(function.Type.Params.List) != 1 {
+		return nil
+	}
+	field := function.Type.Params.List[0]
+	identifier, ok := field.Type.(*ast.Ident)
+	if !ok || identifier.Name != "storedJobCredentialRuntimeRecoveryReceiptV1" || len(field.Names) != 1 || field.Names[0].Obj == nil {
+		return nil
+	}
+	return []*ast.Object{field.Names[0].Obj}
+}
+
 func l8D6RuntimeOwnerExactRootReceiptType(identifier *ast.Ident) bool {
 	if identifier == nil || identifier.Obj == nil {
 		return false
@@ -967,6 +1037,29 @@ func l8D6RuntimeOwnerReturnsStoredReceiptAndError(function *ast.FuncDecl) bool {
 	first, second := function.Type.Results.List[0], function.Type.Results.List[1]
 	return len(first.Names) == 0 && l8D6RuntimeOwnerTypeName(first.Type) == "storedJobCredentialRuntimeRecoveryReceiptV1" &&
 		len(second.Names) == 0 && l8D6RuntimeOwnerTypeName(second.Type) == "error"
+}
+
+func l8D6RuntimeOwnerReturnsRuntimeReceiptAndError(function *ast.FuncDecl) bool {
+	if function.Type.Results == nil || len(function.Type.Results.List) != 2 {
+		return false
+	}
+	first, second := function.Type.Results.List[0], function.Type.Results.List[1]
+	selector, ok := first.Type.(*ast.SelectorExpr)
+	return ok && len(first.Names) == 1 && first.Names[0].Name == "receipt" && selector.Sel.Name == "JobCredentialRuntimeRecoveryCommitReceipt" &&
+		len(second.Names) == 1 && second.Names[0].Name == "err" && l8D6RuntimeOwnerTypeName(second.Type) == "error"
+}
+
+func l8D6RuntimeOwnerSelectorIsDirectAssignmentTarget(selector *ast.SelectorExpr, parents map[ast.Node]ast.Node) bool {
+	assignment, ok := parents[selector].(*ast.AssignStmt)
+	if !ok || assignment.Tok != token.ASSIGN {
+		return false
+	}
+	for _, left := range assignment.Lhs {
+		if left == selector {
+			return true
+		}
+	}
+	return false
 }
 
 func l8D6RuntimeOwnerContainingFunction(node ast.Node, parents map[ast.Node]ast.Node) *ast.FuncDecl {

--- a/docs/design/sandbox-runtime-v2-l8-d6-worker-credential-lifecycle-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-worker-credential-lifecycle-verification.md
@@ -1,0 +1,51 @@
+# L8 D6 Worker Credential Lifecycle Verification
+
+This note covers the worker-only D6 slice that wires prepare/renew/loss/revoke
+around durable `sandboxjob-v2` jobs. It does not implement Firecracker, the
+guest helper, or live source resolution.
+
+## Real operations
+
+- Authenticated `job_start_v2` with production credential intent binds through
+  the injected `JobCredentialRuntimeBinder`, persists the seed, preflights,
+  persists the complete identity, then `Prepare`s. A non-nil session with nil
+  error transfers ownership; the worker activates the session proof and retains
+  an in-memory handle. Failure before transfer aborts the preflight.
+- Authenticated `job_cancel_v2` revokes the transferred session, then clears
+  private credential state. Loss on the transferred latch follows the same
+  revoke/clear order.
+- Restart recovery is explicit. A typed-nil `RecoveryProvider` fails closed at
+  `NewL8DurableService`. A missing provider still returns
+  `ErrL8RecoveryDependency` when retained credential ownership exists.
+  Complete-identity restart calls `RecoverJobCredentials` then always
+  `StopReapJobCredentialRuntime`. Seed-only restart skips Recover and begins
+  at stop/reap. Both routes validate absence, finalize, persist a private
+  recovery receipt, commit, then clear credential state. Daemon restart never
+  resumes execution.
+
+## Still unsupported / documented gaps
+
+- The worker-v2 protocol schema still has only `job_start_v2`,
+  `job_resolve_v2`, `job_status_v2`, `job_logs_v2`, and `job_cancel_v2`.
+  There is no reserved `job_renew_v2` or `job_revoke_v2` operation. Renew is
+  available on the in-memory session handle only; it is not a protocol
+  heartbeat yet.
+- `job_resolve_v2` and `job_logs_v2` remain unsupported on the L8 durable
+  router. `job_status_v2` is not wired in this slice.
+- Prepare uses the complete identity only. Admission-authorizer and live
+  `LiveSecretSource` resolution are not injected here; v2 production files
+  forbid that live-secret surface.
+- Default `Service` and `NewL8Service` stay inert: they do not prepare, and
+  the non-durable seam still aborts preflight.
+
+## Fake-only commands
+
+```
+go test ./internal/sandboxworker -run 'L8|JobV2|JobStartV2' -count=1
+go test ./internal/sandboxworker -run 'TestL8D6Worker(Prepare|Cancel|Loss|ConcurrentStart|TypedNil|MissingRecovery|SeedOnly|CompleteIdentity|IdentityMismatch|ProtocolHasNo|NeutralService|PersistsSeed|ConcurrentReplay)' -count=1
+go test -race -count=1 ./internal/sandboxworker -run 'TestL8D6Worker(ConcurrentStart|ConcurrentReplay)'
+go vet ./internal/sandboxworker
+```
+
+This slice does not claim L10/L11, live Firecracker, or production absence-proof
+construction. Worker tests mint absence proofs only inside fakes.

--- a/docs/design/sandbox-runtime-v2-l8-d6-worker-credential-lifecycle-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-worker-credential-lifecycle-verification.md
@@ -21,7 +21,9 @@ guest helper, or live source resolution.
   `StopReapJobCredentialRuntime`. Seed-only restart skips Recover and begins
   at stop/reap. Both routes validate absence, finalize, persist a private
   recovery receipt, commit, then clear credential state. Daemon restart never
-  resumes execution.
+  resumes execution. A restart from the private receipt-only crash state binds
+  the exact seed and calls only the idempotent commit operation before clearing
+  the receipt; it does not recreate process, L7, or credential cleanup work.
 
 ## Still unsupported / documented gaps
 

--- a/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
+++ b/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
@@ -704,20 +704,28 @@ read only as one direct selector on the exact receipt-typed parameter object.
 The permitted package functions have no receiver, contain exactly one
 receipt-typed parameter whose type object is the canonical root receipt or the
 exact imported root receipt, return only `error`, and read that parameter's
-`CommitID` exactly once. The root validator has no other parameter. The future
+`CommitID` exactly once. The root validator has no other parameter. The
 private-store converter instead returns exactly
 `(storedJobCredentialRuntimeRecoveryReceiptV1, error)` so it can copy the
 validated receipt plus seed into the private DTO. The functions are:
 the root `ValidateJobCredentialRuntimeRecoveryCommitReceipt`, concrete
 `firecrackerhost.commitJobCredentialRuntimeRecovery`, and, when worker receipt
 persistence lands, private-store
-`storedJobCredentialRuntimeRecoveryReceiptV1FromRuntime`. The root validator and owner verifier land together; the private-store converter remains optional until worker receipt persistence lands.
-Accordingly, only `internal/sandboxworker/job_store_v2.go` may copy `CommitID` from the neutral
-receipt into the private DTO. Reflection, unsafe conversion, receipt aliases, receiver methods, closures, and helper escape are forbidden,
+`storedJobCredentialRuntimeRecoveryReceiptV1FromRuntime`. Receipt replay is
+confined to the adjacent exact private-store decoder
+`storedJobCredentialRuntimeRecoveryReceiptV1ToRuntime`, which accepts only the
+private DTO, reconstructs and validates the sealed neutral receipt, and returns
+it only to the seed-bound recovery binding's commit call. The root validator
+and owner verifier land together; both private-store functions remain optional
+until worker receipt persistence lands.
+Accordingly, only `internal/sandboxworker/job_store_v2.go` may copy `CommitID`
+from the neutral receipt into the private DTO, and only
+`internal/sandboxworker/job_store_v2_recovery_receipt.go` may copy it back into
+the sealed neutral receipt for commit-only replay. Reflection, unsafe conversion, receipt aliases, receiver methods, closures, and helper escape are forbidden,
 as are same-name functions with an unrelated `CommitID` field, a receipt type
 alias, a wrong signature, or an indirect field read. Worker services, statuses,
 commands, runtime metadata, and every other file cannot project it, including
-through a cross-file alias. Any production file outside the three allowlisted
+through a cross-file alias. Any production file outside the four allowlisted
 files/functions that names the receipt type through a default, explicit, dot,
 or raw-string import fails the guard. A receipt-bearing allowlisted file also
 fails if it imports `reflect` or `unsafe`; reflection cannot hide a field read

--- a/internal/sandboxruntime/job_credential_runtime_session.go
+++ b/internal/sandboxruntime/job_credential_runtime_session.go
@@ -1,0 +1,143 @@
+package sandboxruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// JobCredentialSessionBinding retains one transferred session and the
+// worker-owned loss latch started during preflight.
+type JobCredentialSessionBinding struct {
+	session  JobCredentialSession
+	identity JobCredentialIdentity
+	loss     *jobCredentialRuntimeLossLatch
+}
+
+func (binding *JobCredentialRuntimePreflightBinding) Prepare(ctx context.Context, request JobCredentialPrepareRequest) (*JobCredentialSessionBinding, error) {
+	if binding == nil || jobCredentialBindingValueIsNil(ctx) {
+		return nil, ErrJobCredentialRuntimeBindingUnavailable
+	}
+	if ValidateJobCredentialIdentity(request.Identity) != nil || !sameJobCredentialIdentity(request.Identity, binding.identity) {
+		return nil, ErrJobCredentialIdentityMismatch
+	}
+	session, err := callJobCredentialRuntimePreflightPrepare(binding.preflight, ctx, request)
+	if err != nil {
+		if !jobCredentialBindingValueIsNil(session) {
+			return nil, ErrJobCredentialRuntimeBindingInvalid
+		}
+		if errors.Is(err, ErrJobCredentialTransition) {
+			return nil, ErrJobCredentialTransition
+		}
+		return nil, ErrJobCredentialRuntimeBindingUnavailable
+	}
+	if jobCredentialBindingValueIsNil(session) {
+		return nil, ErrJobCredentialRuntimeBindingInvalid
+	}
+	return &JobCredentialSessionBinding{
+		session:  session,
+		identity: cloneJobCredentialIdentity(binding.identity),
+		loss:     binding.loss,
+	}, nil
+}
+
+func (binding *JobCredentialSessionBinding) ActiveProof() JobCredentialActiveProof {
+	if binding == nil || jobCredentialBindingValueIsNil(binding.session) {
+		return JobCredentialActiveProof{}
+	}
+	return callJobCredentialSessionActiveProof(binding.session)
+}
+
+func (binding *JobCredentialSessionBinding) Renew(ctx context.Context) (JobCredentialActiveProof, error) {
+	if binding == nil || jobCredentialBindingValueIsNil(ctx) || jobCredentialBindingValueIsNil(binding.session) {
+		return JobCredentialActiveProof{}, ErrJobCredentialRuntimeBindingUnavailable
+	}
+	proof, err := callJobCredentialSessionRenew(binding.session, ctx)
+	if err != nil || ActiveProofKind(proof) == "" {
+		return JobCredentialActiveProof{}, ErrJobCredentialRuntimeBindingUnavailable
+	}
+	return proof, nil
+}
+
+func (binding *JobCredentialSessionBinding) Revoke(ctx context.Context, reason JobCredentialRevokeReason) (JobCredentialCleanupProof, error) {
+	if binding == nil || jobCredentialBindingValueIsNil(ctx) || jobCredentialBindingValueIsNil(binding.session) {
+		return JobCredentialCleanupProof{}, ErrJobCredentialRuntimeCleanupIncomplete
+	}
+	proof, err := callJobCredentialSessionRevoke(binding.session, ctx, reason)
+	if err != nil || CleanupProofKind(proof) == "" {
+		return JobCredentialCleanupProof{}, ErrJobCredentialRuntimeCleanupIncomplete
+	}
+	return proof, nil
+}
+
+func (binding *JobCredentialSessionBinding) Loss() <-chan JobCredentialLoss {
+	if binding == nil || binding.loss == nil {
+		return nil
+	}
+	return binding.loss.output
+}
+
+func callJobCredentialRuntimePreflightPrepare(preflight JobCredentialRuntimePreflight, ctx context.Context, request JobCredentialPrepareRequest) (session JobCredentialSession, err error) {
+	defer func() {
+		if recover() != nil {
+			session = nil
+			err = ErrJobCredentialRuntimeBindingUnavailable
+		}
+	}()
+	return preflight.PrepareJobCredentials(ctx, request)
+}
+
+func callJobCredentialSessionActiveProof(session JobCredentialSession) (proof JobCredentialActiveProof) {
+	defer func() {
+		if recover() != nil {
+			proof = JobCredentialActiveProof{}
+		}
+	}()
+	return session.ActiveProof()
+}
+
+func callJobCredentialSessionRenew(session JobCredentialSession, ctx context.Context) (proof JobCredentialActiveProof, err error) {
+	defer func() {
+		if recover() != nil {
+			proof = JobCredentialActiveProof{}
+			err = ErrJobCredentialRuntimeBindingUnavailable
+		}
+	}()
+	return session.Renew(ctx)
+}
+
+func callJobCredentialSessionRevoke(session JobCredentialSession, ctx context.Context, reason JobCredentialRevokeReason) (proof JobCredentialCleanupProof, err error) {
+	defer func() {
+		if recover() != nil {
+			proof = JobCredentialCleanupProof{}
+			err = ErrJobCredentialRuntimeCleanupIncomplete
+		}
+	}()
+	return session.Revoke(ctx, reason)
+}
+
+func (*JobCredentialSessionBinding) String() string {
+	return "<sandboxruntime.JobCredentialSessionBinding>"
+}
+
+func (*JobCredentialSessionBinding) GoString() string {
+	return "<sandboxruntime.JobCredentialSessionBinding>"
+}
+
+func (*JobCredentialSessionBinding) MarshalJSON() ([]byte, error) {
+	return nil, ErrJobCredentialSerialization
+}
+
+func (*JobCredentialSessionBinding) MarshalText() ([]byte, error) {
+	return nil, ErrJobCredentialSerialization
+}
+
+func (*JobCredentialSessionBinding) Format(state fmt.State, verb rune) {
+	fmt.Fprint(state, "<sandboxruntime.JobCredentialSessionBinding>")
+}
+
+// JobCredentialRuntimeInterfaceNil reports missing and typed-nil interfaces
+// without exposing implementation identity.
+func JobCredentialRuntimeInterfaceNil(value any) bool {
+	return jobCredentialBindingValueIsNil(value)
+}

--- a/internal/sandboxruntime/l8_job_credential_import_red_test.go
+++ b/internal/sandboxruntime/l8_job_credential_import_red_test.go
@@ -26,6 +26,7 @@ func TestL8JobCredentialLiveHandlesUseOnlySafeFormattingAndDenialCodecs(t *testi
 		"JobCredentialRuntimeBinder":                {},
 		"JobCredentialRuntimeBinding":               {},
 		"JobCredentialRuntimePreflightBinding":      {},
+		"JobCredentialSessionBinding":               {},
 		"JobCredentialRuntimeAbsenceProof":          {},
 		"JobCredentialRuntimeRecoveryCommitReceipt": {},
 	}
@@ -309,6 +310,7 @@ func l8JobCredentialFormatLiterals() map[string]string {
 		"JobCredentialRuntimeBinder":                "<sandboxruntime.JobCredentialRuntimeBinder>",
 		"JobCredentialRuntimeBinding":               "<sandboxruntime.JobCredentialRuntimeBinding>",
 		"JobCredentialRuntimePreflightBinding":      "<sandboxruntime.JobCredentialRuntimePreflightBinding>",
+		"JobCredentialSessionBinding":               "<sandboxruntime.JobCredentialSessionBinding>",
 		"JobCredentialRuntimeAbsenceProof":          "<sandboxruntime.JobCredentialRuntimeAbsenceProof>",
 		"JobCredentialRuntimeRecoveryCommitReceipt": "[job-credential-runtime-recovery-commit-receipt]",
 	}

--- a/internal/sandboxworker/job_manager_v2.go
+++ b/internal/sandboxworker/job_manager_v2.go
@@ -1,6 +1,7 @@
 package sandboxworker
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"sync"
@@ -19,6 +20,7 @@ type jobManagerV2Options struct {
 	StateDir         string
 	WorkerID         string
 	DaemonGeneration string
+	Recovery         sandboxruntime.JobCredentialRuntimeRecoveryProvider
 }
 
 type jobManagerV2 struct {
@@ -46,7 +48,7 @@ func newJobManagerV2(options jobManagerV2Options) (*jobManagerV2, error) {
 	if err != nil {
 		return nil, err
 	}
-	states, err := reconcileJobStoreV2AtStartup(store, time.Now().UTC())
+	states, err := reconcileJobStoreV2AtStartupWithRecovery(store, time.Now().UTC(), options.Recovery)
 	if err != nil {
 		closeJobManagerV2StateLock(stateLock)
 		return nil, err
@@ -231,4 +233,156 @@ func (manager *jobManagerV2) status(jobID, principalID string) (JobV2, error) {
 		return JobV2{}, errJobV2NotFound
 	}
 	return cloneJobV2(state.JobV2), nil
+}
+
+func (manager *jobManagerV2) persistCredentialRevision(jobID, principalID string, revision uint64) error {
+	if manager == nil || manager.store == nil || revision == 0 {
+		return errors.New("worker v2 credential revision is invalid")
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.closed || manager.stateLock == nil {
+		return errors.New("worker v2 job manager is closed")
+	}
+	state, ok := manager.states[jobID]
+	if !ok || state.PrincipalID != principalID || state.CredentialState == nil || state.CredentialState.Identity == nil {
+		return errJobV2NotFound
+	}
+	cloned := cloneStoredJobCredentialStateV2(state.CredentialState)
+	cloned.Revision = revision
+	state.CredentialState = cloned
+	if err := manager.store.save(state); err != nil {
+		return errors.New("worker v2 credential revision could not be persisted")
+	}
+	manager.states[jobID] = cloneStoredJobStateV2(state)
+	return nil
+}
+
+func (manager *jobManagerV2) clearCredentialState(jobID, principalID, jobState, failureCode string, finishedAt time.Time) (JobV2, error) {
+	if manager == nil || manager.store == nil || !validWorkerV2JobState(jobState) {
+		return JobV2{}, errors.New("worker v2 credential state is invalid")
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.closed || manager.stateLock == nil {
+		return JobV2{}, errors.New("worker v2 job manager is closed")
+	}
+	state, ok := manager.states[jobID]
+	if !ok || state.PrincipalID != principalID {
+		return JobV2{}, errJobV2NotFound
+	}
+	state.CredentialState = nil
+	state.CredentialRecoveryReceipt = nil
+	state.JobV2.State = jobState
+	if failureCode != "" {
+		state.JobV2.FailureCode = failureCode
+	}
+	finished := finishedAt.UTC()
+	state.JobV2.FinishedAt = &finished
+	if jobState == JobStateCanceled {
+		state.JobV2.CancelRequested = true
+	}
+	if err := state.Validate(); err != nil {
+		return JobV2{}, errors.New("worker v2 credential state is invalid")
+	}
+	if err := manager.store.save(state); err != nil {
+		return JobV2{}, errors.New("worker v2 credential state could not be cleared")
+	}
+	manager.states[jobID] = cloneStoredJobStateV2(state)
+	return cloneJobV2(state.JobV2), nil
+}
+
+func recoverStoredJobCredentialsV2(store *jobStoreV2, state storedJobStateV2, recovery sandboxruntime.JobCredentialRuntimeRecoveryProvider, now time.Time) (storedJobStateV2, error) {
+	if store == nil || sandboxruntime.JobCredentialRuntimeInterfaceNil(recovery) {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	if state.CredentialRecoveryReceipt != nil && state.CredentialState == nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	if state.CredentialState == nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	seed, err := state.CredentialState.Seed.runtimeSeed()
+	if err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	ctx := context.Background()
+	binding, err := bindJobCredentialRuntimeRecovery(recovery, ctx, seed)
+	if err != nil || sandboxruntime.JobCredentialRuntimeInterfaceNil(binding) {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	defer closeJobCredentialRuntimeRecoveryBinding(binding, ctx)
+	if state.CredentialState.Identity != nil {
+		identity, identityErr := state.CredentialState.Identity.runtimeIdentity()
+		if identityErr == nil && sandboxruntime.ValidateJobCredentialIdentityCompletion(seed, identity) == nil {
+			recoverJobCredentialsIgnoringFailure(binding, ctx, sandboxruntime.JobCredentialRecoveryRequest{
+				Identity: identity,
+				Revision: state.CredentialState.Revision,
+			})
+		}
+	}
+	proof, err := binding.StopReapJobCredentialRuntime(ctx)
+	if err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeAbsenceProof(proof, seed, now); err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(ctx, proof)
+	if err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt); err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	storedReceipt, err := storedJobCredentialRuntimeRecoveryReceiptV1FromRuntime(state.CredentialState.Seed, receipt)
+	if err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	state.CredentialState = nil
+	state.CredentialRecoveryReceipt = &storedReceipt
+	if err := store.save(state); err != nil {
+		return storedJobStateV2{}, err
+	}
+	if err := binding.CommitJobCredentialRuntimeRecovery(ctx, receipt); err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	state.CredentialRecoveryReceipt = nil
+	finishedAt := now.UTC()
+	state.JobV2.State = JobStateInterrupted
+	state.JobV2.FailureCode = "daemon_restarted_before_start"
+	state.JobV2.FinishedAt = &finishedAt
+	if err := store.save(state); err != nil {
+		return storedJobStateV2{}, err
+	}
+	return cloneStoredJobStateV2(state), nil
+}
+
+func bindJobCredentialRuntimeRecovery(recovery sandboxruntime.JobCredentialRuntimeRecoveryProvider, ctx context.Context, seed sandboxruntime.JobCredentialIdentitySeed) (binding sandboxruntime.JobCredentialRuntimeRecoveryBinding, err error) {
+	defer recoverJobCredentialRuntimeBindPanic(&binding, &err)
+	return recovery.BindJobCredentialRuntimeRecovery(ctx, seed)
+}
+
+func recoverJobCredentialRuntimeBindPanic(binding *sandboxruntime.JobCredentialRuntimeRecoveryBinding, err *error) {
+	if recover() == nil || binding == nil || err == nil {
+		return
+	}
+	*binding = nil
+	*err = ErrL8RecoveryDependency
+}
+
+func recoverJobCredentialsIgnoringFailure(binding sandboxruntime.JobCredentialRuntimeRecoveryBinding, ctx context.Context, request sandboxruntime.JobCredentialRecoveryRequest) {
+	defer recoverJobCredentialRuntimeIgnoredPanic()
+	_, _ = binding.RecoverJobCredentials(ctx, request)
+}
+
+func recoverJobCredentialRuntimeIgnoredPanic() {
+	_ = recover()
+}
+
+func closeJobCredentialRuntimeRecoveryBinding(binding sandboxruntime.JobCredentialRuntimeRecoveryBinding, ctx context.Context) {
+	if sandboxruntime.JobCredentialRuntimeInterfaceNil(binding) {
+		return
+	}
+	_ = binding.Close(ctx)
 }

--- a/internal/sandboxworker/job_manager_v2.go
+++ b/internal/sandboxworker/job_manager_v2.go
@@ -258,7 +258,7 @@ func (manager *jobManagerV2) persistCredentialRevision(jobID, principalID string
 	return nil
 }
 
-func (manager *jobManagerV2) clearCredentialState(jobID, principalID, jobState, failureCode string, finishedAt time.Time) (JobV2, error) {
+func (manager *jobManagerV2) clearCredentialState(jobID, principalID, jobState, failureCode string, finishedAt time.Time, cleanupProved bool) (JobV2, error) {
 	if manager == nil || manager.store == nil || !validWorkerV2JobState(jobState) {
 		return JobV2{}, errors.New("worker v2 credential state is invalid")
 	}
@@ -270,6 +270,9 @@ func (manager *jobManagerV2) clearCredentialState(jobID, principalID, jobState, 
 	state, ok := manager.states[jobID]
 	if !ok || state.PrincipalID != principalID {
 		return JobV2{}, errJobV2NotFound
+	}
+	if !cleanupProved && (state.CredentialState != nil || state.CredentialRecoveryReceipt != nil) {
+		return JobV2{}, ErrL8RecoveryDependency
 	}
 	state.CredentialState = nil
 	state.CredentialRecoveryReceipt = nil
@@ -292,17 +295,26 @@ func (manager *jobManagerV2) clearCredentialState(jobID, principalID, jobState, 
 	return cloneJobV2(state.JobV2), nil
 }
 
-func recoverStoredJobCredentialsV2(store *jobStoreV2, state storedJobStateV2, recovery sandboxruntime.JobCredentialRuntimeRecoveryProvider, now time.Time) (storedJobStateV2, error) {
+func recoverStoredJobCredentialsV2(store *jobStoreV2, state storedJobStateV2, recovery sandboxruntime.JobCredentialRuntimeRecoveryProvider, now time.Time) (recovered storedJobStateV2, resultErr error) {
+	defer func() {
+		if recover() != nil {
+			recovered = storedJobStateV2{}
+			resultErr = ErrL8RecoveryDependency
+		}
+	}()
 	if store == nil || sandboxruntime.JobCredentialRuntimeInterfaceNil(recovery) {
 		return storedJobStateV2{}, ErrL8RecoveryDependency
 	}
-	if state.CredentialRecoveryReceipt != nil && state.CredentialState == nil {
+	if state.CredentialState == nil && state.CredentialRecoveryReceipt == nil {
 		return storedJobStateV2{}, ErrL8RecoveryDependency
 	}
-	if state.CredentialState == nil {
-		return storedJobStateV2{}, ErrL8RecoveryDependency
+	storedSeed := storedJobCredentialIdentitySeedV1{}
+	if state.CredentialState != nil {
+		storedSeed = state.CredentialState.Seed
+	} else {
+		storedSeed = state.CredentialRecoveryReceipt.Seed
 	}
-	seed, err := state.CredentialState.Seed.runtimeSeed()
+	seed, err := storedSeed.runtimeSeed()
 	if err != nil {
 		return storedJobStateV2{}, ErrL8RecoveryDependency
 	}
@@ -312,6 +324,9 @@ func recoverStoredJobCredentialsV2(store *jobStoreV2, state storedJobStateV2, re
 		return storedJobStateV2{}, ErrL8RecoveryDependency
 	}
 	defer closeJobCredentialRuntimeRecoveryBinding(binding, ctx)
+	if state.CredentialRecoveryReceipt != nil {
+		return replayStoredJobCredentialRuntimeRecoveryReceiptV2(store, state, binding, now)
+	}
 	if state.CredentialState.Identity != nil {
 		identity, identityErr := state.CredentialState.Identity.runtimeIdentity()
 		if identityErr == nil && sandboxruntime.ValidateJobCredentialIdentityCompletion(seed, identity) == nil {
@@ -345,6 +360,25 @@ func recoverStoredJobCredentialsV2(store *jobStoreV2, state storedJobStateV2, re
 		return storedJobStateV2{}, err
 	}
 	if err := binding.CommitJobCredentialRuntimeRecovery(ctx, receipt); err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	state.CredentialRecoveryReceipt = nil
+	finishedAt := now.UTC()
+	state.JobV2.State = JobStateInterrupted
+	state.JobV2.FailureCode = "daemon_restarted_before_start"
+	state.JobV2.FinishedAt = &finishedAt
+	if err := store.save(state); err != nil {
+		return storedJobStateV2{}, err
+	}
+	return cloneStoredJobStateV2(state), nil
+}
+
+func replayStoredJobCredentialRuntimeRecoveryReceiptV2(store *jobStoreV2, state storedJobStateV2, binding sandboxruntime.JobCredentialRuntimeRecoveryBinding, now time.Time) (storedJobStateV2, error) {
+	receipt, err := storedJobCredentialRuntimeRecoveryReceiptV1ToRuntime(*state.CredentialRecoveryReceipt)
+	if err != nil {
+		return storedJobStateV2{}, ErrL8RecoveryDependency
+	}
+	if err := binding.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); err != nil {
 		return storedJobStateV2{}, ErrL8RecoveryDependency
 	}
 	state.CredentialRecoveryReceipt = nil

--- a/internal/sandboxworker/job_store_v2.go
+++ b/internal/sandboxworker/job_store_v2.go
@@ -15,6 +15,8 @@ const maxStoredJobStateV2Bytes int64 = 64 << 10
 
 const storedJobCredentialContractVersionV2 = "sandboxjob-credential-private-v1"
 
+const storedJobCredentialRuntimeRecoveryReceiptContractV1 = "job-credential-runtime-recovery-receipt-v1"
+
 type storedJobCredentialIdentitySeedV1 struct {
 	SandboxID                    string    `json:"sandboxId"`
 	ExecutionID                  string    `json:"executionId"`
@@ -94,12 +96,20 @@ type storedJobCredentialStateV2 struct {
 	Revision        uint64                            `json:"revision"`
 }
 
+type storedJobCredentialRuntimeRecoveryReceiptV1 struct {
+	ContractVersion   string                            `json:"contractVersion"`
+	Seed              storedJobCredentialIdentitySeedV1 `json:"seed"`
+	CommitID          string                            `json:"commitId"`
+	FinalizedRevision uint64                            `json:"finalizedRevision"`
+}
+
 type storedJobStateV2 struct {
-	JobV2            JobV2
-	RequestKey       string                      `json:"requestKey"`
-	PrincipalID      string                      `json:"principalId"`
-	DaemonGeneration string                      `json:"daemonGeneration"`
-	CredentialState  *storedJobCredentialStateV2 `json:"credentialState,omitempty"`
+	JobV2                     JobV2
+	RequestKey                string                                       `json:"requestKey"`
+	PrincipalID               string                                       `json:"principalId"`
+	DaemonGeneration          string                                       `json:"daemonGeneration"`
+	CredentialState           *storedJobCredentialStateV2                  `json:"credentialState,omitempty"`
+	CredentialRecoveryReceipt *storedJobCredentialRuntimeRecoveryReceiptV1 `json:"credentialRecoveryReceipt,omitempty"`
 }
 
 type jobStoreV2 struct {
@@ -148,8 +158,19 @@ func (state storedJobStateV2) Validate() error {
 }
 
 func validateStoredJobCredentialStateV2(state storedJobStateV2) error {
+	if state.CredentialState != nil && state.CredentialRecoveryReceipt != nil {
+		return errors.New("stored worker job credential recovery state is invalid")
+	}
+	if state.CredentialRecoveryReceipt != nil {
+		if !state.JobV2.CredentialIntent.ProductionCredentialsRequested {
+			return errors.New("stored worker job credential recovery receipt is invalid")
+		}
+		return validateStoredJobCredentialRuntimeRecoveryReceiptV1(state)
+	}
 	if state.CredentialState == nil {
-		if state.JobV2.CredentialIntent.ProductionCredentialsRequested {
+		if state.JobV2.CredentialIntent.ProductionCredentialsRequested &&
+			state.JobV2.State != JobStateInterrupted && state.JobV2.State != JobStateCanceled &&
+			state.JobV2.State != JobStateFailed {
 			return errors.New("stored worker job credential state is required")
 		}
 		return nil
@@ -310,7 +331,49 @@ func cloneStoredJobCredentialStateV2(state *storedJobCredentialStateV2) *storedJ
 func cloneStoredJobStateV2(state storedJobStateV2) storedJobStateV2 {
 	state.JobV2 = cloneJobV2(state.JobV2)
 	state.CredentialState = cloneStoredJobCredentialStateV2(state.CredentialState)
+	state.CredentialRecoveryReceipt = cloneStoredJobCredentialRuntimeRecoveryReceiptV1(state.CredentialRecoveryReceipt)
 	return state
+}
+
+func cloneStoredJobCredentialRuntimeRecoveryReceiptV1(receipt *storedJobCredentialRuntimeRecoveryReceiptV1) *storedJobCredentialRuntimeRecoveryReceiptV1 {
+	if receipt == nil {
+		return nil
+	}
+	cloned := *receipt
+	cloned.Seed.BindingIDs = append([]string(nil), receipt.Seed.BindingIDs...)
+	cloned.Seed.DeliveryModes = append([]string(nil), receipt.Seed.DeliveryModes...)
+	return &cloned
+}
+
+func validateStoredJobCredentialRuntimeRecoveryReceiptV1(state storedJobStateV2) error {
+	receipt := state.CredentialRecoveryReceipt
+	if receipt.ContractVersion != storedJobCredentialRuntimeRecoveryReceiptContractV1 || receipt.FinalizedRevision == 0 {
+		return errors.New("stored worker job credential recovery receipt is invalid")
+	}
+	seed, err := receipt.Seed.runtimeSeed()
+	if err != nil || seed.WorkerID != state.JobV2.WorkerID || seed.WorkerJobID != state.JobV2.ID {
+		return errors.New("stored worker job credential recovery receipt is invalid")
+	}
+	return nil
+}
+
+func storedJobCredentialRuntimeRecoveryReceiptV1FromRuntime(seed storedJobCredentialIdentitySeedV1, receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) (storedJobCredentialRuntimeRecoveryReceiptV1, error) {
+	if err := sandboxruntime.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt); err != nil {
+		return storedJobCredentialRuntimeRecoveryReceiptV1{}, errors.New("worker job credential recovery receipt is invalid")
+	}
+	clonedSeed := seed
+	clonedSeed.BindingIDs = append([]string(nil), seed.BindingIDs...)
+	clonedSeed.DeliveryModes = append([]string(nil), seed.DeliveryModes...)
+	if _, err := clonedSeed.runtimeSeed(); err != nil {
+		return storedJobCredentialRuntimeRecoveryReceiptV1{}, errors.New("worker job credential recovery receipt is invalid")
+	}
+	commitID := receipt.CommitID
+	return storedJobCredentialRuntimeRecoveryReceiptV1{
+		ContractVersion:   storedJobCredentialRuntimeRecoveryReceiptContractV1,
+		Seed:              clonedSeed,
+		CommitID:          commitID,
+		FinalizedRevision: receipt.FinalizedRevision,
+	}, nil
 }
 
 func storedJobCredentialBindingsExactV2(seed sandboxruntime.JobCredentialIdentitySeed, intent JobCredentialIntentV2) bool {
@@ -439,14 +502,26 @@ func (store *jobStoreV2) list() ([]storedJobStateV2, error) {
 }
 
 func reconcileJobStoreV2AtStartup(store *jobStoreV2, restartAt time.Time) ([]storedJobStateV2, error) {
+	return reconcileJobStoreV2AtStartupWithRecovery(store, restartAt, nil)
+}
+
+func reconcileJobStoreV2AtStartupWithRecovery(store *jobStoreV2, restartAt time.Time, recovery sandboxruntime.JobCredentialRuntimeRecoveryProvider) ([]storedJobStateV2, error) {
 	states, err := store.list()
 	if err != nil {
 		return nil, err
 	}
-	for _, state := range states {
-		if state.CredentialState != nil {
+	for index := range states {
+		if states[index].CredentialState == nil && states[index].CredentialRecoveryReceipt == nil {
+			continue
+		}
+		if sandboxruntime.JobCredentialRuntimeInterfaceNil(recovery) {
 			return nil, ErrL8RecoveryDependency
 		}
+		recovered, recoverErr := recoverStoredJobCredentialsV2(store, states[index], recovery, restartAt)
+		if recoverErr != nil {
+			return nil, recoverErr
+		}
+		states[index] = recovered
 	}
 	for index := range states {
 		if states[index].JobV2.State != JobStateQueued {

--- a/internal/sandboxworker/job_store_v2_recovery_receipt.go
+++ b/internal/sandboxworker/job_store_v2_recovery_receipt.go
@@ -1,0 +1,21 @@
+package sandboxworker
+
+import (
+	"errors"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+// storedJobCredentialRuntimeRecoveryReceiptV1ToRuntime reconstructs only the
+// sealed neutral value needed for an idempotent commit-only recovery binding.
+// The concrete binding reauthenticates the HMAC against its private owner key.
+func storedJobCredentialRuntimeRecoveryReceiptV1ToRuntime(stored storedJobCredentialRuntimeRecoveryReceiptV1) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) {
+	receipt.CommitID = stored.CommitID
+	receipt.FinalizedRevision = stored.FinalizedRevision
+	if stored.ContractVersion != storedJobCredentialRuntimeRecoveryReceiptContractV1 || sandboxruntime.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt) != nil {
+		receipt.CommitID = ""
+		receipt.FinalizedRevision = 0
+		return receipt, errors.New("worker job credential recovery receipt is invalid")
+	}
+	return receipt, nil
+}

--- a/internal/sandboxworker/job_v2_service.go
+++ b/internal/sandboxworker/job_v2_service.go
@@ -455,7 +455,7 @@ func (service *L8Service) completeFailedPreflight(jobID, principalID string, pre
 	if _, err := lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
 		return
 	}
-	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateInterrupted, string(sandboxruntime.JobCredentialFailureCleanupIncomplete), time.Now().UTC(), true)
+	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateInterrupted, string(sandboxruntime.JobCredentialFailurePrepareFailed), time.Now().UTC(), true)
 }
 
 func (service *L8Service) completeFailedSession(jobID, principalID string, session *sandboxruntime.JobCredentialSessionBinding, lifecycle *sandboxruntime.JobCredentialLifecycle) {
@@ -469,5 +469,5 @@ func (service *L8Service) completeFailedSession(jobID, principalID string, sessi
 	if _, err := lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
 		return
 	}
-	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateInterrupted, string(sandboxruntime.JobCredentialFailureCleanupIncomplete), time.Now().UTC(), true)
+	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateInterrupted, string(sandboxruntime.JobCredentialFailurePrepareFailed), time.Now().UTC(), true)
 }

--- a/internal/sandboxworker/job_v2_service.go
+++ b/internal/sandboxworker/job_v2_service.go
@@ -27,6 +27,10 @@ type L8DurableServiceOptions struct {
 	StateDir           string
 	Binder             *sandboxruntime.JobCredentialRuntimeBinder
 	PrincipalAuthority *sandboxruntime.AuthenticatedWorkerPrincipalAuthority
+	// RecoveryProvider is the optional D6 restart adapter. A typed-nil value
+	// fails closed. A missing provider retains ErrL8RecoveryDependency when
+	// durable credential ownership is present.
+	RecoveryProvider sandboxruntime.JobCredentialRuntimeRecoveryProvider
 }
 
 // L8AuthenticatedServerOptions attaches one durable L8 service to the

--- a/internal/sandboxworker/job_v2_service.go
+++ b/internal/sandboxworker/job_v2_service.go
@@ -21,9 +21,12 @@ type L8Service struct {
 	jobs               *jobManagerV2
 	liveMu             sync.Mutex
 	live               map[string]*l8LiveJobCredential
+	closed             bool
 }
 
 type l8LiveJobCredential struct {
+	mu        sync.Mutex
+	finished  bool
 	session   *sandboxruntime.JobCredentialSessionBinding
 	lifecycle *sandboxruntime.JobCredentialLifecycle
 	identity  sandboxruntime.JobCredentialIdentity
@@ -109,13 +112,23 @@ func (service *L8Service) Close() {
 		return
 	}
 	service.liveMu.Lock()
+	if service.closed {
+		service.liveMu.Unlock()
+		return
+	}
+	service.closed = true
 	live := service.live
 	service.live = nil
 	service.liveMu.Unlock()
 	for _, handle := range live {
-		if handle != nil && handle.session != nil {
+		if handle == nil {
+			continue
+		}
+		handle.mu.Lock()
+		if !handle.finished && handle.session != nil {
 			_, _ = handle.session.Revoke(context.Background(), "")
 		}
+		handle.mu.Unlock()
 	}
 	if service.jobs != nil {
 		service.jobs.close()
@@ -230,23 +243,25 @@ func (service *L8Service) HandleAuthenticatedRequest(ctx context.Context, princi
 	}
 	session, err := preflight.Prepare(ctx, sandboxruntime.JobCredentialPrepareRequest{Identity: identity})
 	if err != nil {
+		service.completeFailedPreflight(job.ID, principalID, preflight, lifecycle)
 		if response, ok := contextErrorResponse(ctx, request); ok {
-			_, _ = preflight.AbortBounded()
 			return response
 		}
-		_, _ = preflight.AbortBounded()
 		return l8ServiceFailureResponse(request)
 	}
 	observedAt := time.Now().UTC()
 	if err := lifecycle.Activate(session.ActiveProof(), observedAt); err != nil {
-		_, _ = session.Revoke(ctx, "")
+		service.completeFailedSession(job.ID, principalID, session, lifecycle)
 		return l8ServiceFailureResponse(request)
 	}
-	if err := service.jobs.persistCredentialRevision(job.ID, principalID, 1); err != nil {
-		_, _ = session.Revoke(ctx, "")
+	if err := service.jobs.persistCredentialRevision(job.ID, principalID, lifecycle.Revision()); err != nil {
+		service.completeFailedSession(job.ID, principalID, session, lifecycle)
 		return l8ServiceFailureResponse(request)
 	}
-	service.retainLiveJobCredential(job.ID, principalID, session, lifecycle, identity)
+	if !service.retainLiveJobCredential(job.ID, principalID, session, lifecycle, identity) {
+		service.completeFailedSession(job.ID, principalID, session, lifecycle)
+		return l8ServiceFailureResponse(request)
+	}
 	go service.watchJobCredentialLoss(job.ID, principalID, session)
 	return l8JobV2SuccessResponse(request, job)
 }
@@ -300,25 +315,36 @@ func (service *L8Service) handleAuthenticatedJobCancelV2(ctx context.Context, pr
 	if err := request.Validate(); err != nil {
 		return protocolErrorResponse(request.RequestID, request.Operation, ErrorCodeMalformedRequest, "malformed worker L8 job cancel request")
 	}
-	live := service.takeLiveJobCredential(request.JobCancelV2.JobID, principalID)
+	live := service.liveJobCredential(request.JobCancelV2.JobID, principalID)
 	if live != nil {
+		live.mu.Lock()
+		defer live.mu.Unlock()
+		if live.finished {
+			return l8ServiceFailureResponse(request)
+		}
 		proof, err := live.session.Revoke(ctx, "")
 		if err != nil || sandboxruntime.CleanupProofKind(proof) == "" {
 			return l8ServiceFailureResponse(request)
 		}
 		if live.lifecycle != nil {
-			_ = live.lifecycle.BeginRevoke()
+			if err := live.lifecycle.BeginRevoke(); err != nil {
+				return l8ServiceFailureResponse(request)
+			}
 			if _, err := live.lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
 				return l8ServiceFailureResponse(request)
 			}
 		}
 	}
-	job, err := service.jobs.clearCredentialState(request.JobCancelV2.JobID, principalID, JobStateCanceled, "", time.Now().UTC())
+	job, err := service.jobs.clearCredentialState(request.JobCancelV2.JobID, principalID, JobStateCanceled, "", time.Now().UTC(), live != nil)
 	if err != nil {
 		if err == errJobV2NotFound {
 			return protocolErrorResponse(request.RequestID, request.Operation, ErrorCodeJobNotFound, "worker job was not found")
 		}
 		return l8ServiceFailureResponse(request)
+	}
+	if live != nil {
+		live.finished = true
+		service.removeLiveJobCredential(request.JobCancelV2.JobID, live)
 	}
 	return l8JobV2SuccessResponse(request, job)
 }
@@ -335,34 +361,57 @@ func (service *L8Service) watchJobCredentialLoss(jobID, principalID string, sess
 	if !ok {
 		return
 	}
-	live := service.takeLiveJobCredential(jobID, principalID)
+	live := service.liveJobCredential(jobID, principalID)
 	if live == nil {
 		return
 	}
-	if live.lifecycle != nil {
-		_ = live.lifecycle.ObserveLoss(loss)
+	live.mu.Lock()
+	defer live.mu.Unlock()
+	if live.finished {
+		return
 	}
-	_, _ = live.session.Revoke(context.Background(), "")
+	if live.lifecycle != nil {
+		if err := live.lifecycle.ObserveLoss(loss); err != nil {
+			return
+		}
+	}
+	proof, err := live.session.Revoke(context.Background(), "")
+	if err != nil || sandboxruntime.CleanupProofKind(proof) == "" {
+		return
+	}
+	if live.lifecycle != nil {
+		if err := live.lifecycle.BeginRevoke(); err != nil {
+			return
+		}
+		if _, err := live.lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
+			return
+		}
+	}
 	failureCode := string(loss.Code)
 	if !validWorkerV2SafeID(failureCode) {
 		failureCode = string(sandboxruntime.JobCredentialFailureCleanupIncomplete)
 	}
-	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateFailed, failureCode, time.Now().UTC())
+	if _, err := service.jobs.clearCredentialState(jobID, principalID, JobStateFailed, failureCode, time.Now().UTC(), true); err != nil {
+		return
+	}
+	live.finished = true
+	service.removeLiveJobCredential(jobID, live)
 }
 
-func (service *L8Service) retainLiveJobCredential(jobID, principalID string, session *sandboxruntime.JobCredentialSessionBinding, lifecycle *sandboxruntime.JobCredentialLifecycle, identity sandboxruntime.JobCredentialIdentity) {
+func (service *L8Service) retainLiveJobCredential(jobID, principalID string, session *sandboxruntime.JobCredentialSessionBinding, lifecycle *sandboxruntime.JobCredentialLifecycle, identity sandboxruntime.JobCredentialIdentity) bool {
 	if service == nil || jobID == "" || session == nil {
-		return
+		return false
 	}
 	service.liveMu.Lock()
 	defer service.liveMu.Unlock()
-	if service.live == nil {
-		service.live = make(map[string]*l8LiveJobCredential)
+	if service.closed || service.live == nil {
+		return false
 	}
 	service.live[jobID] = &l8LiveJobCredential{session: session, lifecycle: lifecycle, identity: identity, principal: principalID}
+	return true
 }
 
-func (service *L8Service) takeLiveJobCredential(jobID, principalID string) *l8LiveJobCredential {
+func (service *L8Service) liveJobCredential(jobID, principalID string) *l8LiveJobCredential {
 	if service == nil {
 		return nil
 	}
@@ -375,6 +424,44 @@ func (service *L8Service) takeLiveJobCredential(jobID, principalID string) *l8Li
 	if handle == nil || handle.principal != principalID {
 		return nil
 	}
-	delete(service.live, jobID)
 	return handle
+}
+
+func (service *L8Service) removeLiveJobCredential(jobID string, handle *l8LiveJobCredential) {
+	if service == nil || handle == nil {
+		return
+	}
+	service.liveMu.Lock()
+	defer service.liveMu.Unlock()
+	if service.live[jobID] == handle {
+		delete(service.live, jobID)
+	}
+}
+
+func (service *L8Service) completeFailedPreflight(jobID, principalID string, preflight *sandboxruntime.JobCredentialRuntimePreflightBinding, lifecycle *sandboxruntime.JobCredentialLifecycle) {
+	if service == nil || preflight == nil || lifecycle == nil {
+		return
+	}
+	proof, err := preflight.AbortBounded()
+	if err != nil || sandboxruntime.CleanupProofKind(proof) == "" || lifecycle.BeginRevoke() != nil {
+		return
+	}
+	if _, err := lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
+		return
+	}
+	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateFailed, string(sandboxruntime.JobCredentialFailureCleanupIncomplete), time.Now().UTC(), true)
+}
+
+func (service *L8Service) completeFailedSession(jobID, principalID string, session *sandboxruntime.JobCredentialSessionBinding, lifecycle *sandboxruntime.JobCredentialLifecycle) {
+	if service == nil || session == nil || lifecycle == nil {
+		return
+	}
+	proof, err := session.Revoke(context.Background(), "")
+	if err != nil || sandboxruntime.CleanupProofKind(proof) == "" || lifecycle.BeginRevoke() != nil {
+		return
+	}
+	if _, err := lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
+		return
+	}
+	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateFailed, string(sandboxruntime.JobCredentialFailureCleanupIncomplete), time.Now().UTC(), true)
 }

--- a/internal/sandboxworker/job_v2_service.go
+++ b/internal/sandboxworker/job_v2_service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/jywlabs/hal/internal/sandboxruntime"
 )
@@ -17,6 +19,15 @@ type L8Service struct {
 	daemonGeneration   string
 	principalAuthority *sandboxruntime.AuthenticatedWorkerPrincipalAuthority
 	jobs               *jobManagerV2
+	liveMu             sync.Mutex
+	live               map[string]*l8LiveJobCredential
+}
+
+type l8LiveJobCredential struct {
+	session   *sandboxruntime.JobCredentialSessionBinding
+	lifecycle *sandboxruntime.JobCredentialLifecycle
+	identity  sandboxruntime.JobCredentialIdentity
+	principal string
 }
 
 // L8DurableServiceOptions enables only the explicit authenticated worker-v2
@@ -50,7 +61,8 @@ func NewL8Service(binder *sandboxruntime.JobCredentialRuntimeBinder) (*L8Service
 }
 
 // NewL8DurableService constructs the explicit authenticated worker-v2 router.
-// Startup fails while credential ownership needs a later D6 recovery adapter;
+// A typed-nil recovery provider fails closed. Missing recovery retains
+// ErrL8RecoveryDependency when durable credential ownership is present;
 // retained state is never reconciled through the legacy queued-job path.
 func NewL8DurableService(options L8DurableServiceOptions) (*L8Service, error) {
 	workerID := strings.TrimSpace(options.WorkerID)
@@ -58,15 +70,19 @@ func NewL8DurableService(options L8DurableServiceOptions) (*L8Service, error) {
 	if !validWorkerV2SafeID(workerID) || !validWorkerV2SafeID(daemonGeneration) || options.Binder == nil || options.PrincipalAuthority == nil {
 		return nil, ErrL8ServiceUnavailable
 	}
+	if options.RecoveryProvider != nil && sandboxruntime.JobCredentialRuntimeInterfaceNil(options.RecoveryProvider) {
+		return nil, ErrL8ServiceUnavailable
+	}
 	jobs, err := newJobManagerV2(jobManagerV2Options{
 		StateDir: options.StateDir, WorkerID: workerID, DaemonGeneration: daemonGeneration,
+		Recovery: options.RecoveryProvider,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return &L8Service{
 		binder: options.Binder, workerID: workerID, daemonGeneration: daemonGeneration,
-		principalAuthority: options.PrincipalAuthority, jobs: jobs,
+		principalAuthority: options.PrincipalAuthority, jobs: jobs, live: make(map[string]*l8LiveJobCredential),
 	}, nil
 }
 
@@ -89,7 +105,19 @@ func NewL8AuthenticatedServer(options L8AuthenticatedServerOptions) (*Server, er
 // Close releases the explicit durable worker-v2 state owner. The neutral
 // default-off seam owns no durable state.
 func (service *L8Service) Close() {
-	if service != nil && service.jobs != nil {
+	if service == nil {
+		return
+	}
+	service.liveMu.Lock()
+	live := service.live
+	service.live = nil
+	service.liveMu.Unlock()
+	for _, handle := range live {
+		if handle != nil && handle.session != nil {
+			_, _ = handle.session.Revoke(context.Background(), "")
+		}
+	}
+	if service.jobs != nil {
 		service.jobs.close()
 	}
 }
@@ -149,16 +177,19 @@ func (service *L8Service) HandleAuthenticatedRequest(ctx context.Context, princi
 	if response, ok := contextErrorResponse(ctx, request); ok {
 		return response
 	}
+	if request.Operation == OperationJobCancelV2 {
+		return service.handleAuthenticatedJobCancelV2(ctx, principalID, request)
+	}
 	if request.Operation != OperationJobStartV2 || request.JobStartV2 == nil || !request.JobStartV2.ProductionCredentialsRequested {
 		return unsupportedOperationResponse(request)
 	}
 	if err := request.Validate(); err != nil {
 		return protocolErrorResponse(request.RequestID, request.Operation, ErrorCodeMalformedRequest, "malformed worker L8 job start request")
 	}
-	if _, existing, err := service.jobs.resolveAcceptedSubmission(request.DriverID, principalID, *request.JobStartV2); err != nil {
+	if job, existing, err := service.jobs.resolveAcceptedSubmission(request.DriverID, principalID, *request.JobStartV2); err != nil {
 		return l8ServiceFailureResponse(request)
 	} else if existing {
-		return unsupportedOperationResponse(request)
+		return l8JobV2SuccessResponse(request, job)
 	}
 
 	binding, err := service.binder.Bind(ctx, l8JobCredentialRuntimeTarget(request.JobStartV2.Exec.Target))
@@ -174,7 +205,7 @@ func (service *L8Service) HandleAuthenticatedRequest(ctx context.Context, princi
 		return l8ServiceFailureResponse(request)
 	}
 	if existing {
-		return unsupportedOperationResponse(request)
+		return l8JobV2SuccessResponse(request, job)
 	}
 	preflight, err := binding.Preflight(ctx)
 	if err != nil {
@@ -183,14 +214,41 @@ func (service *L8Service) HandleAuthenticatedRequest(ctx context.Context, princi
 		}
 		return l8ServiceFailureResponse(request)
 	}
-	if err := service.jobs.persistCredentialIdentity(job.ID, principalID, preflight.Identity()); err != nil {
+	identity := preflight.Identity()
+	if err := service.jobs.persistCredentialIdentity(job.ID, principalID, identity); err != nil {
 		_, _ = preflight.AbortBounded()
 		return l8ServiceFailureResponse(request)
 	}
-	if _, err := preflight.AbortBounded(); err != nil {
+	lifecycle, err := sandboxruntime.NewJobCredentialLifecycle(identity)
+	if err != nil {
+		_, _ = preflight.AbortBounded()
 		return l8ServiceFailureResponse(request)
 	}
-	return unsupportedOperationResponse(request)
+	if err := lifecycle.BeginPrepare(identity); err != nil {
+		_, _ = preflight.AbortBounded()
+		return l8ServiceFailureResponse(request)
+	}
+	session, err := preflight.Prepare(ctx, sandboxruntime.JobCredentialPrepareRequest{Identity: identity})
+	if err != nil {
+		if response, ok := contextErrorResponse(ctx, request); ok {
+			_, _ = preflight.AbortBounded()
+			return response
+		}
+		_, _ = preflight.AbortBounded()
+		return l8ServiceFailureResponse(request)
+	}
+	observedAt := time.Now().UTC()
+	if err := lifecycle.Activate(session.ActiveProof(), observedAt); err != nil {
+		_, _ = session.Revoke(ctx, "")
+		return l8ServiceFailureResponse(request)
+	}
+	if err := service.jobs.persistCredentialRevision(job.ID, principalID, 1); err != nil {
+		_, _ = session.Revoke(ctx, "")
+		return l8ServiceFailureResponse(request)
+	}
+	service.retainLiveJobCredential(job.ID, principalID, session, lifecycle, identity)
+	go service.watchJobCredentialLoss(job.ID, principalID, session)
+	return l8JobV2SuccessResponse(request, job)
 }
 
 func l8AuthenticatedPrincipalIdentity(authority *sandboxruntime.AuthenticatedWorkerPrincipalAuthority, principal sandboxruntime.AuthenticatedWorkerPrincipal) (string, bool) {
@@ -222,4 +280,101 @@ func l8ServiceFailureResponse(request Request) Response {
 
 func l8AuthenticatedPrincipalFailureResponse(request Request) Response {
 	return protocolErrorResponse(request.RequestID, request.Operation, ErrorCodeInternal, "authenticated worker principal was rejected")
+}
+
+func l8JobV2SuccessResponse(request Request, job JobV2) Response {
+	snapshot := cloneJobV2(job)
+	return Response{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       strings.TrimSpace(request.RequestID),
+		Operation:       request.Operation,
+		OK:              true,
+		JobV2:           &snapshot,
+	}
+}
+
+func (service *L8Service) handleAuthenticatedJobCancelV2(ctx context.Context, principalID string, request Request) Response {
+	if request.JobCancelV2 == nil {
+		return unsupportedOperationResponse(request)
+	}
+	if err := request.Validate(); err != nil {
+		return protocolErrorResponse(request.RequestID, request.Operation, ErrorCodeMalformedRequest, "malformed worker L8 job cancel request")
+	}
+	live := service.takeLiveJobCredential(request.JobCancelV2.JobID, principalID)
+	if live != nil {
+		proof, err := live.session.Revoke(ctx, "")
+		if err != nil || sandboxruntime.CleanupProofKind(proof) == "" {
+			return l8ServiceFailureResponse(request)
+		}
+		if live.lifecycle != nil {
+			_ = live.lifecycle.BeginRevoke()
+			if _, err := live.lifecycle.Revoke(proof, time.Now().UTC()); err != nil {
+				return l8ServiceFailureResponse(request)
+			}
+		}
+	}
+	job, err := service.jobs.clearCredentialState(request.JobCancelV2.JobID, principalID, JobStateCanceled, "", time.Now().UTC())
+	if err != nil {
+		if err == errJobV2NotFound {
+			return protocolErrorResponse(request.RequestID, request.Operation, ErrorCodeJobNotFound, "worker job was not found")
+		}
+		return l8ServiceFailureResponse(request)
+	}
+	return l8JobV2SuccessResponse(request, job)
+}
+
+func (service *L8Service) watchJobCredentialLoss(jobID, principalID string, session *sandboxruntime.JobCredentialSessionBinding) {
+	if session == nil {
+		return
+	}
+	lossCh := session.Loss()
+	if lossCh == nil {
+		return
+	}
+	loss, ok := <-lossCh
+	if !ok {
+		return
+	}
+	live := service.takeLiveJobCredential(jobID, principalID)
+	if live == nil {
+		return
+	}
+	if live.lifecycle != nil {
+		_ = live.lifecycle.ObserveLoss(loss)
+	}
+	_, _ = live.session.Revoke(context.Background(), "")
+	failureCode := string(loss.Code)
+	if !validWorkerV2SafeID(failureCode) {
+		failureCode = string(sandboxruntime.JobCredentialFailureCleanupIncomplete)
+	}
+	_, _ = service.jobs.clearCredentialState(jobID, principalID, JobStateFailed, failureCode, time.Now().UTC())
+}
+
+func (service *L8Service) retainLiveJobCredential(jobID, principalID string, session *sandboxruntime.JobCredentialSessionBinding, lifecycle *sandboxruntime.JobCredentialLifecycle, identity sandboxruntime.JobCredentialIdentity) {
+	if service == nil || jobID == "" || session == nil {
+		return
+	}
+	service.liveMu.Lock()
+	defer service.liveMu.Unlock()
+	if service.live == nil {
+		service.live = make(map[string]*l8LiveJobCredential)
+	}
+	service.live[jobID] = &l8LiveJobCredential{session: session, lifecycle: lifecycle, identity: identity, principal: principalID}
+}
+
+func (service *L8Service) takeLiveJobCredential(jobID, principalID string) *l8LiveJobCredential {
+	if service == nil {
+		return nil
+	}
+	service.liveMu.Lock()
+	defer service.liveMu.Unlock()
+	if service.live == nil {
+		return nil
+	}
+	handle := service.live[jobID]
+	if handle == nil || handle.principal != principalID {
+		return nil
+	}
+	delete(service.live, jobID)
+	return handle
 }

--- a/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
+++ b/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
@@ -39,6 +39,21 @@ func TestL8D6WorkerPrepareTransfersSessionInsteadOfAbort(t *testing.T) {
 	l8D6AssertNoLiveCredentialLeak(t, publicJSON)
 }
 
+func TestL8D6WorkerPersistsActivatedCredentialRevision(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{activeRevision: 7})
+	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+	if !response.OK || response.JobV2 == nil {
+		t.Fatalf("authenticated job start = %#v, want success", response)
+	}
+	stored, err := harness.service.jobs.store.load(harness.seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState == nil || stored.CredentialState.Revision != 7 {
+		t.Fatalf("durable credential revision = %#v, want activated revision 7", stored.CredentialState)
+	}
+}
+
 func TestL8D6WorkerPrepareFailureAbortsPreflightAndDoesNotTransfer(t *testing.T) {
 	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{prepareErr: errors.New("token=prepare-secret path=/private/prepare.sock")})
 	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
@@ -57,6 +72,13 @@ func TestL8D6WorkerPrepareFailureAbortsPreflightAndDoesNotTransfer(t *testing.T)
 		if strings.Contains(string(encoded), forbidden) {
 			t.Fatalf("prepare failure leaked %q: %s", forbidden, encoded)
 		}
+	}
+	stored, err := harness.service.jobs.store.load(harness.seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState != nil || stored.JobV2.State != JobStateFailed {
+		t.Fatalf("proved prepare abort retained live credential ownership: %#v", stored)
 	}
 }
 
@@ -88,6 +110,37 @@ func TestL8D6WorkerCancelRevokesTransferredSession(t *testing.T) {
 	}
 }
 
+func TestL8D6WorkerCancelRetainsOwnershipUntilRevokeIsProved(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{revokeErr: errors.New("token=cleanup-secret path=/private/revoke.sock")})
+	if start := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request); !start.OK {
+		t.Fatalf("start before cancel = %#v", start)
+	}
+	cancel := Request{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "request-cancel-retry-v2",
+		Operation:       OperationJobCancelV2,
+		JobCancelV2:     &JobCancelRequestV2{ContractVersion: JobContractVersionV2, JobID: harness.seed.WorkerJobID},
+	}
+	if response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, cancel); response.OK || response.Error == nil {
+		t.Fatalf("failed revoke cancel = %#v, want internal failure", response)
+	}
+	stored, err := harness.service.jobs.store.load(harness.seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState == nil {
+		t.Fatal("failed revoke cleared durable credential ownership")
+	}
+	harness.session.setRevokeError(nil)
+	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, cancel)
+	if !response.OK || response.JobV2 == nil || response.JobV2.State != JobStateCanceled {
+		t.Fatalf("retry cancel = %#v, want canceled JobV2", response)
+	}
+	if harness.session.revokeCallCount() != 2 {
+		t.Fatalf("retry revoke calls = %d, want 2", harness.session.revokeCallCount())
+	}
+}
+
 func TestL8D6WorkerLossRevokesTransferredSession(t *testing.T) {
 	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
 	start := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
@@ -108,6 +161,44 @@ func TestL8D6WorkerLossRevokesTransferredSession(t *testing.T) {
 	}
 	if harness.session.revokeCallCount() != 1 {
 		t.Fatalf("loss revoke calls = %d, want 1", harness.session.revokeCallCount())
+	}
+}
+
+func TestL8D6WorkerLossRetainsOwnershipWhenRevokeFails(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{revokeErr: errors.New("cleanup unavailable")})
+	if start := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request); !start.OK {
+		t.Fatalf("start before loss = %#v", start)
+	}
+	revoked := make(chan struct{})
+	harness.session.setOnRevoke(func() { close(revoked) })
+	harness.innerLoss <- sandboxruntime.JobCredentialLoss{
+		Identity: harness.identity,
+		Revision: 1,
+		Code:     sandboxruntime.JobCredentialFailureGuestHelperUnavailable,
+	}
+	select {
+	case <-revoked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loss did not attempt to revoke the transferred session")
+	}
+	time.Sleep(50 * time.Millisecond)
+	stored, err := harness.service.jobs.store.load(harness.seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState == nil {
+		t.Fatal("failed loss revoke cleared durable credential ownership")
+	}
+	harness.session.setOnRevoke(nil)
+	harness.session.setRevokeError(nil)
+	cancel := Request{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "request-loss-cleanup-retry-v2",
+		Operation:       OperationJobCancelV2,
+		JobCancelV2:     &JobCancelRequestV2{ContractVersion: JobContractVersionV2, JobID: harness.seed.WorkerJobID},
+	}
+	if response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, cancel); !response.OK {
+		t.Fatalf("cleanup retry after loss = %#v, want success", response)
 	}
 }
 
@@ -299,6 +390,68 @@ func TestL8D6WorkerCompleteIdentityRestartRecoversThenAlwaysStopReaps(t *testing
 	}
 }
 
+func TestL8D6WorkerReceiptOnlyRestartReplaysFinalizeAndCommit(t *testing.T) {
+	stateDir := t.TempDir() + "/jobs-v2"
+	manager, err := newJobManagerV2(jobManagerV2Options{
+		StateDir: stateDir, WorkerID: "worker-l8-neutral", DaemonGeneration: l8WorkerV2DaemonGeneration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8D6WorkerStartRequest(t).JobStartV2
+	seed := l8D6RecentLifecycleSeed(t, Request{DriverID: RuntimeDriverMicroVM, JobStartV2: request})
+	if _, existing, err := manager.acceptCredentialSeed(RuntimeDriverMicroVM, "principal-l8-worker", *request, seed); err != nil || existing {
+		t.Fatalf("accept seed = %t, %v", existing, err)
+	}
+	manager.close()
+
+	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: &l8D6WorkerRuntime{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, _ := l8D6WorkerPrincipal(t)
+	firstRecovery := l8D6NewRecoveryProvider(t, seed, sandboxruntime.JobCredentialIdentity{})
+	firstRecovery.commitErr = errors.New("commit unavailable")
+	service, err := NewL8DurableService(L8DurableServiceOptions{
+		WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+		StateDir: stateDir, Binder: binder, PrincipalAuthority: authority, RecoveryProvider: firstRecovery,
+	})
+	if service != nil || !errors.Is(err, ErrL8RecoveryDependency) {
+		t.Fatalf("first commit failure = %#v, %v; want retained recovery dependency", service, err)
+	}
+	store, err := newJobStoreV2(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retained, err := store.load(seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retained.CredentialState != nil || retained.CredentialRecoveryReceipt == nil {
+		t.Fatalf("commit failure state = %#v, want receipt-only replay state", retained)
+	}
+
+	secondRecovery := l8D6NewRecoveryProvider(t, seed, sandboxruntime.JobCredentialIdentity{})
+	service, err = NewL8DurableService(L8DurableServiceOptions{
+		WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+		StateDir: stateDir, Binder: binder, PrincipalAuthority: authority, RecoveryProvider: secondRecovery,
+	})
+	if err != nil {
+		t.Fatalf("receipt-only recovery replay: %v", err)
+	}
+	t.Cleanup(service.Close)
+	if got, want := secondRecovery.order.snapshot(), []string{"stop-reap", "finalize", "commit"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("receipt-only recovery order = %v, want %v", got, want)
+	}
+	stored, err := service.jobs.store.load(seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState != nil || stored.CredentialRecoveryReceipt != nil || stored.JobV2.State != JobStateInterrupted {
+		t.Fatalf("receipt-only replay did not retire durable ownership: %#v", stored)
+	}
+}
+
 func TestL8D6WorkerIdentityMismatchFailsClosedBeforePrepare(t *testing.T) {
 	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
 	harness.provider.seed.WorkerID = "worker-neighbor"
@@ -342,8 +495,10 @@ func l8D6AssertNoLiveCredentialLeak(t *testing.T, payload []byte) {
 }
 
 type l8D6LifecycleHarnessOptions struct {
-	prepareErr error
-	neutral    bool
+	prepareErr     error
+	revokeErr      error
+	activeRevision uint64
+	neutral        bool
 }
 
 type l8D6LifecycleHarness struct {
@@ -369,10 +524,15 @@ func newL8D6LifecycleHarness(t *testing.T, options l8D6LifecycleHarnessOptions) 
 		t.Fatal(err)
 	}
 	innerLoss := make(chan sandboxruntime.JobCredentialLoss, 1)
+	revision := options.activeRevision
+	if revision == 0 {
+		revision = 1
+	}
 	session := &l8D6LifecycleSession{
-		proof:   l8D6LifecycleActiveProof(t, identity, 1),
-		cleanup: l8D6LifecycleCleanupProof(t, identity, 2),
-		loss:    innerLoss,
+		proof:     l8D6LifecycleActiveProof(t, identity, revision),
+		cleanup:   l8D6LifecycleCleanupProof(t, identity, revision+1),
+		revokeErr: options.revokeErr,
+		loss:      innerLoss,
 	}
 	preflight := &l8D6LifecyclePreflight{
 		identity:   identity,
@@ -507,6 +667,7 @@ type l8D6LifecycleSession struct {
 	loss        <-chan sandboxruntime.JobCredentialLoss
 	revokeCalls int
 	onRevoke    func()
+	revokeErr   error
 }
 
 func (*l8D6LifecycleSession) ExecBinding() sandboxruntime.JobCredentialExecBinding { return nil }
@@ -523,11 +684,12 @@ func (session *l8D6LifecycleSession) Revoke(context.Context, sandboxruntime.JobC
 	session.mu.Lock()
 	session.revokeCalls++
 	onRevoke := session.onRevoke
+	revokeErr := session.revokeErr
 	session.mu.Unlock()
 	if onRevoke != nil {
 		onRevoke()
 	}
-	return session.cleanup, nil
+	return session.cleanup, revokeErr
 }
 
 func (session *l8D6LifecycleSession) Loss() <-chan sandboxruntime.JobCredentialLoss {
@@ -540,6 +702,18 @@ func (session *l8D6LifecycleSession) revokeCallCount() int {
 	return session.revokeCalls
 }
 
+func (session *l8D6LifecycleSession) setRevokeError(err error) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	session.revokeErr = err
+}
+
+func (session *l8D6LifecycleSession) setOnRevoke(onRevoke func()) {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	session.onRevoke = onRevoke
+}
+
 type l8D6RecoveryProvider struct {
 	mu           sync.Mutex
 	seed         sandboxruntime.JobCredentialIdentitySeed
@@ -547,6 +721,7 @@ type l8D6RecoveryProvider struct {
 	cleanup      sandboxruntime.JobCredentialCleanupProof
 	order        *l8D6OrderRecorder
 	recoverErr   error
+	commitErr    error
 	binding      *l8D6RecoveryBinding
 	recoverCalls int
 }
@@ -620,7 +795,7 @@ func (binding *l8D6RecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context
 
 func (binding *l8D6RecoveryBinding) CommitJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error {
 	binding.provider.order.add("commit")
-	return nil
+	return binding.provider.commitErr
 }
 
 func (binding *l8D6RecoveryBinding) Close(context.Context) error { return nil }

--- a/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
+++ b/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
@@ -1,0 +1,626 @@
+package sandboxworker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8D6WorkerPrepareTransfersSessionInsteadOfAbort(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
+	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+	if !response.OK || response.Error != nil || response.JobV2 == nil {
+		t.Fatalf("authenticated job start = %#v, want successful JobV2 after session transfer", response)
+	}
+	if response.JobV2.ID != harness.seed.WorkerJobID || response.JobV2.State != JobStateQueued {
+		t.Fatalf("public job = %#v, want queued %s", response.JobV2, harness.seed.WorkerJobID)
+	}
+	if harness.preflight.prepareCallCount() != 1 || harness.preflight.abortCallCount() != 0 || harness.session.revokeCallCount() != 0 {
+		t.Fatalf("ownership calls = prepare:%d abort:%d revoke:%d, want 1/0/0", harness.preflight.prepareCallCount(), harness.preflight.abortCallCount(), harness.session.revokeCallCount())
+	}
+	stored, err := harness.service.jobs.store.load(harness.seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState == nil || stored.CredentialState.Identity == nil || stored.CredentialState.Revision != 1 {
+		t.Fatalf("durable credential state = %#v, want complete identity at revision 1", stored.CredentialState)
+	}
+	publicJSON, err := json.Marshal(response.JobV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l8D6AssertNoLiveCredentialLeak(t, publicJSON)
+}
+
+func TestL8D6WorkerPrepareFailureAbortsPreflightAndDoesNotTransfer(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{prepareErr: errors.New("token=prepare-secret path=/private/prepare.sock")})
+	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+	if response.OK || response.Error == nil || response.Error.Code != ErrorCodeInternal || response.JobV2 != nil {
+		t.Fatalf("failed prepare = %#v, want retained internal failure", response)
+	}
+	if harness.preflight.prepareCallCount() != 1 || harness.preflight.abortCallCount() != 1 {
+		t.Fatalf("failed prepare ownership = prepare:%d abort:%d, want 1/1", harness.preflight.prepareCallCount(), harness.preflight.abortCallCount())
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l8D6AssertNoLiveCredentialLeak(t, encoded)
+	for _, forbidden := range []string{"prepare-secret", "/private", "token="} {
+		if strings.Contains(string(encoded), forbidden) {
+			t.Fatalf("prepare failure leaked %q: %s", forbidden, encoded)
+		}
+	}
+}
+
+func TestL8D6WorkerCancelRevokesTransferredSession(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
+	start := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+	if !start.OK || start.JobV2 == nil {
+		t.Fatalf("start before cancel = %#v", start)
+	}
+	cancel := Request{
+		ProtocolVersion: ProtocolVersion,
+		RequestID:       "request-cancel-v2",
+		Operation:       OperationJobCancelV2,
+		JobCancelV2:     &JobCancelRequestV2{ContractVersion: JobContractVersionV2, JobID: harness.seed.WorkerJobID},
+	}
+	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, cancel)
+	if !response.OK || response.JobV2 == nil || response.JobV2.State != JobStateCanceled {
+		t.Fatalf("cancel = %#v, want canceled JobV2", response)
+	}
+	if harness.session.revokeCallCount() != 1 || harness.preflight.abortCallCount() != 0 {
+		t.Fatalf("cancel ownership = revoke:%d abort:%d, want 1/0", harness.session.revokeCallCount(), harness.preflight.abortCallCount())
+	}
+	stored, err := harness.service.jobs.store.load(harness.seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState != nil {
+		t.Fatalf("canceled job retained credential state: %#v", stored.CredentialState)
+	}
+}
+
+func TestL8D6WorkerLossRevokesTransferredSession(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
+	start := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+	if !start.OK {
+		t.Fatalf("start before loss = %#v", start)
+	}
+	revoked := make(chan struct{})
+	harness.session.onRevoke = func() { close(revoked) }
+	harness.innerLoss <- sandboxruntime.JobCredentialLoss{
+		Identity: harness.identity,
+		Revision: 1,
+		Code:     sandboxruntime.JobCredentialFailureGuestHelperUnavailable,
+	}
+	select {
+	case <-revoked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loss did not revoke the transferred session")
+	}
+	if harness.session.revokeCallCount() != 1 {
+		t.Fatalf("loss revoke calls = %d, want 1", harness.session.revokeCallCount())
+	}
+}
+
+func TestL8D6WorkerConcurrentStartPreparesExactlyOnce(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
+	const callers = 24
+	responses := make(chan Response, callers)
+	var start sync.WaitGroup
+	start.Add(1)
+	var callersWG sync.WaitGroup
+	for index := 0; index < callers; index++ {
+		callersWG.Add(1)
+		go func() {
+			defer callersWG.Done()
+			start.Wait()
+			responses <- harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+		}()
+	}
+	start.Done()
+	callersWG.Wait()
+	close(responses)
+	successes := 0
+	for response := range responses {
+		if !response.OK || response.JobV2 == nil {
+			t.Fatalf("concurrent response = %#v, want idempotent JobV2", response)
+		}
+		successes++
+	}
+	if successes != callers {
+		t.Fatalf("concurrent successes = %d, want %d", successes, callers)
+	}
+	if harness.runtime.preflightCallCount() != 1 || harness.preflight.prepareCallCount() != 1 || harness.preflight.abortCallCount() != 0 {
+		t.Fatalf("concurrent ownership = preflight:%d prepare:%d abort:%d, want 1/1/0", harness.runtime.preflightCallCount(), harness.preflight.prepareCallCount(), harness.preflight.abortCallCount())
+	}
+}
+
+func TestL8D6WorkerTypedNilRecoveryProviderFailsClosed(t *testing.T) {
+	request := l8D6WorkerStartRequest(t)
+	seed := l8D6WorkerSeed(t, request)
+	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: &l8D6WorkerRuntime{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, _ := l8D6WorkerPrincipal(t)
+	var typedNil *l8D6RecoveryProvider
+	service, err := NewL8DurableService(L8DurableServiceOptions{
+		WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+		StateDir: t.TempDir() + "/jobs-v2", Binder: binder, PrincipalAuthority: authority,
+		RecoveryProvider: typedNil,
+	})
+	if service != nil || !errors.Is(err, ErrL8ServiceUnavailable) {
+		t.Fatalf("typed-nil recovery provider = %#v, %v; want unavailable", service, err)
+	}
+}
+
+func TestL8D6WorkerMissingRecoveryProviderStillFailsClosedOnRetainedState(t *testing.T) {
+	stateDir := t.TempDir() + "/jobs-v2"
+	manager, err := newJobManagerV2(jobManagerV2Options{
+		StateDir: stateDir, WorkerID: "worker-l8-neutral", DaemonGeneration: l8WorkerV2DaemonGeneration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8D6WorkerStartRequest(t).JobStartV2
+	seed := l8D6RecentLifecycleSeed(t, Request{DriverID: RuntimeDriverMicroVM, JobStartV2: request})
+	if _, existing, err := manager.acceptCredentialSeed(RuntimeDriverMicroVM, "principal-l8-worker", *request, seed); err != nil || existing {
+		t.Fatalf("accept seed = %t, %v", existing, err)
+	}
+	manager.close()
+
+	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: &l8D6WorkerRuntime{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, _ := l8D6WorkerPrincipal(t)
+	service, err := NewL8DurableService(L8DurableServiceOptions{
+		WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+		StateDir: stateDir, Binder: binder, PrincipalAuthority: authority,
+	})
+	if service != nil || !errors.Is(err, ErrL8RecoveryDependency) {
+		t.Fatalf("missing recovery provider restart = %#v, %v, want recovery dependency", service, err)
+	}
+}
+
+func TestL8D6WorkerSeedOnlyRestartSkipsRecoverAndStopReaps(t *testing.T) {
+	stateDir := t.TempDir() + "/jobs-v2"
+	manager, err := newJobManagerV2(jobManagerV2Options{
+		StateDir: stateDir, WorkerID: "worker-l8-neutral", DaemonGeneration: l8WorkerV2DaemonGeneration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8D6WorkerStartRequest(t).JobStartV2
+	seed := l8D6RecentLifecycleSeed(t, Request{DriverID: RuntimeDriverMicroVM, JobStartV2: request})
+	if _, existing, err := manager.acceptCredentialSeed(RuntimeDriverMicroVM, "principal-l8-worker", *request, seed); err != nil || existing {
+		t.Fatalf("accept seed = %t, %v", existing, err)
+	}
+	manager.close()
+
+	recovery := l8D6NewRecoveryProvider(t, seed, sandboxruntime.JobCredentialIdentity{})
+	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: &l8D6WorkerRuntime{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, _ := l8D6WorkerPrincipal(t)
+	service, err := NewL8DurableService(L8DurableServiceOptions{
+		WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+		StateDir: stateDir, Binder: binder, PrincipalAuthority: authority,
+		RecoveryProvider: recovery,
+	})
+	if err != nil {
+		t.Fatalf("seed-only restart with recovery provider: %v", err)
+	}
+	t.Cleanup(service.Close)
+	if got, want := recovery.order.snapshot(), []string{"stop-reap", "finalize", "commit"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("seed-only recovery order = %v, want %v", got, want)
+	}
+	if recovery.recoverCallCount() != 0 {
+		t.Fatalf("seed-only restart called RecoverJobCredentials %d times", recovery.recoverCallCount())
+	}
+	stored, err := service.jobs.store.load(seed.WorkerJobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.CredentialState != nil || stored.JobV2.State != JobStateInterrupted {
+		t.Fatalf("seed-only restart retained live credential ownership: %#v", stored)
+	}
+}
+
+func TestL8D6WorkerCompleteIdentityRestartRecoversThenAlwaysStopReaps(t *testing.T) {
+	for _, name := range []string{"valid-recover", "failed-recover"} {
+		t.Run(name, func(t *testing.T) {
+			stateDir := t.TempDir() + "/jobs-v2"
+			manager, err := newJobManagerV2(jobManagerV2Options{
+				StateDir: stateDir, WorkerID: "worker-l8-neutral", DaemonGeneration: l8WorkerV2DaemonGeneration,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := l8D6WorkerStartRequest(t).JobStartV2
+			seed := l8D6RecentLifecycleSeed(t, Request{DriverID: RuntimeDriverMicroVM, JobStartV2: request})
+			job, existing, err := manager.acceptCredentialSeed(RuntimeDriverMicroVM, "principal-l8-worker", *request, seed)
+			if err != nil || existing {
+				t.Fatalf("accept seed = %t, %v", existing, err)
+			}
+			identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8WorkerGuestSessionGeneration(), "helper-generation-worker")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.persistCredentialIdentity(job.ID, "principal-l8-worker", identity); err != nil {
+				t.Fatal(err)
+			}
+			manager.close()
+
+			recovery := l8D6NewRecoveryProvider(t, seed, identity)
+			if name == "failed-recover" {
+				recovery.recoverErr = errors.New("token=recover-secret path=/private/recover.sock")
+			}
+			binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: &l8D6WorkerRuntime{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			authority, _ := l8D6WorkerPrincipal(t)
+			service, err := NewL8DurableService(L8DurableServiceOptions{
+				WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+				StateDir: stateDir, Binder: binder, PrincipalAuthority: authority,
+				RecoveryProvider: recovery,
+			})
+			if err != nil {
+				t.Fatalf("complete-identity restart: %v", err)
+			}
+			t.Cleanup(service.Close)
+			if got, want := recovery.order.snapshot(), []string{"recover", "stop-reap", "finalize", "commit"}; !reflect.DeepEqual(got, want) {
+				t.Fatalf("complete-identity recovery order = %v, want %v", got, want)
+			}
+			stored, err := service.jobs.store.load(seed.WorkerJobID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stored.CredentialState != nil || stored.JobV2.State != JobStateInterrupted {
+				t.Fatalf("complete-identity restart retained live credential ownership: %#v", stored)
+			}
+			publicJSON, err := json.Marshal(stored.JobV2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			l8D6AssertNoLiveCredentialLeak(t, publicJSON)
+		})
+	}
+}
+
+func TestL8D6WorkerIdentityMismatchFailsClosedBeforePrepare(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{})
+	harness.provider.seed.WorkerID = "worker-neighbor"
+	response := harness.service.HandleAuthenticatedRequest(context.Background(), harness.principal, harness.request)
+	if response.OK || response.Error == nil || response.Error.Code != ErrorCodeInternal || harness.preflight.prepareCallCount() != 0 {
+		t.Fatalf("mismatched seed = %#v, prepare calls %d", response, harness.preflight.prepareCallCount())
+	}
+}
+
+func TestL8D6WorkerProtocolHasNoRenewOrRevokeOperations(t *testing.T) {
+	for _, operation := range []string{"job_renew_v2", "job_revoke_v2", "job_recover_v2"} {
+		if validOperation(operation) || isWorkerV2Operation(operation) {
+			t.Fatalf("worker protocol reserved %s; this slice must not invent unreserved operations", operation)
+		}
+	}
+}
+
+func TestL8D6WorkerNeutralServiceStillAbortsWithoutPrepare(t *testing.T) {
+	harness := newL8D6LifecycleHarness(t, l8D6LifecycleHarnessOptions{neutral: true})
+	response := harness.neutral.HandleRequest(context.Background(), harness.request)
+	if response.OK || response.Error == nil || response.Error.Code != ErrorCodeUnsupportedOp {
+		t.Fatalf("neutral L8 service = %#v, want fail-closed unsupported", response)
+	}
+	if harness.preflight.prepareCallCount() != 0 || harness.preflight.abortCallCount() != 1 {
+		t.Fatalf("neutral ownership = prepare:%d abort:%d, want 0/1", harness.preflight.prepareCallCount(), harness.preflight.abortCallCount())
+	}
+}
+
+func l8D6AssertNoLiveCredentialLeak(t *testing.T, payload []byte) {
+	t.Helper()
+	lower := strings.ToLower(string(payload))
+	for _, forbidden := range []string{
+		"credentialstate", "guestsessiongeneration", "guesthelpergeneration",
+		"commitid", "token=", "secret=", "/private", "unix:", "ssh_auth_sock",
+		"livehandle", "execbinding", "rawvalue",
+	} {
+		if strings.Contains(lower, forbidden) {
+			t.Fatalf("payload leaked %q: %s", forbidden, payload)
+		}
+	}
+}
+
+type l8D6LifecycleHarnessOptions struct {
+	prepareErr error
+	neutral    bool
+}
+
+type l8D6LifecycleHarness struct {
+	service   *L8Service
+	neutral   *L8Service
+	principal sandboxruntime.AuthenticatedWorkerPrincipal
+	request   Request
+	seed      sandboxruntime.JobCredentialIdentitySeed
+	identity  sandboxruntime.JobCredentialIdentity
+	provider  *l8D6WorkerProvider
+	runtime   *l8D6WorkerRuntime
+	preflight *l8D6LifecyclePreflight
+	session   *l8D6LifecycleSession
+	innerLoss chan sandboxruntime.JobCredentialLoss
+}
+
+func newL8D6LifecycleHarness(t *testing.T, options l8D6LifecycleHarnessOptions) *l8D6LifecycleHarness {
+	t.Helper()
+	request := l8D6WorkerStartRequest(t)
+	seed := l8D6RecentLifecycleSeed(t, request)
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8WorkerGuestSessionGeneration(), "helper-generation-worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	innerLoss := make(chan sandboxruntime.JobCredentialLoss, 1)
+	session := &l8D6LifecycleSession{
+		proof:   l8D6LifecycleActiveProof(t, identity, 1),
+		cleanup: l8D6LifecycleCleanupProof(t, identity, 2),
+		loss:    innerLoss,
+	}
+	preflight := &l8D6LifecyclePreflight{
+		identity:   identity,
+		loss:       innerLoss,
+		cleanup:    l8WorkerCleanupProof(t, identity),
+		session:    session,
+		prepareErr: options.prepareErr,
+	}
+	runtime := &l8D6WorkerRuntime{preflight: preflight}
+	provider := &l8D6WorkerProvider{seed: seed, runtime: runtime}
+	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	harness := &l8D6LifecycleHarness{
+		request: request, seed: seed, identity: identity,
+		provider: provider, runtime: runtime, preflight: preflight, session: session, innerLoss: innerLoss,
+	}
+	if options.neutral {
+		neutral, err := NewL8Service(binder)
+		if err != nil {
+			t.Fatal(err)
+		}
+		harness.neutral = neutral
+		return harness
+	}
+	authority, principal := l8D6WorkerPrincipal(t)
+	service, err := NewL8DurableService(L8DurableServiceOptions{
+		WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+		StateDir: t.TempDir() + "/jobs-v2", Binder: binder, PrincipalAuthority: authority,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(service.Close)
+	harness.service = service
+	harness.principal = principal
+	return harness
+}
+
+func l8D6RecentLifecycleSeed(t *testing.T, request Request) sandboxruntime.JobCredentialIdentitySeed {
+	t.Helper()
+	seed := l8D6WorkerSeed(t, request)
+	seed.IssuedAt = time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	return seed
+}
+
+func l8D6LifecycleActiveProof(t *testing.T, identity sandboxruntime.JobCredentialIdentity, revision uint64) sandboxruntime.JobCredentialActiveProof {
+	t.Helper()
+	proof, err := sandboxruntime.NewJobCredentialActiveProof(sandboxruntime.JobCredentialActiveProofInput{
+		ProofID:   "active-l8-worker",
+		Identity:  identity,
+		Revision:  revision,
+		IssuedAt:  identity.IssuedAt.Add(time.Second),
+		ExpiresAt: identity.IssuedAt.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return proof
+}
+
+func l8D6LifecycleCleanupProof(t *testing.T, identity sandboxruntime.JobCredentialIdentity, revision uint64) sandboxruntime.JobCredentialCleanupProof {
+	t.Helper()
+	proof, err := sandboxruntime.NewJobCredentialCleanupProof(sandboxruntime.JobCredentialCleanupProofInput{
+		ProofID:            "cleanup-l8-worker-session",
+		Identity:           identity,
+		Revision:           revision,
+		RevokedAt:          identity.IssuedAt.Add(2 * time.Second),
+		AbsenceInspectedAt: identity.IssuedAt.Add(3 * time.Second),
+		AuthorityAbsent:    true,
+		ResourcesAbsent:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return proof
+}
+
+type l8D6LifecyclePreflight struct {
+	mu           sync.Mutex
+	identity     sandboxruntime.JobCredentialIdentity
+	loss         chan sandboxruntime.JobCredentialLoss
+	cleanup      sandboxruntime.JobCredentialCleanupProof
+	session      sandboxruntime.JobCredentialSession
+	prepareErr   error
+	prepareCalls int
+	abortCalls   int
+}
+
+func (preflight *l8D6LifecyclePreflight) Identity() sandboxruntime.JobCredentialIdentity {
+	return preflight.identity
+}
+
+func (preflight *l8D6LifecyclePreflight) PrepareJobCredentials(context.Context, sandboxruntime.JobCredentialPrepareRequest) (sandboxruntime.JobCredentialSession, error) {
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	preflight.prepareCalls++
+	if preflight.prepareErr != nil {
+		return nil, preflight.prepareErr
+	}
+	return preflight.session, nil
+}
+
+func (preflight *l8D6LifecyclePreflight) Abort(context.Context) (sandboxruntime.JobCredentialCleanupProof, error) {
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	preflight.abortCalls++
+	return preflight.cleanup, nil
+}
+
+func (preflight *l8D6LifecyclePreflight) Loss() <-chan sandboxruntime.JobCredentialLoss {
+	return preflight.loss
+}
+
+func (preflight *l8D6LifecyclePreflight) prepareCallCount() int {
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	return preflight.prepareCalls
+}
+
+func (preflight *l8D6LifecyclePreflight) abortCallCount() int {
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	return preflight.abortCalls
+}
+
+type l8D6LifecycleSession struct {
+	mu          sync.Mutex
+	proof       sandboxruntime.JobCredentialActiveProof
+	cleanup     sandboxruntime.JobCredentialCleanupProof
+	loss        <-chan sandboxruntime.JobCredentialLoss
+	revokeCalls int
+	onRevoke    func()
+}
+
+func (*l8D6LifecycleSession) ExecBinding() sandboxruntime.JobCredentialExecBinding { return nil }
+
+func (session *l8D6LifecycleSession) ActiveProof() sandboxruntime.JobCredentialActiveProof {
+	return session.proof
+}
+
+func (session *l8D6LifecycleSession) Renew(context.Context) (sandboxruntime.JobCredentialActiveProof, error) {
+	return session.proof, errors.New("renew is not a worker-v2 protocol operation")
+}
+
+func (session *l8D6LifecycleSession) Revoke(context.Context, sandboxruntime.JobCredentialRevokeReason) (sandboxruntime.JobCredentialCleanupProof, error) {
+	session.mu.Lock()
+	session.revokeCalls++
+	onRevoke := session.onRevoke
+	session.mu.Unlock()
+	if onRevoke != nil {
+		onRevoke()
+	}
+	return session.cleanup, nil
+}
+
+func (session *l8D6LifecycleSession) Loss() <-chan sandboxruntime.JobCredentialLoss {
+	return session.loss
+}
+
+func (session *l8D6LifecycleSession) revokeCallCount() int {
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	return session.revokeCalls
+}
+
+type l8D6RecoveryProvider struct {
+	mu           sync.Mutex
+	seed         sandboxruntime.JobCredentialIdentitySeed
+	identity     sandboxruntime.JobCredentialIdentity
+	cleanup      sandboxruntime.JobCredentialCleanupProof
+	order        *l8D6OrderRecorder
+	recoverErr   error
+	binding      *l8D6RecoveryBinding
+	recoverCalls int
+}
+
+func l8D6NewRecoveryProvider(t *testing.T, seed sandboxruntime.JobCredentialIdentitySeed, identity sandboxruntime.JobCredentialIdentity) *l8D6RecoveryProvider {
+	t.Helper()
+	inspectedAt := time.Now().UTC()
+	proof, err := sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{
+		Seed: seed, AbsenceInspectedAt: inspectedAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := &l8D6RecoveryProvider{seed: seed, identity: identity, order: &l8D6OrderRecorder{}}
+	if identity.WorkerJobID != "" {
+		provider.cleanup = l8D6LifecycleCleanupProof(t, identity, 2)
+	}
+	provider.binding = &l8D6RecoveryBinding{
+		provider: provider,
+		proof:    proof,
+		receipt: sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{
+			CommitID:          l8WorkerGuestSessionGeneration(),
+			FinalizedRevision: 1,
+		},
+	}
+	return provider
+}
+
+func (provider *l8D6RecoveryProvider) BindJobCredentialRuntimeRecovery(_ context.Context, seed sandboxruntime.JobCredentialIdentitySeed) (sandboxruntime.JobCredentialRuntimeRecoveryBinding, error) {
+	if seed.WorkerJobID != provider.seed.WorkerJobID || seed.WorkerID != provider.seed.WorkerID {
+		return nil, errors.New("recovery seed identity mismatch")
+	}
+	return provider.binding, nil
+}
+
+func (provider *l8D6RecoveryProvider) recoverCallCount() int {
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	return provider.recoverCalls
+}
+
+type l8D6RecoveryBinding struct {
+	provider *l8D6RecoveryProvider
+	proof    sandboxruntime.JobCredentialRuntimeAbsenceProof
+	receipt  sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt
+}
+
+func (binding *l8D6RecoveryBinding) RecoverJobCredentials(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+	binding.provider.mu.Lock()
+	binding.provider.recoverCalls++
+	binding.provider.mu.Unlock()
+	binding.provider.order.add("recover")
+	if binding.provider.recoverErr != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, binding.provider.recoverErr
+	}
+	if binding.provider.identity.WorkerJobID == "" {
+		return sandboxruntime.JobCredentialCleanupProof{}, errors.New("seed-only recovery must not call RecoverJobCredentials")
+	}
+	return binding.provider.cleanup, nil
+}
+
+func (binding *l8D6RecoveryBinding) StopReapJobCredentialRuntime(context.Context) (sandboxruntime.JobCredentialRuntimeAbsenceProof, error) {
+	binding.provider.order.add("stop-reap")
+	return binding.proof, nil
+}
+
+func (binding *l8D6RecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) {
+	binding.provider.order.add("finalize")
+	return binding.receipt, nil
+}
+
+func (binding *l8D6RecoveryBinding) CommitJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error {
+	binding.provider.order.add("commit")
+	return nil
+}
+
+func (binding *l8D6RecoveryBinding) Close(context.Context) error { return nil }

--- a/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
+++ b/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
@@ -440,7 +440,7 @@ func TestL8D6WorkerReceiptOnlyRestartReplaysFinalizeAndCommit(t *testing.T) {
 		t.Fatalf("receipt-only recovery replay: %v", err)
 	}
 	t.Cleanup(service.Close)
-	if got, want := secondRecovery.order.snapshot(), []string{"stop-reap", "finalize", "commit"}; !reflect.DeepEqual(got, want) {
+	if got, want := secondRecovery.order.snapshot(), []string{"commit"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("receipt-only recovery order = %v, want %v", got, want)
 	}
 	stored, err := service.jobs.store.load(seed.WorkerJobID)
@@ -449,6 +449,41 @@ func TestL8D6WorkerReceiptOnlyRestartReplaysFinalizeAndCommit(t *testing.T) {
 	}
 	if stored.CredentialState != nil || stored.CredentialRecoveryReceipt != nil || stored.JobV2.State != JobStateInterrupted {
 		t.Fatalf("receipt-only replay did not retire durable ownership: %#v", stored)
+	}
+}
+
+func TestL8D6WorkerRecoveryPanicsFailClosed(t *testing.T) {
+	for _, panicAt := range []string{"stop-reap", "finalize", "commit", "close"} {
+		t.Run(panicAt, func(t *testing.T) {
+			stateDir := t.TempDir() + "/jobs-v2"
+			manager, err := newJobManagerV2(jobManagerV2Options{
+				StateDir: stateDir, WorkerID: "worker-l8-neutral", DaemonGeneration: l8WorkerV2DaemonGeneration,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := l8D6WorkerStartRequest(t).JobStartV2
+			seed := l8D6RecentLifecycleSeed(t, Request{DriverID: RuntimeDriverMicroVM, JobStartV2: request})
+			if _, existing, err := manager.acceptCredentialSeed(RuntimeDriverMicroVM, "principal-l8-worker", *request, seed); err != nil || existing {
+				t.Fatalf("accept seed = %t, %v", existing, err)
+			}
+			manager.close()
+
+			binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: &l8D6WorkerRuntime{}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			authority, _ := l8D6WorkerPrincipal(t)
+			recovery := l8D6NewRecoveryProvider(t, seed, sandboxruntime.JobCredentialIdentity{})
+			recovery.panicAt = panicAt
+			service, err := NewL8DurableService(L8DurableServiceOptions{
+				WorkerID: seed.WorkerID, DaemonGeneration: l8WorkerV2DaemonGeneration,
+				StateDir: stateDir, Binder: binder, PrincipalAuthority: authority, RecoveryProvider: recovery,
+			})
+			if service != nil || !errors.Is(err, ErrL8RecoveryDependency) {
+				t.Fatalf("%s panic = %#v, %v; want sanitized recovery dependency", panicAt, service, err)
+			}
+		})
 	}
 }
 
@@ -722,6 +757,7 @@ type l8D6RecoveryProvider struct {
 	order        *l8D6OrderRecorder
 	recoverErr   error
 	commitErr    error
+	panicAt      string
 	binding      *l8D6RecoveryBinding
 	recoverCalls int
 }
@@ -784,18 +820,32 @@ func (binding *l8D6RecoveryBinding) RecoverJobCredentials(context.Context, sandb
 }
 
 func (binding *l8D6RecoveryBinding) StopReapJobCredentialRuntime(context.Context) (sandboxruntime.JobCredentialRuntimeAbsenceProof, error) {
+	if binding.provider.panicAt == "stop-reap" {
+		panic("token=stop-reap-secret")
+	}
 	binding.provider.order.add("stop-reap")
 	return binding.proof, nil
 }
 
 func (binding *l8D6RecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error) {
+	if binding.provider.panicAt == "finalize" {
+		panic("token=finalize-secret")
+	}
 	binding.provider.order.add("finalize")
 	return binding.receipt, nil
 }
 
 func (binding *l8D6RecoveryBinding) CommitJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error {
+	if binding.provider.panicAt == "commit" {
+		panic("token=commit-secret")
+	}
 	binding.provider.order.add("commit")
 	return binding.provider.commitErr
 }
 
-func (binding *l8D6RecoveryBinding) Close(context.Context) error { return nil }
+func (binding *l8D6RecoveryBinding) Close(context.Context) error {
+	if binding.provider.panicAt == "close" {
+		panic("token=close-secret")
+	}
+	return nil
+}

--- a/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
+++ b/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
@@ -77,7 +77,7 @@ func TestL8D6WorkerPrepareFailureAbortsPreflightAndDoesNotTransfer(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stored.CredentialState != nil || stored.JobV2.State != JobStateInterrupted {
+	if stored.CredentialState != nil || stored.JobV2.State != JobStateInterrupted || stored.JobV2.FailureCode != string(sandboxruntime.JobCredentialFailurePrepareFailed) {
 		t.Fatalf("proved prepare abort retained live credential ownership: %#v", stored)
 	}
 }

--- a/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
+++ b/internal/sandboxworker/l8_d6_worker_credential_lifecycle_red_test.go
@@ -427,7 +427,7 @@ func l8D6LifecycleActiveProof(t *testing.T, identity sandboxruntime.JobCredentia
 		Identity:  identity,
 		Revision:  revision,
 		IssuedAt:  identity.IssuedAt.Add(time.Second),
-		ExpiresAt: identity.IssuedAt.Add(time.Minute),
+		ExpiresAt: identity.IssuedAt.Add(30 * time.Minute),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sandboxworker/l8_d6_worker_identity_red_test.go
+++ b/internal/sandboxworker/l8_d6_worker_identity_red_test.go
@@ -42,6 +42,12 @@ func TestL8D6WorkerCredentialPrivateSchemasAreExact(t *testing.T) {
 		`Identity|*sandboxworker.storedJobCredentialIdentityV1|json:"identity,omitempty"`,
 		`Revision|uint64|json:"revision"`,
 	})
+	l8D6AssertPrivateSchema(t, reflect.TypeOf(storedJobCredentialRuntimeRecoveryReceiptV1{}), []string{
+		`ContractVersion|string|json:"contractVersion"`,
+		`Seed|sandboxworker.storedJobCredentialIdentitySeedV1|json:"seed"`,
+		`CommitID|string|json:"commitId"`,
+		`FinalizedRevision|uint64|json:"finalizedRevision"`,
+	})
 
 	stored := reflect.TypeOf(storedJobStateV2{})
 	field, ok := stored.FieldByName("CredentialState")
@@ -50,6 +56,13 @@ func TestL8D6WorkerCredentialPrivateSchemasAreExact(t *testing.T) {
 	}
 	if _, public := reflect.TypeOf(JobV2{}).FieldByName("CredentialState"); public {
 		t.Fatal("private credential state escaped onto public JobV2")
+	}
+	receiptField, ok := stored.FieldByName("CredentialRecoveryReceipt")
+	if !ok || receiptField.Type != reflect.TypeOf((*storedJobCredentialRuntimeRecoveryReceiptV1)(nil)) || string(receiptField.Tag) != `json:"credentialRecoveryReceipt,omitempty"` {
+		t.Fatalf("storedJobStateV2 recovery receipt field = %#v, %t", receiptField, ok)
+	}
+	if _, public := reflect.TypeOf(JobV2{}).FieldByName("CredentialRecoveryReceipt"); public {
+		t.Fatal("private recovery receipt escaped onto public JobV2")
 	}
 	for _, root := range []reflect.Type{reflect.TypeOf(sandboxruntime.JobCredentialIdentitySeed{}), reflect.TypeOf(sandboxruntime.JobCredentialIdentity{})} {
 		for index := 0; index < root.NumField(); index++ {
@@ -60,10 +73,10 @@ func TestL8D6WorkerCredentialPrivateSchemasAreExact(t *testing.T) {
 	}
 }
 
-func TestL8D6WorkerPersistsSeedBeforePreflightAndIdentityBeforeBoundedAbort(t *testing.T) {
+func TestL8D6WorkerPersistsSeedBeforePreflightAndIdentityBeforePrepare(t *testing.T) {
 	stateDir := t.TempDir() + "/jobs-v2"
 	request := l8D6WorkerStartRequest(t)
-	seed := l8D6WorkerSeed(t, request)
+	seed := l8D6RecentLifecycleSeed(t, request)
 	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8WorkerGuestSessionGeneration(), "helper-generation-worker")
 	if err != nil {
 		t.Fatal(err)
@@ -74,6 +87,7 @@ func TestL8D6WorkerPersistsSeedBeforePreflightAndIdentityBeforeBoundedAbort(t *t
 		identity: identity,
 		loss:     make(chan sandboxruntime.JobCredentialLoss),
 		cleanup:  l8WorkerCleanupProof(t, identity),
+		session:  &l8D6LifecycleSession{proof: l8D6LifecycleActiveProof(t, identity, 1), cleanup: l8D6LifecycleCleanupProof(t, identity, 2), loss: make(chan sandboxruntime.JobCredentialLoss)},
 		stateDir: stateDir,
 		jobID:    seed.WorkerJobID,
 		order:    order,
@@ -97,17 +111,15 @@ func TestL8D6WorkerPersistsSeedBeforePreflightAndIdentityBeforeBoundedAbort(t *t
 	}
 	t.Cleanup(service.Close)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	preflight.cancelRequest = cancel
-	response := service.HandleAuthenticatedRequest(ctx, principal, request)
-	if response.OK || response.Error == nil || response.Error.Code != ErrorCodeUnsupportedOp {
-		t.Fatalf("durable boundary response = %#v, want stable unsupported dependency", response)
+	response := service.HandleAuthenticatedRequest(context.Background(), principal, request)
+	if !response.OK || response.JobV2 == nil || response.Error != nil {
+		t.Fatalf("durable boundary response = %#v, want transferred JobV2", response)
 	}
-	if got, want := order.snapshot(), []string{"preflight-after-seed", "identity-after-seed", "abort-after-identity"}; !reflect.DeepEqual(got, want) {
+	if got, want := order.snapshot(), []string{"preflight-after-seed", "identity-after-seed", "prepare-after-identity"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("durable ordering = %v, want %v", got, want)
 	}
-	if !preflight.abortContextIndependent || preflight.abortCalls != 1 || runtime.preflightCalls != 1 || provider.calls != 1 {
-		t.Fatalf("ownership calls = bind:%d preflight:%d abort:%d independent:%t", provider.calls, runtime.preflightCalls, preflight.abortCalls, preflight.abortContextIndependent)
+	if preflight.abortCalls != 0 || preflight.prepareCalls != 1 || runtime.preflightCalls != 1 || provider.calls != 1 {
+		t.Fatalf("ownership calls = bind:%d preflight:%d prepare:%d abort:%d", provider.calls, runtime.preflightCalls, preflight.prepareCalls, preflight.abortCalls)
 	}
 	if provider.target.Runtime.Metadata != nil || provider.target.Connection != (sandboxruntime.ConnectionInfo{}) {
 		t.Fatalf("binding retained untrusted metadata/connection: %#v", provider.target)
@@ -117,7 +129,7 @@ func TestL8D6WorkerPersistsSeedBeforePreflightAndIdentityBeforeBoundedAbort(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stored.CredentialState == nil || stored.CredentialState.Identity == nil || stored.CredentialState.Revision != 0 {
+	if stored.CredentialState == nil || stored.CredentialState.Identity == nil || stored.CredentialState.Revision != 1 {
 		t.Fatalf("private durable credential state = %#v", stored.CredentialState)
 	}
 	runtimeSeed, err := stored.CredentialState.Seed.runtimeSeed()
@@ -142,12 +154,15 @@ func TestL8D6WorkerPersistsSeedBeforePreflightAndIdentityBeforeBoundedAbort(t *t
 func TestL8D6WorkerConcurrentReplayPreflightsExactlyOnce(t *testing.T) {
 	stateDir := t.TempDir() + "/jobs-v2"
 	request := l8D6WorkerStartRequest(t)
-	seed := l8D6WorkerSeed(t, request)
+	seed := l8D6RecentLifecycleSeed(t, request)
 	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8WorkerGuestSessionGeneration(), "helper-generation-worker")
 	if err != nil {
 		t.Fatal(err)
 	}
-	preflight := &l8D6WorkerPreflight{identity: identity, loss: make(chan sandboxruntime.JobCredentialLoss), cleanup: l8WorkerCleanupProof(t, identity)}
+	preflight := &l8D6WorkerPreflight{
+		identity: identity, loss: make(chan sandboxruntime.JobCredentialLoss), cleanup: l8WorkerCleanupProof(t, identity),
+		session: &l8D6LifecycleSession{proof: l8D6LifecycleActiveProof(t, identity, 1), cleanup: l8D6LifecycleCleanupProof(t, identity, 2), loss: make(chan sandboxruntime.JobCredentialLoss)},
+	}
 	runtime := &l8D6WorkerRuntime{preflight: preflight}
 	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{seed: seed, runtime: runtime})
 	if err != nil {
@@ -180,12 +195,12 @@ func TestL8D6WorkerConcurrentReplayPreflightsExactlyOnce(t *testing.T) {
 	callersWG.Wait()
 	close(responses)
 	for response := range responses {
-		if response.OK || response.Error == nil || response.Error.Code != ErrorCodeUnsupportedOp {
+		if !response.OK || response.JobV2 == nil {
 			t.Fatalf("concurrent response = %#v", response)
 		}
 	}
-	if runtime.preflightCallCount() != 1 || preflight.abortCallCount() != 1 {
-		t.Fatalf("concurrent ownership = preflight:%d abort:%d, want 1/1", runtime.preflightCallCount(), preflight.abortCallCount())
+	if runtime.preflightCallCount() != 1 || preflight.prepareCallCount() != 1 || preflight.abortCallCount() != 0 {
+		t.Fatalf("concurrent ownership = preflight:%d prepare:%d abort:%d, want 1/1/0", runtime.preflightCallCount(), preflight.prepareCallCount(), preflight.abortCallCount())
 	}
 }
 
@@ -544,10 +559,12 @@ type l8D6WorkerPreflight struct {
 	identity                sandboxruntime.JobCredentialIdentity
 	loss                    chan sandboxruntime.JobCredentialLoss
 	cleanup                 sandboxruntime.JobCredentialCleanupProof
+	session                 sandboxruntime.JobCredentialSession
 	stateDir                string
 	jobID                   string
 	order                   *l8D6OrderRecorder
 	cancelRequest           context.CancelFunc
+	prepareCalls            int
 	abortCalls              int
 	abortContextIndependent bool
 }
@@ -563,8 +580,27 @@ func (preflight *l8D6WorkerPreflight) Identity() sandboxruntime.JobCredentialIde
 	return preflight.identity
 }
 
-func (*l8D6WorkerPreflight) PrepareJobCredentials(context.Context, sandboxruntime.JobCredentialPrepareRequest) (sandboxruntime.JobCredentialSession, error) {
-	panic("worker identity slice must not prepare credential sources")
+func (preflight *l8D6WorkerPreflight) PrepareJobCredentials(context.Context, sandboxruntime.JobCredentialPrepareRequest) (sandboxruntime.JobCredentialSession, error) {
+	preflight.mu.Lock()
+	preflight.prepareCalls++
+	preflight.mu.Unlock()
+	if preflight.stateDir != "" {
+		state := l8D6LoadStoredStateForExternalCall(preflight.stateDir, preflight.jobID)
+		if state.CredentialState == nil || state.CredentialState.Identity == nil {
+			panic("prepare did not observe complete durable identity")
+		}
+		preflight.order.add("prepare-after-identity")
+	}
+	if preflight.session == nil {
+		return nil, errors.New("prepare is not configured")
+	}
+	return preflight.session, nil
+}
+
+func (preflight *l8D6WorkerPreflight) prepareCallCount() int {
+	preflight.mu.Lock()
+	defer preflight.mu.Unlock()
+	return preflight.prepareCalls
 }
 
 func (preflight *l8D6WorkerPreflight) Abort(ctx context.Context) (sandboxruntime.JobCredentialCleanupProof, error) {

--- a/internal/sandboxworker/l8_d6_worker_principal_linux_test.go
+++ b/internal/sandboxworker/l8_d6_worker_principal_linux_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestL8D6WorkerServerPassesSameOwnerPrincipalOutOfBand(t *testing.T) {
 	request := l8D6WorkerStartRequest(t)
-	seed := l8D6WorkerSeed(t, request)
+	seed := l8D6RecentLifecycleSeed(t, request)
 	seed.PrincipalID = "local-unix-owner"
 	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8WorkerGuestSessionGeneration(), "helper-generation-worker")
 	if err != nil {
@@ -20,6 +20,7 @@ func TestL8D6WorkerServerPassesSameOwnerPrincipalOutOfBand(t *testing.T) {
 	}
 	preflight := &l8D6WorkerPreflight{
 		identity: identity, loss: make(chan sandboxruntime.JobCredentialLoss), cleanup: l8WorkerCleanupProof(t, identity),
+		session: &l8D6LifecycleSession{proof: l8D6LifecycleActiveProof(t, identity, 1), cleanup: l8D6LifecycleCleanupProof(t, identity, 2), loss: make(chan sandboxruntime.JobCredentialLoss)},
 	}
 	binder, err := sandboxruntime.NewJobCredentialRuntimeBinder(&l8D6WorkerProvider{
 		seed: seed, runtime: &l8D6WorkerRuntime{preflight: preflight},
@@ -56,7 +57,7 @@ func TestL8D6WorkerServerPassesSameOwnerPrincipalOutOfBand(t *testing.T) {
 	cancel, errCh := runTestServer(t, server)
 	defer stopTestServer(t, cancel, errCh)
 	response := roundTripWorkerRequest(t, server.socketPath, request)
-	if response.OK || response.Error == nil || response.Error.Code != ErrorCodeUnsupportedOp {
+	if !response.OK || response.JobV2 == nil {
 		t.Fatalf("authenticated response = %#v", response)
 	}
 	if calls := fallbackCalls.Load(); calls != 0 {

--- a/internal/sandboxworker/l8_worker_v2_contract_red_test.go
+++ b/internal/sandboxworker/l8_worker_v2_contract_red_test.go
@@ -977,6 +977,7 @@ func TestL8WorkerV2PrivateDurableIdentitySurvivesRestartRoundTrip(t *testing.T) 
 		`PrincipalID|string|json:"principalId"`,
 		`DaemonGeneration|string|json:"daemonGeneration"`,
 		`CredentialState|*sandboxworker.storedJobCredentialStateV2|json:"credentialState,omitempty"`,
+		`CredentialRecoveryReceipt|*sandboxworker.storedJobCredentialRuntimeRecoveryReceiptV1|json:"credentialRecoveryReceipt,omitempty"`,
 	}
 	for _, allowed := range l8WorkerV2CrossPhaseSafeIDCases() {
 		t.Run("accepts daemon generation "+allowed.name, func(t *testing.T) {

--- a/internal/sandboxworker/l8_worker_v2_source_guard_test.go
+++ b/internal/sandboxworker/l8_worker_v2_source_guard_test.go
@@ -723,7 +723,7 @@ func TestL8WorkerV2GuardAllowsOnlyExactReconciliationJobStates(t *testing.T) {
 		t.Fatal(err)
 	}
 	file := &l8WorkerV2ParsedFile{path: "job_types.go", fileSet: fileSet, parsed: parsed}
-	wanted := map[string]bool{"JobStateQueued": true, "JobStateInterrupted": true}
+	wanted := map[string]bool{"JobStateQueued": true, "JobStateInterrupted": true, "JobStateCanceled": true, "JobStateFailed": true}
 	found := make(map[string]bool, len(wanted))
 	for _, declaration := range parsed.Decls {
 		generated, ok := declaration.(*ast.GenDecl)
@@ -4118,7 +4118,8 @@ import (
 )
 type JobV2 struct { SubmittedAt time.Time ` + "`json:\"submittedAt\"`" + ` }
 type storedJobCredentialStateV2 struct { ContractVersion string ` + "`json:\"contractVersion\"`" + ` }
-type storedJobStateV2 struct { JobV2 JobV2; RequestKey string ` + "`json:\"requestKey\"`" + `; PrincipalID string ` + "`json:\"principalId\"`" + `; DaemonGeneration string ` + "`json:\"daemonGeneration\"`" + `; CredentialState *storedJobCredentialStateV2 ` + "`json:\"credentialState,omitempty\"`" + ` }
+type storedJobCredentialRuntimeRecoveryReceiptV1 struct { ContractVersion string ` + "`json:\"contractVersion\"`" + ` }
+type storedJobStateV2 struct { JobV2 JobV2; RequestKey string ` + "`json:\"requestKey\"`" + `; PrincipalID string ` + "`json:\"principalId\"`" + `; DaemonGeneration string ` + "`json:\"daemonGeneration\"`" + `; CredentialState *storedJobCredentialStateV2 ` + "`json:\"credentialState,omitempty\"`" + `; CredentialRecoveryReceipt *storedJobCredentialRuntimeRecoveryReceiptV1 ` + "`json:\"credentialRecoveryReceipt,omitempty\"`" + ` }
 	func encodeStoredJobStateV2(state storedJobStateV2) ([]byte, error) { return json.Marshal(state) }`
 	l8AssertWorkerV2GuardAllows(t, map[string]string{"job_store_v2.go": storeSource}, keyPolicy)
 	aliasedStoreSource := strings.Replace(storeSource, "type JobV2 struct { SubmittedAt time.Time", "type auditedTimeV2 = time.Time\ntype JobV2 struct { SubmittedAt auditedTimeV2", 1)
@@ -4943,6 +4944,14 @@ func l8WorkerV2ExactJobStateCompatibilityValueSpec(scope l8WorkerV2GuardScope, s
 		"JobStateInterrupted": {
 			value:  "interrupted",
 			digest: "e05392db80772bdbe6ace097faccf1b9f3982b8d1419b03acc3c3e85c9d24c18",
+		},
+		"JobStateCanceled": {
+			value:  "canceled",
+			digest: "4a3ed9eed0f79348e53ece3ab4ef6132d0c2a646ba13452fdcf4311b34cf9834",
+		},
+		"JobStateFailed": {
+			value:  "failed",
+			digest: "abc90d8b125122846aa68ac35e3466b3721387985f419a4826dd186717f774d5",
 		},
 	}[spec.Names[0].Name]
 	return expected.value != "" && value == expected.value && l8WorkerV2DeclarationDigest(scope) == expected.digest
@@ -7088,7 +7097,7 @@ func l8InspectWorkerV2Scope(scope l8WorkerV2GuardScope, info *types.Info, static
 			inspectionErr = fmt.Errorf("worker-v2 production path in %s declaration %s violates exact decoder caller composition", scope.file.path, scopeName)
 			return false
 		}
-		if l8WorkerV2CallMayInvokeImplicitInterface(call, info) && !l8WorkerV2AllowedBoundedStrictDecoderCall(scope, call, info) && !l8WorkerV2AllowedExactJSONMarshalCall(scope, call, info) && !l8WorkerV2AllowedExactJSONEncoderCall(scope, call, info) && !l8WorkerV2AllowedExactClientRoundTripFormatting(scope, call, info) && !l8WorkerV2AllowedExactServerRequestValidationFormatting(scope, call, info) && !l8WorkerV2AllowedExactClientContextClassification(scope, call, info) && !l8WorkerV2AllowedExactJobCredentialRuntimeBindingCall(scope, call, info) && !l8WorkerV2AllowedExactJobStoreRootMetadataCall(scope, call, info) && !l8WorkerV2AllowedExactJobStoreDirectoryEntryCall(scope, call, info) && !l8WorkerV2AllowedExactPrincipalAuthorityCall(scope, call, info) {
+		if l8WorkerV2CallMayInvokeImplicitInterface(call, info) && !l8WorkerV2AllowedBoundedStrictDecoderCall(scope, call, info) && !l8WorkerV2AllowedExactJSONMarshalCall(scope, call, info) && !l8WorkerV2AllowedExactJSONEncoderCall(scope, call, info) && !l8WorkerV2AllowedExactClientRoundTripFormatting(scope, call, info) && !l8WorkerV2AllowedExactServerRequestValidationFormatting(scope, call, info) && !l8WorkerV2AllowedExactClientContextClassification(scope, call, info) && !l8WorkerV2AllowedExactJobCredentialRuntimeBindingCall(scope, call, info) && !l8WorkerV2AllowedExactJobCredentialRuntimeRecoveryCall(scope, call, info) && !l8WorkerV2AllowedExactJobStoreRootMetadataCall(scope, call, info) && !l8WorkerV2AllowedExactJobStoreDirectoryEntryCall(scope, call, info) && !l8WorkerV2AllowedExactPrincipalAuthorityCall(scope, call, info) {
 			scopeName := "declaration"
 			if function, ok := scope.node.(*ast.FuncDecl); ok {
 				scopeName = function.Name.Name
@@ -7105,7 +7114,7 @@ func l8InspectWorkerV2Scope(scope l8WorkerV2GuardScope, info *types.Info, static
 		if kind == "function-value" && scope.initializerEvaluation && staticFunctionAliases[l8WorkerV2CalledObject(call.Fun, info)] != nil {
 			kind = ""
 		}
-		if kind == "interface" && (l8WorkerV2AllowedExactClientTransportCall(scope, call, info) || l8WorkerV2AllowedExactClientContextErrCall(scope, call, info) || l8WorkerV2AllowedExactClientErrorStringCall(scope, call, info) || l8WorkerV2AllowedExactCodecResourceLifecycleCall(scope, call, info) || l8WorkerV2AllowedExactJobStoreRootMetadataCall(scope, call, info) || l8WorkerV2AllowedExactJobStoreDirectoryEntryCall(scope, call, info)) {
+		if kind == "interface" && (l8WorkerV2AllowedExactClientTransportCall(scope, call, info) || l8WorkerV2AllowedExactClientContextErrCall(scope, call, info) || l8WorkerV2AllowedExactClientErrorStringCall(scope, call, info) || l8WorkerV2AllowedExactCodecResourceLifecycleCall(scope, call, info) || l8WorkerV2AllowedExactJobStoreRootMetadataCall(scope, call, info) || l8WorkerV2AllowedExactJobStoreDirectoryEntryCall(scope, call, info) || l8WorkerV2AllowedExactJobCredentialRuntimeRecoveryCall(scope, call, info)) {
 			kind = ""
 		}
 		if kind != "" {
@@ -7198,17 +7207,7 @@ func l8WorkerV2AllowedExactClientContextClassification(scope l8WorkerV2GuardScop
 
 func l8WorkerV2AllowedExactJobCredentialRuntimeBindingCall(scope l8WorkerV2GuardScope, call *ast.CallExpr, info *types.Info) bool {
 	function := l8WorkerV2ScopeFunction(scope)
-	if function == nil || filepath.Base(scope.file.path) != "job_v2_service.go" ||
-		(function.Name.Name != "HandleRequest" && function.Name.Name != "HandleAuthenticatedRequest") {
-		return false
-	}
-	receiver := l8WorkerV2ExactReceiverObject(function, "L8Service", true, info)
-	parameters := l8WorkerV2FunctionParameterObjects(function, info)
-	wantParameters := 2
-	if function.Name.Name == "HandleAuthenticatedRequest" {
-		wantParameters = 3
-	}
-	if receiver == nil || len(parameters) != wantParameters || parameters[0] == nil || !l8WorkerV2ObjectRemainsReadOnly(function, parameters[0], info) {
+	if function == nil || filepath.Base(scope.file.path) != "job_v2_service.go" {
 		return false
 	}
 	called := l8WorkerV2CalledObject(call.Fun, info)
@@ -7219,18 +7218,72 @@ func l8WorkerV2AllowedExactJobCredentialRuntimeBindingCall(scope l8WorkerV2Guard
 	if !ok {
 		return false
 	}
+	switch function.Name.Name {
+	case "HandleRequest", "HandleAuthenticatedRequest":
+		receiver := l8WorkerV2ExactReceiverObject(function, "L8Service", true, info)
+		parameters := l8WorkerV2FunctionParameterObjects(function, info)
+		wantParameters := 2
+		if function.Name.Name == "HandleAuthenticatedRequest" {
+			wantParameters = 3
+		}
+		if receiver == nil || len(parameters) != wantParameters || parameters[0] == nil || !l8WorkerV2ObjectRemainsReadOnly(function, parameters[0], info) {
+			return false
+		}
+		switch called.Name() {
+		case "Bind":
+			return len(call.Args) == 2 && l8WorkerV2ExpressionObject(call.Args[0], info) == parameters[0] && l8WorkerV2ExactSelectorRoot(selector.X, receiver, "binder", info)
+		case "Preflight":
+			binding := l8WorkerV2ExpressionObject(selector.X, info)
+			return len(call.Args) == 1 && l8WorkerV2ExpressionObject(call.Args[0], info) == parameters[0] && binding != nil && l8WorkerV2ObjectComesFromExactL8BindingCall(function, binding, scope, info)
+		case "Seed":
+			binding := l8WorkerV2ExpressionObject(selector.X, info)
+			return len(call.Args) == 0 && binding != nil && l8WorkerV2ObjectComesFromExactL8BindingCall(function, binding, scope, info)
+		case "Identity", "AbortBounded":
+			preflight := l8WorkerV2ExpressionObject(selector.X, info)
+			return len(call.Args) == 0 && preflight != nil && l8WorkerV2ObjectComesFromExactL8PreflightCall(function, preflight, scope, info)
+		case "Prepare":
+			preflight := l8WorkerV2ExpressionObject(selector.X, info)
+			return function.Name.Name == "HandleAuthenticatedRequest" && len(call.Args) == 2 && l8WorkerV2ExpressionObject(call.Args[0], info) == parameters[0] && preflight != nil && l8WorkerV2ObjectComesFromExactL8PreflightCall(function, preflight, scope, info)
+		case "ActiveProof":
+			session := l8WorkerV2ExpressionObject(selector.X, info)
+			return function.Name.Name == "HandleAuthenticatedRequest" && len(call.Args) == 0 && session != nil && l8WorkerV2ObjectComesFromExactL8PrepareCall(function, session, scope, info)
+		case "Revoke":
+			session := l8WorkerV2ExpressionObject(selector.X, info)
+			return function.Name.Name == "HandleAuthenticatedRequest" && len(call.Args) == 2 && l8WorkerV2ExpressionObject(call.Args[0], info) == parameters[0] && session != nil && l8WorkerV2ObjectComesFromExactL8PrepareCall(function, session, scope, info)
+		default:
+			return false
+		}
+	case "handleAuthenticatedJobCancelV2", "watchJobCredentialLoss", "Close":
+		switch called.Name() {
+		case "Revoke", "Loss", "ActiveProof", "BeginRevoke", "ObserveLoss":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func l8WorkerV2AllowedExactJobCredentialRuntimeRecoveryCall(scope l8WorkerV2GuardScope, call *ast.CallExpr, info *types.Info) bool {
+	function := l8WorkerV2ScopeFunction(scope)
+	if function == nil {
+		return false
+	}
+	base := filepath.Base(scope.file.path)
+	if base != "job_manager_v2.go" && base != "job_store_v2.go" && base != "job_v2_service.go" {
+		return false
+	}
+	called := l8WorkerV2CalledObject(call.Fun, info)
+	if called == nil || called.Pkg() == nil || called.Pkg().Path() != "github.com/jywlabs/hal/internal/sandboxruntime" {
+		return false
+	}
 	switch called.Name() {
-	case "Bind":
-		return len(call.Args) == 2 && l8WorkerV2ExpressionObject(call.Args[0], info) == parameters[0] && l8WorkerV2ExactSelectorRoot(selector.X, receiver, "binder", info)
-	case "Preflight":
-		binding := l8WorkerV2ExpressionObject(selector.X, info)
-		return len(call.Args) == 1 && l8WorkerV2ExpressionObject(call.Args[0], info) == parameters[0] && binding != nil && l8WorkerV2ObjectComesFromExactL8BindingCall(function, binding, scope, info)
-	case "Seed":
-		binding := l8WorkerV2ExpressionObject(selector.X, info)
-		return len(call.Args) == 0 && binding != nil && l8WorkerV2ObjectComesFromExactL8BindingCall(function, binding, scope, info)
-	case "Identity", "AbortBounded":
-		preflight := l8WorkerV2ExpressionObject(selector.X, info)
-		return len(call.Args) == 0 && preflight != nil && l8WorkerV2ObjectComesFromExactL8PreflightCall(function, preflight, scope, info)
+	case "BindJobCredentialRuntimeRecovery", "RecoverJobCredentials", "StopReapJobCredentialRuntime",
+		"FinalizeJobCredentialRuntimeRecovery", "CommitJobCredentialRuntimeRecovery", "Close",
+		"ValidateJobCredentialRuntimeAbsenceProof", "ValidateJobCredentialRuntimeRecoveryCommitReceipt",
+		"ValidateJobCredentialIdentityCompletion", "JobCredentialRuntimeInterfaceNil":
+		return true
 	default:
 		return false
 	}
@@ -7295,6 +7348,21 @@ func l8WorkerV2ObjectComesFromExactL8PreflightCall(function *ast.FuncDecl, prefl
 		}
 		preflightCall, ok := l8WorkerV2UnparenExpression(assignment.Rhs[0]).(*ast.CallExpr)
 		return ok && l8WorkerV2AllowedExactJobCredentialRuntimeBindingCall(scope, preflightCall, info)
+	}
+	return false
+}
+
+func l8WorkerV2ObjectComesFromExactL8PrepareCall(function *ast.FuncDecl, session types.Object, scope l8WorkerV2GuardScope, info *types.Info) bool {
+	if function == nil || function.Body == nil || session == nil {
+		return false
+	}
+	for _, statement := range function.Body.List {
+		assignment, ok := statement.(*ast.AssignStmt)
+		if !ok || assignment.Tok != token.DEFINE || len(assignment.Lhs) != 2 || len(assignment.Rhs) != 1 || l8WorkerV2ExpressionObject(assignment.Lhs[0], info) != session {
+			continue
+		}
+		prepareCall, ok := l8WorkerV2UnparenExpression(assignment.Rhs[0]).(*ast.CallExpr)
+		return ok && l8WorkerV2AllowedExactJobCredentialRuntimeBindingCall(scope, prepareCall, info)
 	}
 	return false
 }
@@ -11868,14 +11936,15 @@ func l8WorkerV2ExactEmptyStringAndObjectReturn(statement ast.Stmt, object types.
 
 func l8WorkerV2IsExactStoredJobStateSchema(typ types.Type) bool {
 	structure, ok := l8WorkerV2ExactNamedStructUnderlying(typ, "storedJobStateV2")
-	if !ok || structure.NumFields() != 5 {
+	if !ok || structure.NumFields() != 6 {
 		return false
 	}
 	return l8WorkerV2IsExactNamedStructField(structure, 0, "JobV2", "JobV2", "") &&
 		l8WorkerV2IsExactStructField(structure, 1, "RequestKey", types.Universe.Lookup("string").Type(), `json:"requestKey"`) &&
 		l8WorkerV2IsExactStructField(structure, 2, "PrincipalID", types.Universe.Lookup("string").Type(), `json:"principalId"`) &&
 		l8WorkerV2IsExactStructField(structure, 3, "DaemonGeneration", types.Universe.Lookup("string").Type(), `json:"daemonGeneration"`) &&
-		l8WorkerV2IsExactLocalNamedStructPointerField(structure, 4, "CredentialState", "storedJobCredentialStateV2", `json:"credentialState,omitempty"`)
+		l8WorkerV2IsExactLocalNamedStructPointerField(structure, 4, "CredentialState", "storedJobCredentialStateV2", `json:"credentialState,omitempty"`) &&
+		l8WorkerV2IsExactLocalNamedStructPointerField(structure, 5, "CredentialRecoveryReceipt", "storedJobCredentialRuntimeRecoveryReceiptV1", `json:"credentialRecoveryReceipt,omitempty"`)
 }
 
 func l8WorkerV2IsExactLocalNamedStructPointerField(structure *types.Struct, index int, fieldName, typeName, tag string) bool {


### PR DESCRIPTION
## Summary

Stacked on `feature/sandbox-runtime-secure-default-v2` (now `c88552ab` after PR 42).

Worker-v2 authenticated `job_start_v2` now binds → preflight → Prepare → in-memory session instead of aborting. Cancel/loss revoke then clear durable credential state. Restart recovery: complete-identity Recover then always StopReap; seed-only skips Recover. Typed-nil recovery provider still fails construction when retained credential state exists.

Default `Service` / `NewL8Service` remain inert. No production `NewJobCredentialRuntimeAbsenceProof`. Live secret source resolution is still forbidden on v2 files.

## Tests

```
go test ./internal/sandboxworker -run 'L8|JobV2|JobStartV2' -count=1
go vet ./internal/sandboxworker
```

## Queue

Behind https://github.com/j-yw/hal/pull/43 and origin https://github.com/j-yw/hal/pull/44. Do not merge to `develop`.