### PR TITLE
feat: US-049 - L8 guest v2 prepare/renew/revoke/exec packets

### DIFF
--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -4,8 +4,10 @@ This candidate implements the accepted default-off guest-side request inspector,
 readiness dispatcher, and process-local lifecycle composition around the frozen
 contracts for a persistent authenticated control session on fixed VSOCK port
 1025. Controller credential operations prepare, renew, revoke, and exec are
-accepted packet constructors alongside readiness. Helper packets, unknown and
-malformed controller arms, private/stream/credit/close-notify controller
+accepted packet constructors alongside readiness. Each success constructor
+consumes the exact originating controller packet as its sequence, session,
+request-ID, identity-digest, and lifecycle-correlation authority. Helper
+packets, unknown and malformed controller arms, private/stream/credit/close-notify controller
 packets, helper receive construction, and helper `writeCanonicalBody` remain
 `dependency_unaccepted`.
 

--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -3,7 +3,11 @@
 This candidate implements the accepted default-off guest-side request inspector,
 readiness dispatcher, and process-local lifecycle composition around the frozen
 contracts for a persistent authenticated control session on fixed VSOCK port
-1025. Operations beyond readiness remain `dependency_unaccepted`.
+1025. Controller credential operations prepare, renew, revoke, and exec are
+accepted packet constructors alongside readiness. Helper packets, unknown and
+malformed controller arms, private/stream/credit/close-notify controller
+packets, helper receive construction, and helper `writeCanonicalBody` remain
+`dependency_unaccepted`.
 
 The frozen surface is limited to:
 

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
@@ -67,7 +67,7 @@ func (client *Client) dispatchReadinessResponse(ctx context.Context, identity tr
 	if err != nil {
 		return clientError(ClientContractPacket, ClientFieldPacketType)
 	}
-	send, err := newControllerReadinessSendPacket(packet.sequenceValue(), packet.sessionIDValue(), response)
+	send, err := newControllerReadinessSendPacket(packet, response)
 	if err != nil {
 		return clientError(ClientContractPacket, ClientFieldPacketType)
 	}

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
@@ -2,6 +2,7 @@ package credentialclient
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"io"
 	"sync"
@@ -413,30 +414,162 @@ func newControllerReadinessSendPacket(sequence uint64, sessionID [32]byte, respo
 		response.IdentityDigest() != v2control.NewIdentityDigest(sessionID) {
 		return ControllerSendPacket{}, errInvalidControllerSendPacket
 	}
-	return ControllerSendPacket{
+	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmReadiness, controllerSendArm{readiness: response})
+}
+
+func newControllerPreparePacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, prepare v2control.CredentialPrepareRequest) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialPrepareRequest(prepare) != nil ||
+		!controllerIdentityMatchesSession(sessionID, prepare.Identity(), prepare.IdentityDigest()) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != prepare.IdentityDigest() {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	return ControllerPacket{
 		sequence:  sequence,
 		sessionID: sessionID,
-		arm:       controllerSendArmReadiness,
+		arm:       controllerPacketArm{kind: controllerPacketArmPrepare, prepare: prepare},
+	}, nil
+}
+
+func newControllerPrepareSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialPrepareSuccessResponse) (ControllerSendPacket, error) {
+	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialPrepareSuccessResponse(response) != nil ||
+		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+		return ControllerSendPacket{}, errInvalidControllerSendPacket
+	}
+	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmPrepare, controllerSendArm{prepare: response})
+}
+
+func newControllerRenewPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, renew v2control.CredentialRenewRequest) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialRenewRequest(renew) != nil ||
+		!controllerIdentityMatchesSession(sessionID, renew.Identity(), renew.IdentityDigest()) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != renew.IdentityDigest() {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm:       controllerPacketArm{kind: controllerPacketArmRenew, renew: renew},
+	}, nil
+}
+
+func newControllerRenewSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialRenewSuccessResponse) (ControllerSendPacket, error) {
+	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialRenewSuccessResponse(response) != nil ||
+		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+		return ControllerSendPacket{}, errInvalidControllerSendPacket
+	}
+	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmRenew, controllerSendArm{renew: response})
+}
+
+func newControllerRevokePacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, revoke v2control.CredentialRevokeRequest) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialRevokeRequest(revoke) != nil ||
+		!controllerIdentityMatchesSession(sessionID, revoke.Identity(), revoke.IdentityDigest()) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != revoke.IdentityDigest() {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm:       controllerPacketArm{kind: controllerPacketArmRevoke, revoke: revoke},
+	}, nil
+}
+
+func newControllerRevokeSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialRevokeSuccessResponse) (ControllerSendPacket, error) {
+	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialRevokeSuccessResponse(response) != nil ||
+		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+		return ControllerSendPacket{}, errInvalidControllerSendPacket
+	}
+	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmRevoke, controllerSendArm{revoke: response})
+}
+
+func newControllerExecPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, exec v2control.CredentialExecRequest) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialExecRequest(exec) != nil ||
+		!controllerIdentityMatchesSession(sessionID, exec.Identity(), exec.IdentityDigest()) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != exec.IdentityDigest() {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm:       controllerPacketArm{kind: controllerPacketArmExec, exec: exec},
+	}, nil
+}
+
+func newControllerExecSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialExecSuccessResponse) (ControllerSendPacket, error) {
+	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialExecSuccessResponse(response) != nil ||
+		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+		return ControllerSendPacket{}, errInvalidControllerSendPacket
+	}
+	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmExec, controllerSendArm{exec: response})
+}
+
+func controllerIdentityMatchesSession(sessionID [32]byte, jobIdentity v2control.JobIdentity, digest v2control.IdentityDigest) bool {
+	// Credential envelopes bind identityDigest to sessionID through GuestCredentialSessionIdentity, not the raw session bytes.
+	identity, err := v2control.NewGuestCredentialSessionIdentity(sessionID, jobIdentity)
+	if err != nil {
+		return false
+	}
+	computed, err := v2control.GuestCredentialSessionIdentityDigest(identity)
+	if err != nil {
+		return false
+	}
+	return digest == v2control.NewIdentityDigest(computed)
+}
+
+func finishControllerJSONSendPacket(sequence uint64, sessionID [32]byte, kind controllerSendArmKind, arm controllerSendArm) (ControllerSendPacket, error) {
+	body, err := encodeControllerSendCanonicalBody(kind, arm)
+	if err != nil || len(body) == 0 {
+		return ControllerSendPacket{}, errInvalidControllerSendPacket
+	}
+	return ControllerSendPacket{
+		sequence:          sequence,
+		sessionID:         sessionID,
+		arm:               kind,
+		encodedBodyLength: uint32(len(body)),
+		bodySHA256:        sha256.Sum256(body),
 		state: &controllerSendPacketState{
-			owner: &controllerSendPacketOwner{arm: controllerSendArm{readiness: response}},
+			owner: &controllerSendPacketOwner{arm: arm},
 		},
 	}, nil
 }
 
-func newControllerPreparePacket(ControllerReceiveRequest, uint64, [32]byte, v2control.CredentialPrepareRequest) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
-}
-
-func newControllerRenewPacket(ControllerReceiveRequest, uint64, [32]byte, v2control.CredentialRenewRequest) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
-}
-
-func newControllerRevokePacket(ControllerReceiveRequest, uint64, [32]byte, v2control.CredentialRevokeRequest) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
-}
-
-func newControllerExecPacket(ControllerReceiveRequest, uint64, [32]byte, v2control.CredentialExecRequest) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func encodeControllerSendCanonicalBody(kind controllerSendArmKind, arm controllerSendArm) ([]byte, error) {
+	switch kind {
+	case controllerSendArmReadiness:
+		return v2control.EncodeReadinessSuccessResponse(arm.readiness)
+	case controllerSendArmPrepare:
+		return v2control.EncodeCredentialPrepareSuccessResponse(arm.prepare)
+	case controllerSendArmRenew:
+		return v2control.EncodeCredentialRenewSuccessResponse(arm.renew)
+	case controllerSendArmRevoke:
+		return v2control.EncodeCredentialRevokeSuccessResponse(arm.revoke)
+	case controllerSendArmExec:
+		return v2control.EncodeCredentialExecSuccessResponse(arm.exec)
+	default:
+		return nil, ErrClientControlDependencyUnaccepted
+	}
 }
 
 func newControllerPrivatePacket(ControllerReceiveRequest, uint64, [32]byte, credentialprotocol.PrivateRecordKind, v2control.RequestID, v2control.IdentityDigest, uint16, uint16, uint16, uint32, [32]byte, controllerBodyCapability) (ControllerPacket, error) {
@@ -495,8 +628,40 @@ func (packet ControllerSendPacket) sequenceValue() uint64          { return pack
 func (packet ControllerSendPacket) sessionIDValue() [32]byte       { return packet.sessionID }
 func (packet ControllerSendPacket) encodedBodyLengthValue() uint32 { return packet.encodedBodyLength }
 func (packet ControllerSendPacket) bodySHA256Value() [32]byte      { return packet.bodySHA256 }
-func (packet ControllerSendPacket) writeCanonicalBody(bodySegmentSink) error {
-	return ErrClientControlDependencyUnaccepted
+func (packet ControllerSendPacket) writeCanonicalBody(sink bodySegmentSink) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errInvalidControllerSendPacket
+		}
+	}()
+	switch packet.arm {
+	case controllerSendArmReadiness, controllerSendArmPrepare, controllerSendArmRenew, controllerSendArmRevoke, controllerSendArmExec:
+	default:
+		return ErrClientControlDependencyUnaccepted
+	}
+	if packet.state == nil {
+		return errInvalidControllerSendPacket
+	}
+	packet.state.mu.Lock()
+	if packet.state.consumed || packet.state.owner == nil {
+		packet.state.mu.Unlock()
+		return errInvalidControllerSendPacket
+	}
+	owner := packet.state.owner
+	packet.state.consumed = true
+	packet.state.owner = nil
+	packet.state.mu.Unlock()
+	body, encodeErr := encodeControllerSendCanonicalBody(packet.arm, owner.arm)
+	if encodeErr != nil || uint64(len(body)) != uint64(packet.encodedBodyLength) || sha256.Sum256(body) != packet.bodySHA256 {
+		return errInvalidControllerSendPacket
+	}
+	if sink == nil || sink.Capacity() != packet.encodedBodyLength {
+		return errInvalidControllerSendPacket
+	}
+	if writeErr := sink.WriteSegment(0, body); writeErr != nil {
+		return errInvalidControllerSendPacket
+	}
+	return nil
 }
 func (packet ControllerSendPacket) readinessResponseValue() (v2control.ReadinessSuccessResponse, bool) {
 	return controllerSendArmValue(packet, controllerSendArmReadiness, func(arm controllerSendArm) v2control.ReadinessSuccessResponse { return arm.readiness })

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
@@ -409,12 +409,15 @@ func newControllerReadinessPacket(request ControllerReceiveRequest, sequence uin
 	}, nil
 }
 
-func newControllerReadinessSendPacket(sequence uint64, sessionID [32]byte, response v2control.ReadinessSuccessResponse) (ControllerSendPacket, error) {
-	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateReadinessSuccessResponse(response) != nil ||
-		response.IdentityDigest() != v2control.NewIdentityDigest(sessionID) {
+func newControllerReadinessSendPacket(packet ControllerPacket, response v2control.ReadinessSuccessResponse) (ControllerSendPacket, error) {
+	request, ok := packet.readinessValue()
+	if !ok || packet.sequence == 0 || packet.sessionID == ([32]byte{}) ||
+		v2control.ValidateReadinessSuccessResponse(response) != nil ||
+		response.RequestID() != request.RequestID() || response.IdentityDigest() != request.IdentityDigest() ||
+		response.IdentityDigest() != v2control.NewIdentityDigest(packet.sessionID) {
 		return ControllerSendPacket{}, errInvalidControllerSendPacket
 	}
-	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmReadiness, controllerSendArm{readiness: response})
+	return finishControllerJSONSendPacket(packet.sequence, packet.sessionID, controllerSendArmReadiness, controllerSendArm{readiness: response})
 }
 
 func newControllerPreparePacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, prepare v2control.CredentialPrepareRequest) (ControllerPacket, error) {
@@ -436,12 +439,14 @@ func newControllerPreparePacket(request ControllerReceiveRequest, sequence uint6
 	}, nil
 }
 
-func newControllerPrepareSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialPrepareSuccessResponse) (ControllerSendPacket, error) {
-	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialPrepareSuccessResponse(response) != nil ||
-		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+func newControllerPrepareSendPacket(packet ControllerPacket, response v2control.CredentialPrepareSuccessResponse) (ControllerSendPacket, error) {
+	request, ok := packet.prepareValue()
+	if !ok || packet.sequence == 0 || packet.sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialPrepareSuccessResponse(response) != nil ||
+		!controllerPrepareResponseMatchesRequest(request, response) {
 		return ControllerSendPacket{}, errInvalidControllerSendPacket
 	}
-	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmPrepare, controllerSendArm{prepare: response})
+	return finishControllerJSONSendPacket(packet.sequence, packet.sessionID, controllerSendArmPrepare, controllerSendArm{prepare: response})
 }
 
 func newControllerRenewPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, renew v2control.CredentialRenewRequest) (ControllerPacket, error) {
@@ -463,12 +468,15 @@ func newControllerRenewPacket(request ControllerReceiveRequest, sequence uint64,
 	}, nil
 }
 
-func newControllerRenewSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialRenewSuccessResponse) (ControllerSendPacket, error) {
-	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialRenewSuccessResponse(response) != nil ||
-		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+func newControllerRenewSendPacket(packet ControllerPacket, response v2control.CredentialRenewSuccessResponse) (ControllerSendPacket, error) {
+	request, ok := packet.renewValue()
+	if !ok || packet.sequence == 0 || packet.sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialRenewSuccessResponse(response) != nil ||
+		response.RequestID() != request.RequestID() || response.IdentityDigest() != request.IdentityDigest() ||
+		response.Revision() != request.Revision() || response.ExpiresAtUnixNano() != request.ExpiresAtUnixNano() {
 		return ControllerSendPacket{}, errInvalidControllerSendPacket
 	}
-	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmRenew, controllerSendArm{renew: response})
+	return finishControllerJSONSendPacket(packet.sequence, packet.sessionID, controllerSendArmRenew, controllerSendArm{renew: response})
 }
 
 func newControllerRevokePacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, revoke v2control.CredentialRevokeRequest) (ControllerPacket, error) {
@@ -490,12 +498,15 @@ func newControllerRevokePacket(request ControllerReceiveRequest, sequence uint64
 	}, nil
 }
 
-func newControllerRevokeSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialRevokeSuccessResponse) (ControllerSendPacket, error) {
-	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialRevokeSuccessResponse(response) != nil ||
-		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+func newControllerRevokeSendPacket(packet ControllerPacket, response v2control.CredentialRevokeSuccessResponse) (ControllerSendPacket, error) {
+	request, ok := packet.revokeValue()
+	if !ok || packet.sequence == 0 || packet.sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialRevokeSuccessResponse(response) != nil ||
+		response.RequestID() != request.RequestID() || response.IdentityDigest() != request.IdentityDigest() ||
+		response.Revision() != request.Revision() {
 		return ControllerSendPacket{}, errInvalidControllerSendPacket
 	}
-	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmRevoke, controllerSendArm{revoke: response})
+	return finishControllerJSONSendPacket(packet.sequence, packet.sessionID, controllerSendArmRevoke, controllerSendArm{revoke: response})
 }
 
 func newControllerExecPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, exec v2control.CredentialExecRequest) (ControllerPacket, error) {
@@ -517,12 +528,33 @@ func newControllerExecPacket(request ControllerReceiveRequest, sequence uint64, 
 	}, nil
 }
 
-func newControllerExecSendPacket(sequence uint64, sessionID [32]byte, response v2control.CredentialExecSuccessResponse) (ControllerSendPacket, error) {
-	if sequence == 0 || sessionID == ([32]byte{}) || v2control.ValidateCredentialExecSuccessResponse(response) != nil ||
-		response.IdentityDigest() == (v2control.IdentityDigest{}) {
+func newControllerExecSendPacket(packet ControllerPacket, response v2control.CredentialExecSuccessResponse) (ControllerSendPacket, error) {
+	request, ok := packet.execValue()
+	if !ok || packet.sequence == 0 || packet.sessionID == ([32]byte{}) ||
+		v2control.ValidateCredentialExecSuccessResponse(response) != nil ||
+		response.RequestID() != request.RequestID() || response.IdentityDigest() != request.IdentityDigest() ||
+		response.Revision() != request.Revision() {
 		return ControllerSendPacket{}, errInvalidControllerSendPacket
 	}
-	return finishControllerJSONSendPacket(sequence, sessionID, controllerSendArmExec, controllerSendArm{exec: response})
+	return finishControllerJSONSendPacket(packet.sequence, packet.sessionID, controllerSendArmExec, controllerSendArm{exec: response})
+}
+
+func controllerPrepareResponseMatchesRequest(request v2control.CredentialPrepareRequest, response v2control.CredentialPrepareSuccessResponse) bool {
+	if response.RequestID() != request.RequestID() || response.IdentityDigest() != request.IdentityDigest() ||
+		response.Revision() != request.Revision() || response.ExpiresAtUnixNano() != request.ExpiresAtUnixNano() {
+		return false
+	}
+	bindings := request.Bindings()
+	proofs := response.BindingProofs()
+	if len(bindings) != len(proofs) {
+		return false
+	}
+	for index := range bindings {
+		if bindings[index].BindingID() != proofs[index].BindingID() || bindings[index].Mode() != proofs[index].Mode() {
+			return false
+		}
+	}
+	return true
 }
 
 func controllerIdentityMatchesSession(sessionID [32]byte, jobIdentity v2control.JobIdentity, digest v2control.IdentityDigest) bool {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
@@ -1,6 +1,10 @@
 package credentialclient
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -13,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jywlabs/hal/internal/sandboxruntime"
 	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
 	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/session"
 	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/v2control"
@@ -265,6 +270,293 @@ func TestL8D6GuestControllerUnionConsumesOneExactReceiveRequest(t *testing.T) {
 	}
 }
 
+func TestL8D6GuestControllerCredentialPacketsMirrorReadinessDiscipline(t *testing.T) {
+	sessionID := testCredentialPacketSessionID()
+	identity := testCredentialPacketSessionIdentity(t, sessionID)
+	digest := identityDigestForSession(t, identity)
+	requestID := testPacketRequestID(t)
+	prepare := testCredentialPreparePacketRequest(t, requestID, identity)
+	renew := testCredentialRenewPacketRequest(t, requestID, identity)
+	revoke := testCredentialRevokePacketRequest(t, requestID, identity)
+	execReq := testCredentialExecPacketRequest(t, requestID, identity)
+	otherSessionID := testCredentialPacketSessionID()
+	otherSessionID[31] ^= 0xff
+
+	type issueFn func(ControllerReceiveRequest, uint64, [32]byte) (ControllerPacket, error)
+	cases := []struct {
+		name    string
+		digest  v2control.IdentityDigest
+		issue   issueFn
+		inspect func(ControllerPacket) bool
+		zero    issueFn
+	}{
+		{
+			name:   "prepare",
+			digest: digest,
+			issue: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerPreparePacket(receive, sequence, id, prepare)
+			},
+			inspect: func(packet ControllerPacket) bool {
+				arm, ok := packet.prepareValue()
+				return ok && arm.RequestID() == requestID && arm.IdentityDigest() == digest
+			},
+			zero: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerPreparePacket(receive, sequence, id, v2control.CredentialPrepareRequest{})
+			},
+		},
+		{
+			name:   "renew",
+			digest: digest,
+			issue: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerRenewPacket(receive, sequence, id, renew)
+			},
+			inspect: func(packet ControllerPacket) bool {
+				arm, ok := packet.renewValue()
+				return ok && arm.RequestID() == requestID && arm.IdentityDigest() == digest
+			},
+			zero: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerRenewPacket(receive, sequence, id, v2control.CredentialRenewRequest{})
+			},
+		},
+		{
+			name:   "revoke",
+			digest: digest,
+			issue: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerRevokePacket(receive, sequence, id, revoke)
+			},
+			inspect: func(packet ControllerPacket) bool {
+				arm, ok := packet.revokeValue()
+				return ok && arm.RequestID() == requestID && arm.IdentityDigest() == digest
+			},
+			zero: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerRevokePacket(receive, sequence, id, v2control.CredentialRevokeRequest{})
+			},
+		},
+		{
+			name:   "exec",
+			digest: digest,
+			issue: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerExecPacket(receive, sequence, id, execReq)
+			},
+			inspect: func(packet ControllerPacket) bool {
+				arm, ok := packet.execValue()
+				return ok && arm.RequestID() == requestID && arm.IdentityDigest() == digest
+			},
+			zero: func(receive ControllerReceiveRequest, sequence uint64, id [32]byte) (ControllerPacket, error) {
+				return newControllerExecPacket(receive, sequence, id, v2control.CredentialExecRequest{})
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name+"/happy", func(t *testing.T) {
+			receive := mustControlReceiveRequest(t, 1, digest, true)
+			packet, err := test.issue(receive, 1, sessionID)
+			if err != nil {
+				t.Fatalf("issue() error = %v", err)
+			}
+			if !test.inspect(packet) || packet.sequenceValue() != 1 || packet.sessionIDValue() != sessionID {
+				t.Fatal("controller packet did not retain exact typed ownership")
+			}
+			if _, err := test.issue(receive, 1, sessionID); !errors.Is(err, errInvalidControlReceiveRequest) {
+				t.Fatalf("consume-once error = %v", err)
+			}
+		})
+		t.Run(test.name+"/first-prepare-identity-unset", func(t *testing.T) {
+			if test.name != "prepare" {
+				return
+			}
+			receive := mustControlReceiveRequest(t, 1, v2control.IdentityDigest{}, false)
+			packet, err := test.issue(receive, 1, sessionID)
+			if err != nil || !test.inspect(packet) {
+				t.Fatalf("unset expected identity issue() = %v packet ok=%v", err, test.inspect(packet))
+			}
+		})
+		t.Run(test.name+"/sequence-mismatch", func(t *testing.T) {
+			receive := mustControlReceiveRequest(t, 1, digest, true)
+			if _, err := test.issue(receive, 2, sessionID); !errors.Is(err, errInvalidControllerPacket) {
+				t.Fatalf("sequence mismatch error = %v", err)
+			}
+			if _, err := test.issue(receive, 1, sessionID); !errors.Is(err, errInvalidControlReceiveRequest) {
+				t.Fatalf("failed issue did not consume receive request: %v", err)
+			}
+		})
+		t.Run(test.name+"/identity-mismatch", func(t *testing.T) {
+			receive := mustControlReceiveRequest(t, 1, digest, true)
+			if _, err := test.issue(receive, 1, otherSessionID); !errors.Is(err, errInvalidControllerPacket) {
+				t.Fatalf("session identity mismatch error = %v", err)
+			}
+		})
+		t.Run(test.name+"/expected-identity-mismatch", func(t *testing.T) {
+			receive := mustControlReceiveRequest(t, 1, v2control.NewIdentityDigest(sessionID), true)
+			if _, err := test.issue(receive, 1, sessionID); !errors.Is(err, errInvalidControllerPacket) {
+				t.Fatalf("expected identity mismatch error = %v", err)
+			}
+		})
+		t.Run(test.name+"/validator-failure", func(t *testing.T) {
+			receive := mustControlReceiveRequest(t, 1, digest, true)
+			if _, err := test.zero(receive, 1, sessionID); !errors.Is(err, errInvalidControllerPacket) {
+				t.Fatalf("validator failure error = %v", err)
+			}
+		})
+	}
+}
+
+func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
+	sessionID := testCredentialPacketSessionID()
+	identity := testCredentialPacketSessionIdentity(t, sessionID)
+	requestID := testPacketRequestID(t)
+	prepareReq := testCredentialPreparePacketRequest(t, requestID, identity)
+	renewReq := testCredentialRenewPacketRequest(t, requestID, identity)
+	revokeReq := testCredentialRevokePacketRequest(t, requestID, identity)
+	execReq := testCredentialExecPacketRequest(t, requestID, identity)
+	prepareResp := testCredentialPreparePacketResponse(t, prepareReq)
+	renewResp := mustCredentialRenewSuccess(t, renewReq)
+	revokeResp := mustCredentialRevokeSuccess(t, revokeReq)
+	execResp := mustCredentialExecSuccess(t, execReq)
+
+	readinessReq, err := v2control.NewReadinessRequest(requestID, v2control.NewIdentityDigest(sessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	readinessResp, err := v2control.NewReadinessSuccessResponse(readinessReq, "helper-generation-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type sendCase struct {
+		name   string
+		issue  func() (ControllerSendPacket, error)
+		want   []byte
+		access func(ControllerSendPacket) bool
+	}
+	cases := []sendCase{
+		{
+			name: "readiness",
+			issue: func() (ControllerSendPacket, error) {
+				return newControllerReadinessSendPacket(1, sessionID, readinessResp)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeReadinessSuccessResponse(readinessResp) }),
+			access: func(packet ControllerSendPacket) bool {
+				arm, ok := packet.readinessResponseValue()
+				return ok && arm.RequestID() == requestID
+			},
+		},
+		{
+			name: "prepare",
+			issue: func() (ControllerSendPacket, error) {
+				return newControllerPrepareSendPacket(1, sessionID, prepareResp)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialPrepareSuccessResponse(prepareResp) }),
+			access: func(packet ControllerSendPacket) bool {
+				arm, ok := packet.prepareResponseValue()
+				return ok && arm.RequestID() == requestID
+			},
+		},
+		{
+			name: "renew",
+			issue: func() (ControllerSendPacket, error) {
+				return newControllerRenewSendPacket(1, sessionID, renewResp)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialRenewSuccessResponse(renewResp) }),
+			access: func(packet ControllerSendPacket) bool {
+				arm, ok := packet.renewResponseValue()
+				return ok && arm.RequestID() == requestID
+			},
+		},
+		{
+			name: "revoke",
+			issue: func() (ControllerSendPacket, error) {
+				return newControllerRevokeSendPacket(1, sessionID, revokeResp)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialRevokeSuccessResponse(revokeResp) }),
+			access: func(packet ControllerSendPacket) bool {
+				arm, ok := packet.revokeResponseValue()
+				return ok && arm.RequestID() == requestID
+			},
+		},
+		{
+			name: "exec",
+			issue: func() (ControllerSendPacket, error) {
+				return newControllerExecSendPacket(1, sessionID, execResp)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialExecSuccessResponse(execResp) }),
+			access: func(packet ControllerSendPacket) bool {
+				arm, ok := packet.execResponseValue()
+				return ok && arm.RequestID() == requestID
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			packet, err := test.issue()
+			if err != nil {
+				t.Fatalf("send constructor error = %v", err)
+			}
+			if !test.access(packet) || packet.sequenceValue() != 1 || packet.sessionIDValue() != sessionID {
+				t.Fatal("send packet did not retain exact typed ownership")
+			}
+			if packet.encodedBodyLengthValue() != uint32(len(test.want)) || packet.bodySHA256Value() != sha256.Sum256(test.want) {
+				t.Fatal("send packet did not pin canonical body length and digest")
+			}
+			sink := &testCanonicalBodySink{capacity: packet.encodedBodyLengthValue()}
+			if err := packet.writeCanonicalBody(sink); err != nil {
+				t.Fatalf("writeCanonicalBody() error = %v", err)
+			}
+			if string(sink.buf) != string(test.want) {
+				t.Fatalf("canonical body = %s, want %s", sink.buf, test.want)
+			}
+			if test.access(packet) {
+				t.Fatal("consumed send packet still exposed typed arm")
+			}
+			if err := packet.writeCanonicalBody(sink); !errors.Is(err, errInvalidControllerSendPacket) {
+				t.Fatalf("second writeCanonicalBody() error = %v", err)
+			}
+		})
+	}
+
+	if _, err := newControllerPrepareSendPacket(1, sessionID, v2control.CredentialPrepareSuccessResponse{}); !errors.Is(err, errInvalidControllerSendPacket) {
+		t.Fatalf("invalid prepare send error = %v", err)
+	}
+	if err := (ControllerSendPacket{}).writeCanonicalBody(&testCanonicalBodySink{capacity: 1}); !errors.Is(err, ErrClientControlDependencyUnaccepted) && !errors.Is(err, errInvalidControllerSendPacket) {
+		t.Fatalf("zero send packet write error = %v", err)
+	}
+}
+
+func TestL8D6GuestControllerRemainingPacketsStayUnaccepted(t *testing.T) {
+	receive := mustControlReceiveRequest(t, 1, v2control.IdentityDigest{}, false)
+	var sessionID [32]byte
+	sessionID[0] = 1
+	if _, err := newControllerUnknownOperationPacket(receive, 1, sessionID, v2control.InspectedRequest{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("unknown packet error = %v", err)
+	}
+	if _, err := newControllerMalformedKnownPacket(receive, 1, sessionID, v2control.InspectedRequest{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("malformed packet error = %v", err)
+	}
+	if _, err := newControllerPrivatePacket(receive, 1, sessionID, 0, v2control.RequestID{}, v2control.IdentityDigest{}, 0, 0, 0, 0, [32]byte{}, nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("private packet error = %v", err)
+	}
+	if _, err := newControllerStreamPacket(receive, 1, sessionID, 0, 0, v2control.RequestID{}, v2control.IdentityDigest{}, 0, 0, [32]byte{}, nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("stream packet error = %v", err)
+	}
+	if _, err := newControllerCreditPacket(receive, 1, sessionID, 0, v2control.RequestID{}, v2control.IdentityDigest{}, 0); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("credit packet error = %v", err)
+	}
+	if _, err := newControllerCloseNotifyPacket(receive, 1, sessionID, 0); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("close notify packet error = %v", err)
+	}
+	if _, err := newHelperControlReceiveRequest(1, 1, 0, [16]byte{}, false, [32]byte{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("helper receive error = %v", err)
+	}
+	if _, err := newHelperResponsePacket(HelperReceiveRequest{}, credentialprotocol.HelperPacketHeader{}, nil, credentialprotocol.HelperResponseBody{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("helper response error = %v", err)
+	}
+	if err := (HelperSendPacket{}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("helper writeCanonicalBody error = %v", err)
+	}
+}
+
 func TestL8D6GuestPacketUnionsFreezeCompletePrivateOwnership(t *testing.T) {
 	assertPrivateFields(t, ControllerReceiveRequest{}, "liveValue", "nextSequence", "expectedIdentity", "expectedIdentitySet", "maximumPlaintextBytes", "state")
 	assertPrivateFields(t, ControllerPacket{}, "liveValue", "sequence", "sessionID", "arm", "body")
@@ -313,4 +605,227 @@ func testControlSessionIdentity() session.Identity {
 		ImageGeneration:              "image-generation-1",
 		ImageSHA256:                  image,
 	}
+}
+
+func mustControlReceiveRequest(t *testing.T, sequence uint64, identity v2control.IdentityDigest, identitySet bool) ControllerReceiveRequest {
+	t.Helper()
+	receive, err := newControlReceiveRequest(sequence, identity, identitySet, session.MaxControlPlaintextBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receive
+}
+
+func testCredentialPacketSessionID() [32]byte {
+	var sessionID [32]byte
+	for index := range sessionID {
+		sessionID[index] = byte(index)
+	}
+	return sessionID
+}
+
+func testPacketRequestID(t *testing.T) v2control.RequestID {
+	t.Helper()
+	var raw [16]byte
+	for index := range raw {
+		raw[index] = byte(index + 1)
+	}
+	requestID, err := v2control.NewRequestID(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return requestID
+}
+
+func testCredentialPacketSessionIdentity(t *testing.T, sessionID [32]byte) v2control.GuestCredentialSessionIdentity {
+	t.Helper()
+	identity, err := v2control.GuestCredentialSessionIdentityFromRoot(sessionID, testCredentialPacketRoot(sessionID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func identityDigestForSession(t *testing.T, identity v2control.GuestCredentialSessionIdentity) v2control.IdentityDigest {
+	t.Helper()
+	digest, err := v2control.GuestCredentialSessionIdentityDigest(identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v2control.NewIdentityDigest(digest)
+}
+
+func testCredentialPacketRoot(sessionID [32]byte) sandboxruntime.JobCredentialIdentity {
+	return sandboxruntime.JobCredentialIdentity{
+		SandboxID: "sandbox-1", ExecutionID: "execution-1", WorkerID: "worker-1", HostID: "host-1",
+		RuntimeDriver: "microvm", RuntimeID: "runtime-1", RuntimeGeneration: "runtime-generation-1",
+		FirecrackerProcessGeneration: "process-generation-1", VsockGeneration: "vsock-generation-1",
+		WorkerJobID: "worker-job-1", SubmissionID: "submission-1", PlanID: "plan-1",
+		ActivationGeneration: "activation-generation-1", CredentialGeneration: "credential-generation-1",
+		NetworkPlanID: "network-plan-1", PolicySnapshotID: "policy-snapshot-1", ProxySessionID: "proxy-session-1",
+		ProxyGenerationID: "proxy-generation-1", TopologyGenerationID: "topology-generation-1", RuleGenerationID: "rule-generation-1",
+		AdmissionGrantID: "grant-1", PrincipalID: "principal-1", TemplatePolicyID: "template-policy-1", WorkspacePolicyID: "workspace-policy-1",
+		ControllerKeyGeneration: "controller-key-generation-1", GuestBootGeneration: "guest-boot-generation-1",
+		GuestImageGeneration:   "guest-image-generation-1",
+		GuestImageDigest:       "sha256-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		GuestSessionGeneration: base64.RawURLEncoding.EncodeToString(sessionID[:]), GuestHelperGeneration: "helper-generation-1",
+		AdmissionGrantRevision: 7, IssuedAt: time.Unix(0, 1700000000123456789).UTC(),
+		BindingIDs: []string{"binding-http", "binding-file"},
+		DeliveryModes: []sandboxruntime.JobCredentialDeliveryMode{
+			sandboxruntime.JobCredentialDeliveryModeHTTPProxy,
+			sandboxruntime.JobCredentialDeliveryModeFileTmpfs,
+		},
+	}
+}
+
+func testCredentialPreparePacketRequest(t *testing.T, requestID v2control.RequestID, identity v2control.GuestCredentialSessionIdentity) v2control.CredentialPrepareRequest {
+	t.Helper()
+	httpBinding, err := v2control.NewHTTPBindingManifest("binding-http", "azure-openai-responses-v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileBinding, err := v2control.NewFileBindingManifest("binding-file", "credentials/config", 7, strings.Repeat("a", 64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := v2control.NewCredentialPrepareRequest(requestID, identity, 1, 1700000001123456789, []v2control.BindingManifest{httpBinding, fileBinding}, 1, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func testCredentialPreparePacketResponse(t *testing.T, request v2control.CredentialPrepareRequest) v2control.CredentialPrepareSuccessResponse {
+	t.Helper()
+	proofs := []v2control.BindingProof{
+		mustPacketBindingProof(t, "binding-http", v2control.DeliveryMode("http_proxy"), "proof-http"),
+		mustPacketBindingProof(t, "binding-file", v2control.DeliveryMode("file_tmpfs"), "proof-file"),
+	}
+	response, err := v2control.NewCredentialPrepareSuccessResponse(request, 1, 1700000001123456789, "active-proof", "exec-binding", proofs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func mustPacketBindingProof(t *testing.T, bindingID string, mode v2control.DeliveryMode, proofID string) v2control.BindingProof {
+	t.Helper()
+	proof, err := v2control.NewBindingProof(bindingID, mode, proofID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return proof
+}
+
+func testCredentialRenewPacketRequest(t *testing.T, requestID v2control.RequestID, identity v2control.GuestCredentialSessionIdentity) v2control.CredentialRenewRequest {
+	t.Helper()
+	request, err := v2control.NewCredentialRenewRequest(requestID, identity, 8, 1700000600123456789, 1700001200123456789, 1700001800123456789, "active-proof-8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func mustCredentialRenewSuccess(t *testing.T, request v2control.CredentialRenewRequest) v2control.CredentialRenewSuccessResponse {
+	t.Helper()
+	response, err := v2control.NewCredentialRenewSuccessResponse(request, "replacement-proof-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func testCredentialRevokePacketRequest(t *testing.T, requestID v2control.RequestID, identity v2control.GuestCredentialSessionIdentity) v2control.CredentialRevokeRequest {
+	t.Helper()
+	request, err := v2control.NewCredentialRevokeRequest(requestID, identity, 9, v2control.CredentialRevokeReasonRequested)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func mustCredentialRevokeSuccess(t *testing.T, request v2control.CredentialRevokeRequest) v2control.CredentialRevokeSuccessResponse {
+	t.Helper()
+	response, err := v2control.NewCredentialRevokeSuccessResponse(request, "cleanup-proof-9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func testCredentialExecPacketRequest(t *testing.T, requestID v2control.RequestID, identity v2control.GuestCredentialSessionIdentity) v2control.CredentialExecRequest {
+	t.Helper()
+	const proxyURL = "http://proxy-runtime/.well-known/hal/credential-http/v1/azure-openai-responses-v1/deployments/model-1"
+	correlation, err := v2control.NewCredentialExecCorrelation(identity, 3, "exec-binding-3", true, proxyURL, 1, 321, strings.Repeat("a", 64), 1700000000000, 1700001800000, 1700001900000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := []v2control.ExecEnvironment{mustPacketExecEnvironment(t, "MODE", v2control.ExecEnvironmentLiteral, "batch")}
+	for _, name := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"} {
+		env = append(env, mustPacketExecEnvironment(t, name, v2control.ExecEnvironmentGenerated, proxyURL))
+	}
+	timing, err := v2control.NewExecTiming(v2control.ExecTimingTimeoutMillis, 30000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := v2control.NewExecPlan([]string{"/usr/bin/tool", "run"}, env, "/workspace", 1024, 2048, 4096, timing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, err := v2control.NewCredentialExecRequest(requestID, correlation, plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func mustPacketExecEnvironment(t *testing.T, name string, source v2control.ExecEnvironmentSource, value string) v2control.ExecEnvironment {
+	t.Helper()
+	env, err := v2control.NewExecEnvironment(name, source, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return env
+}
+
+func mustCredentialExecSuccess(t *testing.T, request v2control.CredentialExecRequest) v2control.CredentialExecSuccessResponse {
+	t.Helper()
+	empty := sha256.Sum256(nil)
+	response, err := v2control.NewCredentialExecSuccessResponse(request, 0,
+		0, hex.EncodeToString(empty[:]),
+		1, strings.Repeat("b", 64), false,
+		1, strings.Repeat("c", 64), false,
+		strings.Repeat("d", 64),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
+}
+
+func mustEncode(t *testing.T, encode func() ([]byte, error)) []byte {
+	t.Helper()
+	body, err := encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+type testCanonicalBodySink struct {
+	capacity uint32
+	buf      []byte
+}
+
+func (sink *testCanonicalBodySink) Capacity() uint32 { return sink.capacity }
+
+func (sink *testCanonicalBodySink) WriteSegment(offset uint32, source []byte) error {
+	if sink.buf == nil {
+		sink.buf = make([]byte, sink.capacity)
+	}
+	if uint64(offset)+uint64(len(source)) > uint64(len(sink.buf)) {
+		return errInvalidControllerSendPacket
+	}
+	copy(sink.buf[offset:], source)
+	return nil
 }

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
@@ -405,6 +405,7 @@ func TestL8D6GuestControllerCredentialPacketsMirrorReadinessDiscipline(t *testin
 func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 	sessionID := testCredentialPacketSessionID()
 	identity := testCredentialPacketSessionIdentity(t, sessionID)
+	digest := identityDigestForSession(t, identity)
 	requestID := testPacketRequestID(t)
 	prepareReq := testCredentialPreparePacketRequest(t, requestID, identity)
 	renewReq := testCredentialRenewPacketRequest(t, requestID, identity)
@@ -419,7 +420,27 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	readinessPacket, err := newControllerReadinessPacket(mustControlReceiveRequest(t, 1, v2control.NewIdentityDigest(sessionID), true), 1, sessionID, readinessReq)
+	if err != nil {
+		t.Fatal(err)
+	}
 	readinessResp, err := v2control.NewReadinessSuccessResponse(readinessReq, "helper-generation-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparePacket, err := newControllerPreparePacket(mustControlReceiveRequest(t, 1, digest, true), 1, sessionID, prepareReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	renewPacket, err := newControllerRenewPacket(mustControlReceiveRequest(t, 1, digest, true), 1, sessionID, renewReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	revokePacket, err := newControllerRevokePacket(mustControlReceiveRequest(t, 1, digest, true), 1, sessionID, revokeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execPacket, err := newControllerExecPacket(mustControlReceiveRequest(t, 1, digest, true), 1, sessionID, execReq)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +455,7 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 		{
 			name: "readiness",
 			issue: func() (ControllerSendPacket, error) {
-				return newControllerReadinessSendPacket(1, sessionID, readinessResp)
+				return newControllerReadinessSendPacket(readinessPacket, readinessResp)
 			},
 			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeReadinessSuccessResponse(readinessResp) }),
 			access: func(packet ControllerSendPacket) bool {
@@ -445,7 +466,7 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 		{
 			name: "prepare",
 			issue: func() (ControllerSendPacket, error) {
-				return newControllerPrepareSendPacket(1, sessionID, prepareResp)
+				return newControllerPrepareSendPacket(preparePacket, prepareResp)
 			},
 			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialPrepareSuccessResponse(prepareResp) }),
 			access: func(packet ControllerSendPacket) bool {
@@ -456,7 +477,7 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 		{
 			name: "renew",
 			issue: func() (ControllerSendPacket, error) {
-				return newControllerRenewSendPacket(1, sessionID, renewResp)
+				return newControllerRenewSendPacket(renewPacket, renewResp)
 			},
 			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialRenewSuccessResponse(renewResp) }),
 			access: func(packet ControllerSendPacket) bool {
@@ -467,7 +488,7 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 		{
 			name: "revoke",
 			issue: func() (ControllerSendPacket, error) {
-				return newControllerRevokeSendPacket(1, sessionID, revokeResp)
+				return newControllerRevokeSendPacket(revokePacket, revokeResp)
 			},
 			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialRevokeSuccessResponse(revokeResp) }),
 			access: func(packet ControllerSendPacket) bool {
@@ -478,7 +499,7 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 		{
 			name: "exec",
 			issue: func() (ControllerSendPacket, error) {
-				return newControllerExecSendPacket(1, sessionID, execResp)
+				return newControllerExecSendPacket(execPacket, execResp)
 			},
 			want: mustEncode(t, func() ([]byte, error) { return v2control.EncodeCredentialExecSuccessResponse(execResp) }),
 			access: func(packet ControllerSendPacket) bool {
@@ -516,8 +537,33 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 		})
 	}
 
-	if _, err := newControllerPrepareSendPacket(1, sessionID, v2control.CredentialPrepareSuccessResponse{}); !errors.Is(err, errInvalidControllerSendPacket) {
+	if _, err := newControllerPrepareSendPacket(preparePacket, v2control.CredentialPrepareSuccessResponse{}); !errors.Is(err, errInvalidControllerSendPacket) {
 		t.Fatalf("invalid prepare send error = %v", err)
+	}
+
+	otherSessionID := sessionID
+	otherSessionID[31] ^= 0xff
+	otherIdentity := testCredentialPacketSessionIdentity(t, otherSessionID)
+	otherPrepare := testCredentialPreparePacketResponse(t, testCredentialPreparePacketRequest(t, requestID, otherIdentity))
+	otherRenew := mustCredentialRenewSuccess(t, testCredentialRenewPacketRequest(t, requestID, otherIdentity))
+	otherRevoke := mustCredentialRevokeSuccess(t, testCredentialRevokePacketRequest(t, requestID, otherIdentity))
+	otherExec := mustCredentialExecSuccess(t, testCredentialExecPacketRequest(t, requestID, otherIdentity))
+	for _, mismatch := range []struct {
+		name  string
+		issue func() (ControllerSendPacket, error)
+	}{
+		{name: "prepare", issue: func() (ControllerSendPacket, error) {
+			return newControllerPrepareSendPacket(preparePacket, otherPrepare)
+		}},
+		{name: "renew", issue: func() (ControllerSendPacket, error) { return newControllerRenewSendPacket(renewPacket, otherRenew) }},
+		{name: "revoke", issue: func() (ControllerSendPacket, error) { return newControllerRevokeSendPacket(revokePacket, otherRevoke) }},
+		{name: "exec", issue: func() (ControllerSendPacket, error) { return newControllerExecSendPacket(execPacket, otherExec) }},
+	} {
+		t.Run(mismatch.name+"/cross-session-response", func(t *testing.T) {
+			if _, err := mismatch.issue(); !errors.Is(err, errInvalidControllerSendPacket) {
+				t.Fatalf("cross-session response error = %v", err)
+			}
+		})
 	}
 	if err := (ControllerSendPacket{}).writeCanonicalBody(&testCanonicalBodySink{capacity: 1}); !errors.Is(err, ErrClientControlDependencyUnaccepted) && !errors.Is(err, errInvalidControllerSendPacket) {
 		t.Fatalf("zero send packet write error = %v", err)


### PR DESCRIPTION
## Summary
Guest v2 controller packet constructors for prepare, renew, revoke, and exec. Readiness already existed; these remaining receive/send arms now follow the same consume-once, sequence, session, and identity-digest rules. `ControllerSendPacket.writeCanonicalBody` is implemented for readiness plus those four credential arms.

Stacked on `feature/sandbox-runtime-secure-default-v2` at `84e23fe9`.

## Default-off / non-goals
- Helper packets, private/stream/credit/close, unknown/malformed, and Serve dispatch of prepare/renew/revoke/exec remain `dependency_unaccepted`.
- No bind/listen/dial, no command/worker/sandboxd wiring, no D7/L10/L11 claims.

## Tests
- `go test ./internal/sandboxruntime/microvm/guestagent/v2control -run '^TestL8D6GuestV2' -count=1`
- `go test ./internal/sandboxruntime/microvm/guestagent/server/credentialclient -run '^TestL8D6Guest(Control|Transport|Packet|CredentialClient)' -count=1`
- `go test ./internal/sandboxruntime/microvm/guestagent/server -run '^TestL8D6GuestServer' -count=1`
- `go test ./internal/sandboxruntime/microvm/guestagent/l8composition -run '^TestL8D6Guest(ControlBoot|Agent)' -count=1`
- compile-only `-run '^$'` on those packages

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.