### PR TITLE
feat: US-049 - L8 production HTTP credential activator

### DIFF
--- a/cmd/l8_d6_http_activator_docs_test.go
+++ b/cmd/l8_d6_http_activator_docs_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const l8D6HTTPActivatorVerificationDoc = "sandbox-runtime-v2-l8-d6-http-activator-verification.md"
+
+func TestL8D6HTTPActivatorVerificationContract(t *testing.T) {
+	doc := readL8CredentialDeliveryFile(t, filepath.Join("..", "docs", "design", l8D6HTTPActivatorVerificationDoc))
+	for _, required := range []string{
+		"default-off",
+		"TicketStore",
+		"NewProductionL8JobCredentialHTTPProxyActivator",
+		"fake-only",
+		"do not invoke it unless",
+		"failed revoke does not drop ownership",
+		"does not listen or dial",
+		"does not claim D7",
+		"L10",
+		"L11",
+		"live HTTP enforcement",
+		"Default command paths stay unwired",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'L8JobCredential.*HTTP|HTTPActivator|HttpActivator' -count=1",
+		"go test ./internal/credentialproxy -count=1",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^$' -count=1",
+		"go test ./cmd -run 'HTTPActivator|HttpActivator' -count=1",
+		"go vet ./internal/sandboxruntime/microvm/firecrackerhost ./internal/credentialproxy",
+		"go test ./...",
+		"go vet ./...",
+		"make docs-check",
+		"make build",
+		"git diff --check",
+		"command -v golangci-lint",
+	} {
+		if !strings.Contains(doc, required) {
+			t.Fatalf("HTTP activator verification document omits %q", required)
+		}
+	}
+}
+
+func TestL8D6HTTPActivatorRemainsDefaultOff(t *testing.T) {
+	root := filepath.Clean("..")
+	set := token.NewFileSet()
+	callers := 0
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(set, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch function := call.Fun.(type) {
+			case *ast.Ident:
+				name = function.Name
+			case *ast.SelectorExpr:
+				name = function.Sel.Name
+			}
+			if name == "NewProductionL8JobCredentialHTTPProxyActivator" {
+				callers++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callers != 0 {
+		t.Fatalf("production NewProductionL8JobCredentialHTTPProxyActivator callers = %d, want zero", callers)
+	}
+
+	targets := []string{
+		"run_sandbox.go", "auto_sandbox.go", "factory.go", "factory_sandbox_executor.go",
+		filepath.Join("..", "internal", "sandboxworker", "service.go"),
+		filepath.Join("..", "internal", "sandboxruntime", "microvm", "firecrackerhost", "l8_job_credential_runtime.go"),
+	}
+	sandboxdFiles, err := filepath.Glob("sandboxd*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range sandboxdFiles {
+		if !strings.HasSuffix(path, "_test.go") {
+			targets = append(targets, path)
+		}
+	}
+	for _, path := range targets {
+		source := readL8CredentialDeliveryFile(t, path)
+		if strings.Contains(source, "NewProductionL8JobCredentialHTTPProxyActivator") {
+			t.Fatalf("default production path %s wires HTTP activator constructor", filepath.ToSlash(path))
+		}
+	}
+}
+
+func TestL8D6HTTPActivatorProductionSourceIsTicketStoreBackedAndFakeOnly(t *testing.T) {
+	path := filepath.Join("..", "internal", "sandboxruntime", "microvm", "firecrackerhost", "l8_job_credential_http_activator.go")
+	source := readL8CredentialDeliveryFile(t, path)
+	for _, required := range []string{
+		"credentialproxy.TicketStore",
+		"credentialproxy.NewTicketStore",
+		"activator.store.Issue(",
+		"handle.store.Renew(",
+		"handle.store.Revoke(",
+		"NewProductionL8JobCredentialHTTPProxyActivator",
+	} {
+		if !strings.Contains(source, required) {
+			t.Fatalf("HTTP activator production file omits TicketStore marker %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"net.Listen", "net.Dial", "tls.Dial", "http.ListenAndServe", "http.Server{",
+		"kvm", "KVM", "os/exec", "firecracker.Start", "unix.KVM",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("HTTP activator production file contains live marker %q", forbidden)
+		}
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/l8_d6_http_activator_docs_test.go
+++ b/cmd/l8_d6_http_activator_docs_test.go
@@ -18,6 +18,8 @@ func TestL8D6HTTPActivatorVerificationContract(t *testing.T) {
 	for _, required := range []string{
 		"default-off",
 		"TicketStore",
+		"Callers inject a non-nil TicketStore",
+		"caller retains ownership and must Close it",
 		"NewProductionL8JobCredentialHTTPProxyActivator",
 		"fake-only",
 		"do not invoke it unless",
@@ -120,7 +122,6 @@ func TestL8D6HTTPActivatorProductionSourceIsTicketStoreBackedAndFakeOnly(t *test
 	source := readL8CredentialDeliveryFile(t, path)
 	for _, required := range []string{
 		"credentialproxy.TicketStore",
-		"credentialproxy.NewTicketStore",
 		"activator.store.Issue(",
 		"handle.store.Renew(",
 		"handle.store.Revoke(",
@@ -131,6 +132,7 @@ func TestL8D6HTTPActivatorProductionSourceIsTicketStoreBackedAndFakeOnly(t *test
 		}
 	}
 	for _, forbidden := range []string{
+		"credentialproxy.NewTicketStore",
 		"net.Listen", "net.Dial", "tls.Dial", "http.ListenAndServe", "http.Server{",
 		"kvm", "KVM", "os/exec", "firecracker.Start", "unix.KVM",
 	} {

--- a/docs/design/sandbox-runtime-v2-l8-d6-http-activator-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-http-activator-verification.md
@@ -6,7 +6,9 @@ implements `firecrackerhost.l8JobCredentialHTTPProxyActivator` by wrapping
 `NewProductionL8JobCredentialHTTPProxyActivator` and inject it into the host
 JobCredentialRuntime. `sandboxd`, `hal run`, `hal auto`, factory, worker
 `Service`, and `NewProductionL8JobCredentialRuntime` do not invoke it unless
-the caller injects the activator.
+the caller injects the activator. Callers inject a non-nil TicketStore; the
+caller retains ownership and must Close it after every activator and handle
+has finished. The activator never creates or owns a TicketStore HMAC key.
 
 Activate requires HTTP-proxy delivery mode plus a valid identity, binding, and
 source, then issues a TicketStore ticket. The handle `ServiceID()` is the

--- a/docs/design/sandbox-runtime-v2-l8-d6-http-activator-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-http-activator-verification.md
@@ -1,0 +1,42 @@
+# Sandbox Runtime v2 L8 D6 HTTP Credential Activator Verification
+
+This slice adds the default-off production HTTP credential activator that
+implements `firecrackerhost.l8JobCredentialHTTPProxyActivator` by wrapping
+`internal/credentialproxy.TicketStore`. Callers construct it with
+`NewProductionL8JobCredentialHTTPProxyActivator` and inject it into the host
+JobCredentialRuntime. `sandboxd`, `hal run`, `hal auto`, factory, worker
+`Service`, and `NewProductionL8JobCredentialRuntime` do not invoke it unless
+the caller injects the activator.
+
+Activate requires HTTP-proxy delivery mode plus a valid identity, binding, and
+source, then issues a TicketStore ticket. The handle `ServiceID()` is the
+binding service id (safe identifier only). Renew and Revoke go through the
+ticket store. Revoke is mandatory cleanup; a failed revoke does not drop ownership.
+Tickets, secrets, source values, and host paths are never serialized.
+Panic, nil, typed-nil, and identity-mismatch fail closed.
+
+This slice is TicketStore-backed and fake-only. It does not listen or dial, does
+not start a live proxy, KVM, or Firecracker process, and does not claim D7, L10, L11,
+or live HTTP enforcement. Default command paths stay unwired.
+
+## Focused verification
+
+```sh
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'L8JobCredential.*HTTP|HTTPActivator|HttpActivator' -count=1
+go test ./internal/credentialproxy -count=1
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^$' -count=1
+go test ./cmd -run 'HTTPActivator|HttpActivator' -count=1
+go vet ./internal/sandboxruntime/microvm/firecrackerhost ./internal/credentialproxy
+```
+
+## Broad verification
+
+```sh
+go test ./...
+go vet ./...
+make docs-check
+make build
+git diff --check
+```
+
+`golangci-lint` is reported only when `command -v golangci-lint` succeeds.

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator.go
@@ -1,0 +1,314 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jywlabs/hal/internal/credentialproxy"
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+const l8JobCredentialHTTPActivatorValuePlaceholder = "[firecracker-l8-job-credential-http]"
+
+// ProductionL8JobCredentialHTTPProxyActivatorConfig is explicit constructor
+// input for the TicketStore-backed HTTP activator. Zero values are rejected.
+type ProductionL8JobCredentialHTTPProxyActivatorConfig struct {
+	Store              *credentialproxy.TicketStore
+	DaemonGeneration   string
+	CatalogGeneration  string
+	ListenerGeneration uint64
+	LocalAuthority     string
+	Now                func() time.Time
+}
+
+// ProductionL8JobCredentialHTTPProxyActivator issues one TicketStore ticket per
+// HTTP-proxy binding. It is default-off: callers must construct and inject it.
+type ProductionL8JobCredentialHTTPProxyActivator struct {
+	store              *credentialproxy.TicketStore
+	catalogGeneration  string
+	listenerGeneration uint64
+	localAuthority     string
+	now                func() time.Time
+}
+
+type productionL8JobCredentialHTTPProxyHandle struct {
+	mu          sync.Mutex
+	store       *credentialproxy.TicketStore
+	ticket      *credentialproxy.JobTicket
+	correlation credentialproxy.TicketCorrelation
+	serviceID   string
+	revoked     bool
+}
+
+var (
+	_ l8JobCredentialHTTPProxyActivator = (*ProductionL8JobCredentialHTTPProxyActivator)(nil)
+	_ l8JobCredentialHTTPProxyHandle    = (*productionL8JobCredentialHTTPProxyHandle)(nil)
+)
+
+// NewProductionL8JobCredentialHTTPProxyActivator constructs the TicketStore-backed
+// HTTP activator. It is never invoked by sandboxd, hal run, hal auto, factory,
+// worker Service, or NewProductionL8JobCredentialRuntime unless injected.
+func NewProductionL8JobCredentialHTTPProxyActivator(config ProductionL8JobCredentialHTTPProxyActivatorConfig) (*ProductionL8JobCredentialHTTPProxyActivator, error) {
+	if !validL8JobCredentialHTTPCatalogID(config.CatalogGeneration) || config.ListenerGeneration == 0 ||
+		!validL8JobCredentialHTTPLocalAuthority(config.LocalAuthority) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	store := config.Store
+	if store == nil {
+		if !validL8JobCredentialHTTPCatalogID(config.DaemonGeneration) {
+			return nil, ErrL8JobCredentialRuntimeInvalid
+		}
+		created, err := credentialproxy.NewTicketStore(config.DaemonGeneration)
+		if err != nil {
+			return nil, ErrL8JobCredentialRuntimeInvalid
+		}
+		store = created
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &ProductionL8JobCredentialHTTPProxyActivator{
+		store:              store,
+		catalogGeneration:  config.CatalogGeneration,
+		listenerGeneration: config.ListenerGeneration,
+		localAuthority:     config.LocalAuthority,
+		now:                now,
+	}, nil
+}
+
+func (activator *ProductionL8JobCredentialHTTPProxyActivator) Activate(
+	ctx context.Context,
+	identity sandboxruntime.JobCredentialIdentity,
+	binding sandboxruntime.JobCredentialBindingRequest,
+	source sandboxruntime.LiveSecretSource,
+) (handle l8JobCredentialHTTPProxyHandle, err error) {
+	defer func() {
+		if recover() != nil {
+			handle = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if activator == nil || l8JobCredentialRuntimeValueIsNil(ctx) || l8JobCredentialRuntimeValueIsNil(activator.store) || activator.now == nil {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, ErrL8JobCredentialRuntimeUnavailable
+	}
+	if binding.Mode != sandboxruntime.JobCredentialDeliveryModeHTTPProxy {
+		if binding.Mode == sandboxruntime.JobCredentialDeliveryModeFileTmpfs || binding.Mode == sandboxruntime.JobCredentialDeliveryModeSSHAgent {
+			return nil, ErrL8JobCredentialRuntimeUnsupported
+		}
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if sandboxruntime.ValidateJobCredentialIdentity(identity) != nil || !l8JobCredentialHTTPBindingMatchesIdentity(identity, binding) {
+		return nil, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	if !validL8JobCredentialHTTPCatalogID(binding.ID) || !validL8JobCredentialHTTPCatalogID(binding.ServiceID) ||
+		binding.SourceReferenceID == "" || l8JobCredentialRuntimeValueIsNil(source) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if credentialproxy.ServiceID(binding.ServiceID) != credentialproxy.ServiceIDAzureOpenAIResponsesV1 {
+		return nil, ErrL8JobCredentialRuntimeUnsupported
+	}
+	digest, err := sandboxruntime.JobCredentialIdentityDigest(identity)
+	if err != nil {
+		return nil, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	if !validL8JobCredentialHTTPCatalogID(identity.ActivationGeneration) {
+		return nil, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	issuedAt, err := callL8JobCredentialNow(activator.now)
+	if err != nil {
+		return nil, err
+	}
+	correlation := credentialproxy.TicketCorrelation{
+		JobIdentityDigest:    digest,
+		ServiceID:            credentialproxy.ServiceIDAzureOpenAIResponsesV1,
+		BindingID:            binding.ID,
+		ActivationGeneration: identity.ActivationGeneration,
+		CatalogGeneration:    activator.catalogGeneration,
+		ListenerGeneration:   activator.listenerGeneration,
+		LocalAuthority:       activator.localAuthority,
+	}
+	ticket, err := activator.store.Issue(ctx, credentialproxy.TicketActivation{
+		Correlation: correlation,
+		IssuedAt:    issuedAt,
+		Source:      source,
+	})
+	if err != nil {
+		return nil, mapL8JobCredentialHTTPTicketError(err)
+	}
+	if ticket == nil {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	return &productionL8JobCredentialHTTPProxyHandle{
+		store:       activator.store,
+		ticket:      ticket,
+		correlation: correlation,
+		serviceID:   binding.ServiceID,
+	}, nil
+}
+
+func (handle *productionL8JobCredentialHTTPProxyHandle) ServiceID() string {
+	if handle == nil {
+		return ""
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	return handle.serviceID
+}
+
+func (handle *productionL8JobCredentialHTTPProxyHandle) Renew(ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if handle == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if handle.revoked || handle.ticket == nil || l8JobCredentialRuntimeValueIsNil(handle.store) {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	if err := ctx.Err(); err != nil {
+		return ErrL8JobCredentialRuntimeUnavailable
+	}
+	return mapL8JobCredentialHTTPTicketError(handle.store.Renew(ctx, handle.ticket, handle.correlation))
+}
+
+func (handle *productionL8JobCredentialHTTPProxyHandle) Revoke(ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
+	if handle == nil {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	if l8JobCredentialRuntimeValueIsNil(ctx) {
+		ctx = context.Background()
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if handle.revoked {
+		return nil
+	}
+	if handle.ticket == nil || l8JobCredentialRuntimeValueIsNil(handle.store) {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	if err := handle.store.Revoke(ctx, handle.ticket, handle.correlation); err != nil {
+		return mapL8JobCredentialHTTPTicketError(err)
+	}
+	handle.revoked = true
+	handle.ticket = nil
+	return nil
+}
+
+func l8JobCredentialHTTPBindingMatchesIdentity(identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest) bool {
+	if binding.ID == "" || len(identity.BindingIDs) != len(identity.DeliveryModes) {
+		return false
+	}
+	for index, bindingID := range identity.BindingIDs {
+		if bindingID != binding.ID {
+			continue
+		}
+		return identity.DeliveryModes[index] == sandboxruntime.JobCredentialDeliveryModeHTTPProxy &&
+			binding.Mode == sandboxruntime.JobCredentialDeliveryModeHTTPProxy
+	}
+	return false
+}
+
+func mapL8JobCredentialHTTPTicketError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, credentialproxy.ErrTicketCorrelation):
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	case errors.Is(err, credentialproxy.ErrTicketExpired):
+		return sandboxruntime.ErrJobCredentialExpired
+	case errors.Is(err, credentialproxy.ErrTicketRevoked):
+		return sandboxruntime.ErrJobCredentialTransition
+	case errors.Is(err, credentialproxy.ErrTicketInvalid), errors.Is(err, credentialproxy.ErrTicketStoreInvalid):
+		return ErrL8JobCredentialRuntimeInvalid
+	default:
+		return sanitizeL8JobCredentialRuntimeError(err)
+	}
+}
+
+func validL8JobCredentialHTTPCatalogID(value string) bool {
+	if len(value) == 0 || len(value) > 128 || value[0] == '-' || value[len(value)-1] == '-' {
+		return false
+	}
+	previousHyphen := false
+	for _, character := range value {
+		if character == '-' {
+			if previousHyphen {
+				return false
+			}
+			previousHyphen = true
+			continue
+		}
+		previousHyphen = false
+		if (character < 'a' || character > 'z') && (character < '0' || character > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func validL8JobCredentialHTTPLocalAuthority(authority string) bool {
+	if authority == "" || len(authority) > 512 || strings.ContainsAny(authority, "@/\\?# \t\r\n") {
+		return false
+	}
+	host, port, err := net.SplitHostPort(authority)
+	portNumber, portErr := strconv.Atoi(port)
+	return err == nil && portErr == nil && host != "" && portNumber > 0 && portNumber <= 65535
+}
+
+func (*ProductionL8JobCredentialHTTPProxyActivator) String() string {
+	return l8JobCredentialHTTPActivatorValuePlaceholder
+}
+func (*ProductionL8JobCredentialHTTPProxyActivator) GoString() string {
+	return l8JobCredentialHTTPActivatorValuePlaceholder
+}
+func (*ProductionL8JobCredentialHTTPProxyActivator) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialHTTPActivatorValuePlaceholder)
+}
+func (*ProductionL8JobCredentialHTTPProxyActivator) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*ProductionL8JobCredentialHTTPProxyActivator) MarshalText() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*ProductionL8JobCredentialHTTPProxyActivator) MarshalBinary() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+
+func (*productionL8JobCredentialHTTPProxyHandle) String() string {
+	return l8JobCredentialHTTPActivatorValuePlaceholder
+}
+func (*productionL8JobCredentialHTTPProxyHandle) GoString() string {
+	return l8JobCredentialHTTPActivatorValuePlaceholder
+}
+func (*productionL8JobCredentialHTTPProxyHandle) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialHTTPActivatorValuePlaceholder)
+}
+func (*productionL8JobCredentialHTTPProxyHandle) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*productionL8JobCredentialHTTPProxyHandle) MarshalText() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*productionL8JobCredentialHTTPProxyHandle) MarshalBinary() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator.go
@@ -21,7 +21,6 @@ const l8JobCredentialHTTPActivatorValuePlaceholder = "[firecracker-l8-job-creden
 // input for the TicketStore-backed HTTP activator. Zero values are rejected.
 type ProductionL8JobCredentialHTTPProxyActivatorConfig struct {
 	Store              *credentialproxy.TicketStore
-	DaemonGeneration   string
 	CatalogGeneration  string
 	ListenerGeneration uint64
 	LocalAuthority     string
@@ -56,27 +55,16 @@ var (
 // HTTP activator. It is never invoked by sandboxd, hal run, hal auto, factory,
 // worker Service, or NewProductionL8JobCredentialRuntime unless injected.
 func NewProductionL8JobCredentialHTTPProxyActivator(config ProductionL8JobCredentialHTTPProxyActivatorConfig) (*ProductionL8JobCredentialHTTPProxyActivator, error) {
-	if !validL8JobCredentialHTTPCatalogID(config.CatalogGeneration) || config.ListenerGeneration == 0 ||
+	if config.Store == nil || !validL8JobCredentialHTTPCatalogID(config.CatalogGeneration) || config.ListenerGeneration == 0 ||
 		!validL8JobCredentialHTTPLocalAuthority(config.LocalAuthority) {
 		return nil, ErrL8JobCredentialRuntimeInvalid
-	}
-	store := config.Store
-	if store == nil {
-		if !validL8JobCredentialHTTPCatalogID(config.DaemonGeneration) {
-			return nil, ErrL8JobCredentialRuntimeInvalid
-		}
-		created, err := credentialproxy.NewTicketStore(config.DaemonGeneration)
-		if err != nil {
-			return nil, ErrL8JobCredentialRuntimeInvalid
-		}
-		store = created
 	}
 	now := config.Now
 	if now == nil {
 		now = time.Now
 	}
 	return &ProductionL8JobCredentialHTTPProxyActivator{
-		store:              store,
+		store:              config.Store,
 		catalogGeneration:  config.CatalogGeneration,
 		listenerGeneration: config.ListenerGeneration,
 		localAuthority:     config.LocalAuthority,
@@ -275,22 +263,22 @@ func validL8JobCredentialHTTPLocalAuthority(authority string) bool {
 	return err == nil && portErr == nil && host != "" && portNumber > 0 && portNumber <= 65535
 }
 
-func (*ProductionL8JobCredentialHTTPProxyActivator) String() string {
+func (ProductionL8JobCredentialHTTPProxyActivator) String() string {
 	return l8JobCredentialHTTPActivatorValuePlaceholder
 }
-func (*ProductionL8JobCredentialHTTPProxyActivator) GoString() string {
+func (ProductionL8JobCredentialHTTPProxyActivator) GoString() string {
 	return l8JobCredentialHTTPActivatorValuePlaceholder
 }
-func (*ProductionL8JobCredentialHTTPProxyActivator) Format(state fmt.State, _ rune) {
+func (ProductionL8JobCredentialHTTPProxyActivator) Format(state fmt.State, _ rune) {
 	_, _ = io.WriteString(state, l8JobCredentialHTTPActivatorValuePlaceholder)
 }
-func (*ProductionL8JobCredentialHTTPProxyActivator) MarshalJSON() ([]byte, error) {
+func (ProductionL8JobCredentialHTTPProxyActivator) MarshalJSON() ([]byte, error) {
 	return nil, ErrL8JobCredentialRuntimeSerialization
 }
-func (*ProductionL8JobCredentialHTTPProxyActivator) MarshalText() ([]byte, error) {
+func (ProductionL8JobCredentialHTTPProxyActivator) MarshalText() ([]byte, error) {
 	return nil, ErrL8JobCredentialRuntimeSerialization
 }
-func (*ProductionL8JobCredentialHTTPProxyActivator) MarshalBinary() ([]byte, error) {
+func (ProductionL8JobCredentialHTTPProxyActivator) MarshalBinary() ([]byte, error) {
 	return nil, ErrL8JobCredentialRuntimeSerialization
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator_test.go
@@ -182,7 +182,14 @@ func TestL8JobCredentialHTTPActivatorRedactsSecretsAndDeniesSerialization(t *tes
 		t.Fatal(err)
 	}
 
-	values := []any{activator, handle, &ProductionL8JobCredentialHTTPProxyActivator{}, &productionL8JobCredentialHTTPProxyHandle{}}
+	values := []any{
+		activator,
+		*activator,
+		handle,
+		ProductionL8JobCredentialHTTPProxyActivator{},
+		&ProductionL8JobCredentialHTTPProxyActivator{},
+		&productionL8JobCredentialHTTPProxyHandle{},
+	}
 	for _, value := range values {
 		encoded, marshalErr := json.Marshal(value)
 		if marshalErr == nil || encoded != nil || !errors.Is(marshalErr, ErrL8JobCredentialRuntimeSerialization) {
@@ -225,12 +232,6 @@ func TestL8JobCredentialHTTPActivatorConstructorRejectsInvalidConfig(t *testing.
 	if activator, err := NewProductionL8JobCredentialHTTPProxyActivator(missingStore); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
 		t.Fatalf("missing store = %#v, %v", activator, err)
 	}
-	missingStore.DaemonGeneration = "daemon-generation-01"
-	owned, err := NewProductionL8JobCredentialHTTPProxyActivator(missingStore)
-	if err != nil || owned == nil || owned.store == nil {
-		t.Fatalf("owned store constructor = %#v, %v", owned, err)
-	}
-	t.Cleanup(func() { _ = owned.store.Close(context.Background()) })
 
 	rawAuthority := valid
 	rawAuthority.LocalAuthority = "https://unsafe.invalid/secret"

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_http_activator_test.go
@@ -1,0 +1,395 @@
+package firecrackerhost
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/credentialproxy"
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8JobCredentialHTTPActivatorIssuesTicketAndExposesSafeServiceID(t *testing.T) {
+	store, activator := l8JobCredentialHTTPActivatorForTest(t)
+	identity, binding, source := l8JobCredentialHTTPActivatorFixture(t)
+
+	handle, err := activator.Activate(context.Background(), identity, binding, source)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+		t.Fatalf("Activate = %#v, %v", handle, err)
+	}
+	if got := handle.ServiceID(); got != binding.ServiceID || got != string(credentialproxy.ServiceIDAzureOpenAIResponsesV1) {
+		t.Fatalf("ServiceID = %q, want binding service id", got)
+	}
+	owned, ok := handle.(*productionL8JobCredentialHTTPProxyHandle)
+	if !ok || owned.ticket == nil {
+		t.Fatal("Activate did not retain a TicketStore ticket")
+	}
+	if owned.correlation.BindingID != binding.ID || owned.correlation.ServiceID != credentialproxy.ServiceIDAzureOpenAIResponsesV1 {
+		t.Fatalf("ticket correlation = %#v", owned.correlation)
+	}
+	if err := store.Validate(context.Background(), owned.ticket, owned.correlation); err != nil {
+		t.Fatalf("TicketStore.Validate after Activate: %v", err)
+	}
+	if source.(*l8JobCredentialHTTPActivatorSecretSource).fills != 0 {
+		t.Fatal("Activate consumed LiveSecretSource")
+	}
+}
+
+func TestL8JobCredentialHTTPActivatorRejectsNonHTTPAndInvalidIdentity(t *testing.T) {
+	_, activator := l8JobCredentialHTTPActivatorForTest(t)
+	identity, binding, source := l8JobCredentialHTTPActivatorFixture(t)
+
+	tmpfs := binding
+	tmpfs.Mode = sandboxruntime.JobCredentialDeliveryModeFileTmpfs
+	if handle, err := activator.Activate(context.Background(), identity, tmpfs, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("tmpfs mode = %#v, %v", handle, err)
+	}
+
+	empty := binding
+	empty.Mode = ""
+	if handle, err := activator.Activate(context.Background(), identity, empty, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("empty mode = %#v, %v", handle, err)
+	}
+
+	unknownService := binding
+	unknownService.ServiceID = "other-service-v1"
+	if handle, err := activator.Activate(context.Background(), identity, unknownService, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("unknown service = %#v, %v", handle, err)
+	}
+
+	rawService := binding
+	rawService.ServiceID = "https://unsafe.invalid/raw-secret"
+	handle, err := activator.Activate(context.Background(), identity, rawService, source)
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("raw service = %#v, %v", handle, err)
+	}
+	l8JobCredentialHTTPActivatorAssertSafeError(t, err)
+
+	neighbor := binding
+	neighbor.ID = "binding-neighbor"
+	if handle, err := activator.Activate(context.Background(), identity, neighbor, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("neighbor binding = %#v, %v", handle, err)
+	}
+
+	partial := identity
+	partial.RuntimeGeneration = ""
+	if handle, err := activator.Activate(context.Background(), partial, binding, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("partial identity = %#v, %v", handle, err)
+	}
+
+	var typedNilSource *l8JobCredentialHTTPActivatorSecretSource
+	if handle, err := activator.Activate(context.Background(), identity, binding, typedNilSource); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("typed-nil source = %#v, %v", handle, err)
+	}
+}
+
+func TestL8JobCredentialHTTPActivatorRenewAndRevokeUseTicketStore(t *testing.T) {
+	store, activator := l8JobCredentialHTTPActivatorForTest(t)
+	identity, binding, source := l8JobCredentialHTTPActivatorFixture(t)
+	handle, err := activator.Activate(context.Background(), identity, binding, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owned := handle.(*productionL8JobCredentialHTTPProxyHandle)
+	if err := handle.Renew(context.Background()); err != nil {
+		t.Fatalf("Renew = %v", err)
+	}
+	if err := store.Validate(context.Background(), owned.ticket, owned.correlation); err != nil {
+		t.Fatalf("Validate after Renew: %v", err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("Revoke = %v", err)
+	}
+	if owned.ticket != nil || !owned.revoked {
+		t.Fatal("successful Revoke retained ticket ownership")
+	}
+	if err := handle.Renew(context.Background()); !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("Renew after Revoke = %v", err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("idempotent Revoke = %v", err)
+	}
+}
+
+func TestL8JobCredentialHTTPActivatorFailedRevokeRetainsOwnership(t *testing.T) {
+	store, activator := l8JobCredentialHTTPActivatorForTest(t)
+	identity, binding, source := l8JobCredentialHTTPActivatorFixture(t)
+	handle, err := activator.Activate(context.Background(), identity, binding, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	owned := handle.(*productionL8JobCredentialHTTPProxyHandle)
+	ticket := owned.ticket
+	if err := store.Close(context.Background()); err != nil {
+		t.Fatalf("Close = %v", err)
+	}
+	if err := handle.Revoke(context.Background()); !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("Revoke after store close = %v, want invalid", err)
+	}
+	if owned.revoked || owned.ticket != ticket {
+		t.Fatal("failed Revoke dropped ticket ownership")
+	}
+}
+
+func TestL8JobCredentialHTTPActivatorNilTypedNilAndPanicFailClosed(t *testing.T) {
+	identity, binding, source := l8JobCredentialHTTPActivatorFixture(t)
+	var typedNilActivator *ProductionL8JobCredentialHTTPProxyActivator
+	if handle, err := typedNilActivator.Activate(context.Background(), identity, binding, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("typed-nil activator = %#v, %v", handle, err)
+	}
+
+	_, activator := l8JobCredentialHTTPActivatorForTest(t)
+	if handle, err := activator.Activate(nil, identity, binding, source); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("nil context = %#v, %v", handle, err)
+	}
+
+	activator.now = func() time.Time {
+		panic("sk_live=/private/http-activator.sock")
+	}
+	handle, err := activator.Activate(context.Background(), identity, binding, source)
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeUnavailable) {
+		t.Fatalf("panic now = %#v, %v", handle, err)
+	}
+	l8JobCredentialHTTPActivatorAssertSafeError(t, err)
+
+	var typedNilHandle *productionL8JobCredentialHTTPProxyHandle
+	if typedNilHandle.ServiceID() != "" {
+		t.Fatal("typed-nil handle ServiceID leaked a value")
+	}
+	if err := typedNilHandle.Renew(context.Background()); !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("typed-nil Renew = %v", err)
+	}
+	if err := typedNilHandle.Revoke(context.Background()); !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("typed-nil Revoke = %v", err)
+	}
+}
+
+func TestL8JobCredentialHTTPActivatorRedactsSecretsAndDeniesSerialization(t *testing.T) {
+	store, activator := l8JobCredentialHTTPActivatorForTest(t)
+	identity, binding, source := l8JobCredentialHTTPActivatorFixture(t)
+	source.(*l8JobCredentialHTTPActivatorSecretSource).payload = []byte("sk_live=/private/http-activator.sock")
+	handle, err := activator.Activate(context.Background(), identity, binding, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	values := []any{activator, handle, &ProductionL8JobCredentialHTTPProxyActivator{}, &productionL8JobCredentialHTTPProxyHandle{}}
+	for _, value := range values {
+		encoded, marshalErr := json.Marshal(value)
+		if marshalErr == nil || encoded != nil || !errors.Is(marshalErr, ErrL8JobCredentialRuntimeSerialization) {
+			t.Fatalf("json.Marshal(%T) = %q, %v", value, encoded, marshalErr)
+		}
+		for _, rendered := range []string{fmt.Sprint(value), fmt.Sprintf("%#v", value), fmt.Sprintf("%+v", value)} {
+			if rendered != l8JobCredentialHTTPActivatorValuePlaceholder {
+				t.Fatalf("format %T = %q", value, rendered)
+			}
+			l8JobCredentialHTTPActivatorAssertSafeText(t, rendered)
+		}
+	}
+
+	if err := store.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	revokeErr := handle.Revoke(context.Background())
+	if !errors.Is(revokeErr, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("closed-store Revoke = %v", revokeErr)
+	}
+	l8JobCredentialHTTPActivatorAssertSafeError(t, revokeErr)
+}
+
+func TestL8JobCredentialHTTPActivatorConstructorRejectsInvalidConfig(t *testing.T) {
+	store, err := credentialproxy.NewTicketStore("daemon-generation-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close(context.Background()) })
+	valid := ProductionL8JobCredentialHTTPProxyActivatorConfig{
+		Store: store, CatalogGeneration: "catalog-generation-01", ListenerGeneration: 7,
+		LocalAuthority: "runtime-credential.internal:8080",
+	}
+	if _, err := NewProductionL8JobCredentialHTTPProxyActivator(valid); err != nil {
+		t.Fatalf("valid config: %v", err)
+	}
+
+	missingStore := valid
+	missingStore.Store = nil
+	if activator, err := NewProductionL8JobCredentialHTTPProxyActivator(missingStore); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("missing store = %#v, %v", activator, err)
+	}
+	missingStore.DaemonGeneration = "daemon-generation-01"
+	owned, err := NewProductionL8JobCredentialHTTPProxyActivator(missingStore)
+	if err != nil || owned == nil || owned.store == nil {
+		t.Fatalf("owned store constructor = %#v, %v", owned, err)
+	}
+	t.Cleanup(func() { _ = owned.store.Close(context.Background()) })
+
+	rawAuthority := valid
+	rawAuthority.LocalAuthority = "https://unsafe.invalid/secret"
+	if activator, err := NewProductionL8JobCredentialHTTPProxyActivator(rawAuthority); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("raw authority = %#v, %v", activator, err)
+	}
+}
+
+func TestL8JobCredentialRuntimeUsesProductionHTTPActivator(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	clock := &l8JobCredentialRuntimeClock{now: now.Add(time.Second)}
+	_, activator := l8JobCredentialHTTPActivatorForTest(t)
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeHTTPProxy})
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, activator, nil, nil)
+	runtime.deps.Now = clock.Now
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := preflight.Identity()
+	request := l8JobCredentialRuntimePrepareRequest(t, identity)
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(session) {
+		t.Fatalf("prepare with production HTTP activator = %#v, %v", session, err)
+	}
+	if len(guest.lastManifests) != 1 || guest.lastManifests[0].ServiceID != string(credentialproxy.ServiceIDAzureOpenAIResponsesV1) {
+		t.Fatalf("guest HTTP manifest = %#v", guest.lastManifests)
+	}
+	clock.now = now.Add(2 * time.Second)
+	if _, err := session.Renew(context.Background()); err != nil {
+		t.Fatalf("runtime Renew: %v", err)
+	}
+	if _, err := session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested")); err != nil {
+		t.Fatalf("runtime Revoke: %v", err)
+	}
+}
+
+func TestProductionL8JobCredentialHTTPProxyActivatorRemainsDefaultOff(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	set := token.NewFileSet()
+	callers := 0
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(set, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch function := call.Fun.(type) {
+			case *ast.Ident:
+				name = function.Name
+			case *ast.SelectorExpr:
+				name = function.Sel.Name
+			}
+			if name == "NewProductionL8JobCredentialHTTPProxyActivator" {
+				callers++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callers != 0 {
+		t.Fatalf("production NewProductionL8JobCredentialHTTPProxyActivator callers = %d, want zero", callers)
+	}
+
+	for _, name := range []string{"adapter.go", "live_driver.go", "l7_live_composition.go", "l8_job_credential_runtime.go"} {
+		source, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(source), "NewProductionL8JobCredentialHTTPProxyActivator") {
+			t.Fatalf("%s wires production HTTP activator constructor", name)
+		}
+	}
+}
+
+func l8JobCredentialHTTPActivatorForTest(t *testing.T) (*credentialproxy.TicketStore, *ProductionL8JobCredentialHTTPProxyActivator) {
+	t.Helper()
+	store, err := credentialproxy.NewTicketStore("daemon-generation-01")
+	if err != nil {
+		t.Fatalf("NewTicketStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close(context.Background()) })
+	activator, err := NewProductionL8JobCredentialHTTPProxyActivator(ProductionL8JobCredentialHTTPProxyActivatorConfig{
+		Store: store, CatalogGeneration: "catalog-generation-01", ListenerGeneration: 7,
+		LocalAuthority: "runtime-credential.internal:8080",
+	})
+	if err != nil {
+		t.Fatalf("NewProductionL8JobCredentialHTTPProxyActivator: %v", err)
+	}
+	return store, activator
+}
+
+func l8JobCredentialHTTPActivatorFixture(t *testing.T) (sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest, sandboxruntime.LiveSecretSource) {
+	t.Helper()
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeHTTPProxy})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8JobCredentialRuntimePrepareRequest(t, identity)
+	source := &l8JobCredentialHTTPActivatorSecretSource{payload: []byte("sk_live=/private/http-activator.sock")}
+	return identity, request.Admission.Bindings[0], source
+}
+
+func l8JobCredentialHTTPActivatorAssertSafeError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	l8JobCredentialHTTPActivatorAssertSafeText(t, err.Error())
+}
+
+func l8JobCredentialHTTPActivatorAssertSafeText(t *testing.T, text string) {
+	t.Helper()
+	for _, forbidden := range []string{
+		"sk_live", "OPENAI_API_KEY", "/private/", "http-activator.sock",
+		"unsafe.invalid", "runtime-credential.internal", "raw-secret",
+		"secret-bytes", "helper-generation-runtime",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("leaked %q: %q", forbidden, text)
+		}
+	}
+}
+
+type l8JobCredentialHTTPActivatorSecretSource struct {
+	payload []byte
+	fills   int
+}
+
+func (source *l8JobCredentialHTTPActivatorSecretSource) FillSecret(_ context.Context, sink sandboxruntime.JobCredentialSecretSink) error {
+	source.fills++
+	if source.payload == nil {
+		panic("sk_live=/private/http-activator.sock")
+	}
+	if len(source.payload) > sink.MaxCredentialBytes() {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	return sink.WriteCredential(source.payload)
+}


### PR DESCRIPTION
## Summary
Default-off `NewProductionL8JobCredentialHTTPProxyActivator` wrapping `credentialproxy.TicketStore`. Implements the existing host JobCredentialRuntime HTTP activator/handle interfaces. Not invoked by sandboxd, run, auto, factory, worker Service, or `NewProductionL8JobCredentialRuntime` unless injected.

Stacked on #46.

## Default-off / non-goals
- No live HTTP listen/dial, no L6 route changes, no D7/L10/L11.
- tmpfs/SSH activators are later stack PRs.

## Tests
- `go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'L8JobCredential.*HTTP|HTTPActivator|HttpActivator' -count=1`
- `go test ./internal/credentialproxy -count=1`
- `go test ./cmd -run 'HTTPActivator|HttpActivator' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.