### PR TITLE
feat: US-049 - L8 production file-tmpfs credential activator

### DIFF
--- a/cmd/l8_d6_tmpfs_activator_docs_test.go
+++ b/cmd/l8_d6_tmpfs_activator_docs_test.go
@@ -24,6 +24,8 @@ func TestL8D6TmpfsActivatorVerificationContract(t *testing.T) {
 		"JobCredentialDeliveryModeFileTmpfs",
 		"never a host absolute scratch path",
 		"does not retain the live source",
+		"A source panic",
+		"wipes its sink copy",
 		"failed revoke",
 		"keeps ownership",
 		"ErrL8JobCredentialRuntimeUnsupported",

--- a/cmd/l8_d6_tmpfs_activator_docs_test.go
+++ b/cmd/l8_d6_tmpfs_activator_docs_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestL8D6TmpfsActivatorVerificationContract(t *testing.T) {
+	document, err := os.ReadFile("../docs/design/sandbox-runtime-v2-l8-d6-tmpfs-activator-verification.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(document)
+	for _, required := range []string{
+		"l8JobCredentialFileTmpfsActivator",
+		"l8JobCredentialFileHandle",
+		"NewProductionL8JobCredentialFileTmpfsActivator",
+		"LiveSecretSource",
+		"JobCredentialDeliveryModeFileTmpfs",
+		"never a host absolute scratch path",
+		"does not retain the live source",
+		"failed revoke",
+		"keeps ownership",
+		"ErrL8JobCredentialRuntimeUnsupported",
+		"does not implement or claim guest mount-monitor/PID1 wiring",
+		"D7 live tmpfs",
+		"never invoked by sandboxd",
+		"NewProductionL8JobCredentialRuntime",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'Tmpfs|FileTmpfs|FileHandle' -count=1",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^$' -count=1",
+		"go test ./cmd -run 'TmpfsActivator|FileTmpfs' -count=1",
+		"go vet ./internal/sandboxruntime/microvm/firecrackerhost",
+		"No test requires KVM, Firecracker, a live guest, network, or cloud APIs.",
+		"command -v golangci-lint",
+		"GOOS=windows GOARCH=amd64 go test -c",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("verification document omits %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"guest mount-monitor is implemented",
+		"D7 live tmpfs acceptance is complete",
+		"default sandboxd constructs the activator",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("verification document contains forbidden claim %q", forbidden)
+		}
+	}
+}
+
+func TestL8D6FileTmpfsActivatorRemainsDefaultOff(t *testing.T) {
+	root := filepath.Clean("..")
+	set := token.NewFileSet()
+	callers := 0
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(set, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch function := call.Fun.(type) {
+			case *ast.Ident:
+				name = function.Name
+			case *ast.SelectorExpr:
+				name = function.Sel.Name
+			}
+			if name == "NewProductionL8JobCredentialFileTmpfsActivator" {
+				callers++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callers != 0 {
+		t.Fatalf("production NewProductionL8JobCredentialFileTmpfsActivator callers = %d, want zero", callers)
+	}
+
+	for _, path := range []string{
+		"run.go", "run_sandbox.go", "auto.go", "auto_sandbox.go",
+		"factory.go", "factory_sandbox_executor.go", "sandbox.go", "sandboxd.go",
+		"../internal/sandboxworker/service.go", "../internal/sandboxworker/job_service_v2.go",
+		"../internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go",
+	} {
+		payload, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatal(err)
+		}
+		if strings.Contains(string(payload), "NewProductionL8JobCredentialFileTmpfsActivator") {
+			t.Fatalf("default production path wires file-tmpfs activator: %s", filepath.ToSlash(path))
+		}
+	}
+}

--- a/docs/design/sandbox-runtime-v2-l8-d6-tmpfs-activator-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-tmpfs-activator-verification.md
@@ -1,0 +1,69 @@
+# L8 D6 Production File-Tmpfs Credential Activator Verification
+
+This slice implements the default-off Firecracker host
+`l8JobCredentialFileTmpfsActivator` / `l8JobCredentialFileHandle` production
+path. It is the host materializer that `L8JobCredentialRuntime` already calls
+during prepare: fill from `LiveSecretSource`, then copy guest `TargetPath`,
+`DeclaredFileBytes`, and SHA-256 into the guest prepare manifest.
+
+It does not implement or claim guest mount-monitor/PID1 wiring, D7 live tmpfs
+acceptance, HTTP/SSH activators, worker v2 protocol operations, or command
+defaults.
+
+## Real operations
+
+- `NewProductionL8JobCredentialFileTmpfsActivator` requires an explicit
+  absolute scratch root. It never defaults to the project `.hal/` directory,
+  and it is never invoked by sandboxd, `hal run`, `hal auto`, factory, worker
+  defaults, or `NewProductionL8JobCredentialRuntime` unless a later caller
+  injects the returned activator.
+- `Materialize` requires `JobCredentialDeliveryModeFileTmpfs`, a complete
+  identity that names that file binding, and a non-nil `LiveSecretSource`. It
+  fills once, does not retain the live source, exposes the guest `TargetPath`
+  from the binding identity token (never a host absolute scratch path), and
+  records `DeclaredFileBytes` plus SHA-256 of the exact filled bytes.
+- Oversize, empty-when-required, identity mismatch, nil source, nil context,
+  and cancellation fail closed before a durable host file is left behind.
+- `Revoke` overwrites then unlinks the host materialization. A failed revoke
+  keeps ownership so a later retry can still wipe and unlink.
+- Non-Linux constructors and `Materialize` fail closed with
+  `ErrL8JobCredentialRuntimeUnsupported` before creating files.
+- Errors, `String`/`GoString`/`Format`, and JSON/text/binary encodings never
+  include secret bytes, host scratch paths, or `.hal` locations.
+
+## Still unsupported / documented gaps
+
+- Guest tmpfs mount-namespace, mount-monitor, and PID1 composition remain D4/D6
+  guest work, not this host activator.
+- D7 prepared-Linux live tmpfs acceptance is not claimed.
+- HTTP proxy and SSH-relay production activators are separate slices.
+- Default sandboxd/run/auto/factory/worker paths stay inert.
+
+## Fake-only commands
+
+```
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'Tmpfs|FileTmpfs|FileHandle' -count=1
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^$' -count=1
+go test ./cmd -run 'TmpfsActivator|FileTmpfs' -count=1
+go vet ./internal/sandboxruntime/microvm/firecrackerhost
+```
+
+No test requires KVM, Firecracker, a live guest, network, or cloud APIs.
+Tests use in-memory/fake `LiveSecretSource` values plus temporary directories.
+
+## Broad verification
+
+```
+go test ./...
+go vet ./...
+make docs-check
+make build
+git diff --check
+```
+
+`golangci-lint` is reported only when `command -v golangci-lint` succeeds.
+
+```
+GOOS=linux GOARCH=amd64 go test -c -o /tmp/hal-firecrackerhost-linux.test ./internal/sandboxruntime/microvm/firecrackerhost
+GOOS=windows GOARCH=amd64 go test -c -o /tmp/hal-firecrackerhost-windows.test.exe ./internal/sandboxruntime/microvm/firecrackerhost
+```

--- a/docs/design/sandbox-runtime-v2-l8-d6-tmpfs-activator-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-tmpfs-activator-verification.md
@@ -24,6 +24,9 @@ defaults.
   records `DeclaredFileBytes` plus SHA-256 of the exact filled bytes.
 - Oversize, empty-when-required, identity mismatch, nil source, nil context,
   and cancellation fail closed before a durable host file is left behind.
+- A source panic, including one after filling the bounded sink, is contained;
+  the activator wipes its sink copy and returns only the stable unavailable
+  error.
 - `Revoke` overwrites then unlinks the host materialization. A failed revoke
   keeps ownership so a later retry can still wipe and unlink.
 - Non-Linux constructors and `Materialize` fail closed with

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator.go
@@ -66,6 +66,16 @@ func NewProductionL8JobCredentialFileTmpfsActivator(options L8JobCredentialFileT
 }
 
 func (activator *L8JobCredentialFileTmpfsActivator) Materialize(ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest, source sandboxruntime.LiveSecretSource) (handle l8JobCredentialFileHandle, err error) {
+	var sink *l8JobCredentialFileTmpfsSink
+	defer func() {
+		if recover() != nil {
+			if sink != nil {
+				sink.wipe()
+			}
+			handle = nil
+			err = ErrL8JobCredentialRuntimeUnavailable
+		}
+	}()
 	if activator == nil || activator.rootDir == "" {
 		return nil, ErrL8JobCredentialRuntimeInvalid
 	}
@@ -92,7 +102,7 @@ func (activator *L8JobCredentialFileTmpfsActivator) Materialize(ctx context.Cont
 		return nil, ErrL8JobCredentialRuntimeInvalid
 	}
 
-	sink := &l8JobCredentialFileTmpfsSink{max: l8JobCredentialFileTmpfsMaxBytes}
+	sink = &l8JobCredentialFileTmpfsSink{max: l8JobCredentialFileTmpfsMaxBytes}
 	fillErr := source.FillSecret(ctx, sink)
 	source = nil
 	if fillErr != nil {
@@ -275,22 +285,22 @@ func (sink *l8JobCredentialFileTmpfsSink) wipe() {
 	sink.payload = nil
 }
 
-func (*L8JobCredentialFileTmpfsActivator) String() string {
+func (L8JobCredentialFileTmpfsActivator) String() string {
 	return l8JobCredentialFileTmpfsValuePlaceholder
 }
-func (*L8JobCredentialFileTmpfsActivator) GoString() string {
+func (L8JobCredentialFileTmpfsActivator) GoString() string {
 	return l8JobCredentialFileTmpfsValuePlaceholder
 }
-func (*L8JobCredentialFileTmpfsActivator) Format(state fmt.State, _ rune) {
+func (L8JobCredentialFileTmpfsActivator) Format(state fmt.State, _ rune) {
 	_, _ = io.WriteString(state, l8JobCredentialFileTmpfsValuePlaceholder)
 }
-func (*L8JobCredentialFileTmpfsActivator) MarshalJSON() ([]byte, error) {
+func (L8JobCredentialFileTmpfsActivator) MarshalJSON() ([]byte, error) {
 	return nil, ErrL8JobCredentialRuntimeSerialization
 }
-func (*L8JobCredentialFileTmpfsActivator) MarshalText() ([]byte, error) {
+func (L8JobCredentialFileTmpfsActivator) MarshalText() ([]byte, error) {
 	return nil, ErrL8JobCredentialRuntimeSerialization
 }
-func (*L8JobCredentialFileTmpfsActivator) MarshalBinary() ([]byte, error) {
+func (L8JobCredentialFileTmpfsActivator) MarshalBinary() ([]byte, error) {
 	return nil, ErrL8JobCredentialRuntimeSerialization
 }
 
@@ -318,5 +328,6 @@ var (
 	_ l8JobCredentialFileHandle              = (*l8JobCredentialFileHandleProduction)(nil)
 	_ sandboxruntime.JobCredentialSecretSink = (*l8JobCredentialFileTmpfsSink)(nil)
 	_ fmt.Stringer                           = (*L8JobCredentialFileTmpfsActivator)(nil)
+	_ fmt.Stringer                           = L8JobCredentialFileTmpfsActivator{}
 	_ fmt.Stringer                           = (*l8JobCredentialFileHandleProduction)(nil)
 )

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator.go
@@ -1,0 +1,322 @@
+package firecrackerhost
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+const (
+	l8JobCredentialFileTmpfsValuePlaceholder = "[firecracker-l8-job-credential-file-tmpfs]"
+	// Per-file fill bound matches the guest helper private-file ceiling without
+	// importing the helper protocol into this host activator.
+	l8JobCredentialFileTmpfsMaxBytes = 64 * 1024
+	l8JobCredentialFileTmpfsDirMode  = 0o700
+	l8JobCredentialFileTmpfsFileMode = 0o600
+)
+
+// L8JobCredentialFileTmpfsActivatorOptions selects the host scratch root for
+// one explicit production file-tmpfs activator. Callers must inject a
+// non-project directory; the constructor never defaults to `.hal/`.
+type L8JobCredentialFileTmpfsActivatorOptions struct {
+	RootDir string
+}
+
+// L8JobCredentialFileTmpfsActivator is the default-off host file-tmpfs
+// materializer. It is never constructed by sandboxd, run/auto/factory, worker
+// defaults, or NewProductionL8JobCredentialRuntime unless a caller injects it.
+type L8JobCredentialFileTmpfsActivator struct {
+	rootDir string
+}
+
+type l8JobCredentialFileHandleProduction struct {
+	mu         sync.Mutex
+	targetPath string
+	size       uint32
+	digest     string
+	dir        string
+	filePath   string
+	file       *os.File
+	owned      bool
+}
+
+type l8JobCredentialFileTmpfsSink struct {
+	max     int
+	payload []byte
+}
+
+func NewProductionL8JobCredentialFileTmpfsActivator(options L8JobCredentialFileTmpfsActivatorOptions) (*L8JobCredentialFileTmpfsActivator, error) {
+	if !l8JobCredentialRuntimePlatformSupported() {
+		return nil, ErrL8JobCredentialRuntimeUnsupported
+	}
+	rootDir, err := validateL8JobCredentialFileTmpfsRoot(options.RootDir)
+	if err != nil {
+		return nil, err
+	}
+	return &L8JobCredentialFileTmpfsActivator{rootDir: rootDir}, nil
+}
+
+func (activator *L8JobCredentialFileTmpfsActivator) Materialize(ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest, source sandboxruntime.LiveSecretSource) (handle l8JobCredentialFileHandle, err error) {
+	if activator == nil || activator.rootDir == "" {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if !l8JobCredentialRuntimePlatformSupported() {
+		return nil, ErrL8JobCredentialRuntimeUnsupported
+	}
+	if l8JobCredentialRuntimeValueIsNil(ctx) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if binding.Mode != sandboxruntime.JobCredentialDeliveryModeFileTmpfs {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	if err := matchL8JobCredentialFileTmpfsIdentity(identity, binding); err != nil {
+		return nil, err
+	}
+	targetPath, err := l8JobCredentialFileTmpfsGuestTargetPath(binding)
+	if err != nil {
+		return nil, err
+	}
+	if l8JobCredentialRuntimeValueIsNil(source) {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+
+	sink := &l8JobCredentialFileTmpfsSink{max: l8JobCredentialFileTmpfsMaxBytes}
+	fillErr := source.FillSecret(ctx, sink)
+	source = nil
+	if fillErr != nil {
+		sink.wipe()
+		return nil, sanitizeL8JobCredentialFileTmpfsError(fillErr)
+	}
+	if err := ctx.Err(); err != nil {
+		sink.wipe()
+		return nil, err
+	}
+	payload := sink.payload
+	sink.payload = nil
+	defer clear(payload)
+	if len(payload) == 0 || len(payload) > l8JobCredentialFileTmpfsMaxBytes {
+		return nil, ErrL8JobCredentialRuntimeInvalid
+	}
+
+	sum := sha256.Sum256(payload)
+	digest := hex.EncodeToString(sum[:])
+	dir, filePath, file, err := materializeL8JobCredentialFileTmpfsPayload(activator.rootDir, payload)
+	if err != nil {
+		return nil, sanitizeL8JobCredentialFileTmpfsError(err)
+	}
+	return &l8JobCredentialFileHandleProduction{
+		targetPath: targetPath,
+		size:       uint32(len(payload)),
+		digest:     digest,
+		dir:        dir,
+		filePath:   filePath,
+		file:       file,
+		owned:      true,
+	}, nil
+}
+
+func (handle *l8JobCredentialFileHandleProduction) TargetPath() string {
+	if handle == nil {
+		return ""
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	return handle.targetPath
+}
+
+func (handle *l8JobCredentialFileHandleProduction) DeclaredFileBytes() uint32 {
+	if handle == nil {
+		return 0
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	return handle.size
+}
+
+func (handle *l8JobCredentialFileHandleProduction) FileSHA256() string {
+	if handle == nil {
+		return ""
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	return handle.digest
+}
+
+func (handle *l8JobCredentialFileHandleProduction) Revoke(context.Context) error {
+	if handle == nil {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if !handle.owned {
+		return nil
+	}
+	file, err := wipeL8JobCredentialFileTmpfsMaterialization(handle.file, handle.filePath, handle.dir, handle.size)
+	handle.file = file
+	if err != nil {
+		// Keep owned so a later retry can still wipe and unlink.
+		return sanitizeL8JobCredentialFileTmpfsError(err)
+	}
+	handle.owned = false
+	handle.file = nil
+	handle.filePath = ""
+	handle.dir = ""
+	return nil
+}
+
+func matchL8JobCredentialFileTmpfsIdentity(identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest) error {
+	if sandboxruntime.ValidateJobCredentialIdentity(identity) != nil {
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	for index, bindingID := range identity.BindingIDs {
+		if bindingID != binding.ID {
+			continue
+		}
+		if identity.DeliveryModes[index] != sandboxruntime.JobCredentialDeliveryModeFileTmpfs {
+			return sandboxruntime.ErrJobCredentialIdentityMismatch
+		}
+		return nil
+	}
+	return sandboxruntime.ErrJobCredentialIdentityMismatch
+}
+
+func l8JobCredentialFileTmpfsGuestTargetPath(binding sandboxruntime.JobCredentialBindingRequest) (string, error) {
+	// The guest path is the binding's already-safe identity token. Host absolute
+	// scratch paths must never become TargetPath.
+	if !validL8JobCredentialRuntimeToken(binding.ID) {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	if strings.Contains(binding.ID, "/") || strings.Contains(binding.ID, "\\") || strings.HasPrefix(binding.ID, ".") {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	return binding.ID, nil
+}
+
+func validateL8JobCredentialFileTmpfsRoot(root string) (string, error) {
+	if root == "" || !filepath.IsAbs(root) {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	cleaned := filepath.Clean(root)
+	if !filepath.IsAbs(cleaned) || l8JobCredentialFileTmpfsPathHasHalDir(cleaned) {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() || l8JobCredentialFileTmpfsPathHasHalDir(resolved) {
+		return "", ErrL8JobCredentialRuntimeInvalid
+	}
+	return resolved, nil
+}
+
+func l8JobCredentialFileTmpfsPathHasHalDir(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".hal" {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizeL8JobCredentialFileTmpfsError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return err
+	case errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch):
+		return sandboxruntime.ErrJobCredentialIdentityMismatch
+	case errors.Is(err, ErrL8JobCredentialRuntimeUnsupported):
+		return ErrL8JobCredentialRuntimeUnsupported
+	case errors.Is(err, ErrL8JobCredentialRuntimeInvalid):
+		return ErrL8JobCredentialRuntimeInvalid
+	default:
+		return ErrL8JobCredentialRuntimeUnavailable
+	}
+}
+
+func (sink *l8JobCredentialFileTmpfsSink) MaxCredentialBytes() int {
+	if sink == nil || sink.max <= 0 {
+		return 0
+	}
+	return sink.max
+}
+
+func (sink *l8JobCredentialFileTmpfsSink) WriteCredential(value []byte) error {
+	if sink == nil || sink.max <= 0 || sink.payload != nil {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	if len(value) == 0 || len(value) > sink.max {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	sink.payload = append([]byte(nil), value...)
+	return nil
+}
+
+func (sink *l8JobCredentialFileTmpfsSink) wipe() {
+	if sink == nil {
+		return
+	}
+	clear(sink.payload)
+	sink.payload = nil
+}
+
+func (*L8JobCredentialFileTmpfsActivator) String() string {
+	return l8JobCredentialFileTmpfsValuePlaceholder
+}
+func (*L8JobCredentialFileTmpfsActivator) GoString() string {
+	return l8JobCredentialFileTmpfsValuePlaceholder
+}
+func (*L8JobCredentialFileTmpfsActivator) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialFileTmpfsValuePlaceholder)
+}
+func (*L8JobCredentialFileTmpfsActivator) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*L8JobCredentialFileTmpfsActivator) MarshalText() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*L8JobCredentialFileTmpfsActivator) MarshalBinary() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+
+func (*l8JobCredentialFileHandleProduction) String() string {
+	return l8JobCredentialFileTmpfsValuePlaceholder
+}
+func (*l8JobCredentialFileHandleProduction) GoString() string {
+	return l8JobCredentialFileTmpfsValuePlaceholder
+}
+func (*l8JobCredentialFileHandleProduction) Format(state fmt.State, _ rune) {
+	_, _ = io.WriteString(state, l8JobCredentialFileTmpfsValuePlaceholder)
+}
+func (*l8JobCredentialFileHandleProduction) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*l8JobCredentialFileHandleProduction) MarshalText() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+func (*l8JobCredentialFileHandleProduction) MarshalBinary() ([]byte, error) {
+	return nil, ErrL8JobCredentialRuntimeSerialization
+}
+
+var (
+	_ l8JobCredentialFileTmpfsActivator      = (*L8JobCredentialFileTmpfsActivator)(nil)
+	_ l8JobCredentialFileHandle              = (*l8JobCredentialFileHandleProduction)(nil)
+	_ sandboxruntime.JobCredentialSecretSink = (*l8JobCredentialFileTmpfsSink)(nil)
+	_ fmt.Stringer                           = (*L8JobCredentialFileTmpfsActivator)(nil)
+	_ fmt.Stringer                           = (*l8JobCredentialFileHandleProduction)(nil)
+)

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_linux.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_linux.go
@@ -1,0 +1,87 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func materializeL8JobCredentialFileTmpfsPayload(rootDir string, payload []byte) (dir, filePath string, file *os.File, err error) {
+	if rootDir == "" || len(payload) == 0 {
+		return "", "", nil, ErrL8JobCredentialRuntimeInvalid
+	}
+	dir, err = os.MkdirTemp(rootDir, "l8-file-")
+	if err != nil {
+		return "", "", nil, ErrL8JobCredentialRuntimeUnavailable
+	}
+	if err := os.Chmod(dir, l8JobCredentialFileTmpfsDirMode); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", "", nil, ErrL8JobCredentialRuntimeUnavailable
+	}
+	filePath = filepath.Join(dir, "payload")
+	file, err = os.OpenFile(filePath, os.O_CREATE|os.O_EXCL|os.O_RDWR, l8JobCredentialFileTmpfsFileMode)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return "", "", nil, ErrL8JobCredentialRuntimeUnavailable
+	}
+	wrote, writeErr := file.Write(payload)
+	if writeErr != nil || wrote != len(payload) {
+		abandonL8JobCredentialFileTmpfsPayload(file, filePath, dir, uint32(len(payload)))
+		return "", "", nil, ErrL8JobCredentialRuntimeUnavailable
+	}
+	if err := file.Sync(); err != nil {
+		abandonL8JobCredentialFileTmpfsPayload(file, filePath, dir, uint32(len(payload)))
+		return "", "", nil, ErrL8JobCredentialRuntimeUnavailable
+	}
+	return dir, filePath, file, nil
+}
+
+func abandonL8JobCredentialFileTmpfsPayload(file *os.File, filePath, dir string, size uint32) {
+	leftover, _ := wipeL8JobCredentialFileTmpfsMaterialization(file, filePath, dir, size)
+	if leftover != nil {
+		_ = leftover.Close()
+	}
+	if dir != "" {
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func wipeL8JobCredentialFileTmpfsMaterialization(file *os.File, filePath, dir string, size uint32) (*os.File, error) {
+	var firstErr error
+	if file != nil {
+		if _, err := file.Seek(0, io.SeekStart); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if size > 0 {
+			zeros := make([]byte, size)
+			if _, err := file.Write(zeros); err != nil && firstErr == nil {
+				firstErr = err
+			}
+			clear(zeros)
+		}
+		if err := file.Sync(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if firstErr != nil {
+			return file, firstErr
+		}
+	}
+	if filePath != "" {
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+			return file, err
+		}
+	}
+	if dir != "" {
+		if err := os.RemoveAll(dir); err != nil {
+			return file, err
+		}
+	}
+	if file != nil {
+		if err := file.Close(); err != nil {
+			return file, err
+		}
+	}
+	return nil, nil
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_linux_test.go
@@ -238,6 +238,18 @@ func TestL8JobCredentialFileTmpfsActivatorSanitizesSourceErrors(t *testing.T) {
 		t.Fatalf("source error = %#v, %v", handle, err)
 	}
 	l8JobCredentialFileTmpfsAssertSafeError(t, err, canary)
+
+	handle, err = activator.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsSource{
+		payload:         append([]byte(nil), canary...),
+		panicAfterWrite: true,
+	})
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeUnavailable) {
+		t.Fatalf("source panic = %#v, %v", handle, err)
+	}
+	l8JobCredentialFileTmpfsAssertSafeError(t, err, canary)
+	if files := l8JobCredentialFileTmpfsRegularFiles(t, activator.rootDir); len(files) != 0 {
+		t.Fatal("source panic created host files")
+	}
 }
 
 func TestL8JobCredentialFileTmpfsActivatorMaterializeMetadataReachesGuestPrepare(t *testing.T) {
@@ -333,12 +345,13 @@ func l8JobCredentialFileTmpfsAssertSafeError(t *testing.T, err error, canary []b
 }
 
 type l8JobCredentialFileTmpfsSource struct {
-	mu        sync.Mutex
-	payload   []byte
-	fills     int
-	skipWrite bool
-	ignoreMax bool
-	err       error
+	mu              sync.Mutex
+	payload         []byte
+	fills           int
+	skipWrite       bool
+	ignoreMax       bool
+	panicAfterWrite bool
+	err             error
 }
 
 func (source *l8JobCredentialFileTmpfsSource) FillSecret(ctx context.Context, sink sandboxruntime.JobCredentialSecretSink) error {
@@ -355,6 +368,12 @@ func (source *l8JobCredentialFileTmpfsSource) FillSecret(ctx context.Context, si
 	}
 	if source.skipWrite {
 		return nil
+	}
+	if source.panicAfterWrite {
+		if err := sink.WriteCredential(source.payload); err != nil {
+			return err
+		}
+		panic(string(source.payload))
 	}
 	if !source.ignoreMax && len(source.payload) > sink.MaxCredentialBytes() {
 		return ErrL8JobCredentialRuntimeInvalid

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_linux_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_linux_test.go
@@ -1,0 +1,363 @@
+//go:build linux
+
+package firecrackerhost
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
+)
+
+func TestL8JobCredentialFileTmpfsActivatorLinuxConstructorRequiresScratchRoot(t *testing.T) {
+	if l8JobCredentialFileTmpfsMaxBytes != credentialprotocol.MaxHelperFileBytes {
+		t.Fatalf("host file-tmpfs max = %d, want helper bound %d", l8JobCredentialFileTmpfsMaxBytes, credentialprotocol.MaxHelperFileBytes)
+	}
+	root := t.TempDir()
+	activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: root})
+	if err != nil || activator == nil || activator.rootDir == "" {
+		t.Fatalf("NewProductionL8JobCredentialFileTmpfsActivator = %#v, %v", activator, err)
+	}
+
+	missing := filepath.Join(root, "missing")
+	if activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: missing}); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("missing root = %#v, %v", activator, err)
+	}
+	if activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{}); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("empty root = %#v, %v", activator, err)
+	}
+	if activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: "relative-scratch"}); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("relative root = %#v, %v", activator, err)
+	}
+
+	halDir := filepath.Join(root, ".hal")
+	if err := os.Mkdir(halDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: halDir}); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf(".hal root = %#v, %v", activator, err)
+	}
+	link := filepath.Join(root, "scratch-link")
+	if err := os.Symlink(halDir, link); err != nil {
+		t.Fatal(err)
+	}
+	if activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: link}); activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("symlink into .hal = %#v, %v", activator, err)
+	}
+}
+
+func TestL8JobCredentialFileTmpfsActivatorMaterializeFillsHashAndGuestPath(t *testing.T) {
+	activator := l8JobCredentialFileTmpfsActivatorForTest(t)
+	identity, binding := l8JobCredentialFileTmpfsIdentity(t)
+	payload := []byte("tmpfs-canary-secret")
+	source := &l8JobCredentialFileTmpfsSource{payload: append([]byte(nil), payload...)}
+
+	handle, err := activator.Materialize(context.Background(), identity, binding, source)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+		t.Fatalf("Materialize = %#v, %v", handle, err)
+	}
+	if source.fills != 1 {
+		t.Fatalf("FillSecret calls = %d, want 1", source.fills)
+	}
+	source.payload = []byte("mutated-after-fill")
+	source = nil
+
+	sum := sha256.Sum256(payload)
+	if handle.TargetPath() != binding.ID {
+		t.Fatalf("TargetPath = %q, want binding ID %q", handle.TargetPath(), binding.ID)
+	}
+	if filepath.IsAbs(handle.TargetPath()) {
+		t.Fatalf("TargetPath used a host absolute path: %q", handle.TargetPath())
+	}
+	if handle.DeclaredFileBytes() != uint32(len(payload)) || handle.FileSHA256() != hex.EncodeToString(sum[:]) {
+		t.Fatalf("file metadata = %d %q", handle.DeclaredFileBytes(), handle.FileSHA256())
+	}
+
+	root := activator.rootDir
+	if strings.Contains(handle.TargetPath(), root) {
+		t.Fatalf("TargetPath leaked host root %q", handle.TargetPath())
+	}
+	files := l8JobCredentialFileTmpfsRegularFiles(t, root)
+	if len(files) != 1 {
+		t.Fatalf("host materialization files = %d, want 1", len(files))
+	}
+	got, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("host materialization payload mismatch")
+	}
+	if handle.TargetPath() == files[0] {
+		t.Fatal("TargetPath returned the host materialization path")
+	}
+
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if leftover := l8JobCredentialFileTmpfsRegularFiles(t, root); len(leftover) != 0 {
+		t.Fatalf("revoke left host files: %d", len(leftover))
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("idempotent Revoke: %v", err)
+	}
+}
+
+func TestL8JobCredentialFileHandleFailedRevokeKeepsOwnership(t *testing.T) {
+	activator := l8JobCredentialFileTmpfsActivatorForTest(t)
+	identity, binding := l8JobCredentialFileTmpfsIdentity(t)
+	handle, err := activator.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsSource{payload: []byte("tmpfs-canary-secret")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs, err := os.ReadDir(activator.rootDir)
+	if err != nil || len(dirs) != 1 || !dirs[0].IsDir() {
+		t.Fatalf("materialization dirs = %v, %v", dirs, err)
+	}
+	uniqueDir := filepath.Join(activator.rootDir, dirs[0].Name())
+	if err := os.Chmod(uniqueDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(uniqueDir, 0o700) })
+
+	revokeErr := handle.Revoke(context.Background())
+	if revokeErr == nil {
+		t.Fatal("Revoke succeeded while unlink was denied")
+	}
+	l8JobCredentialRuntimeAssertSafeError(t, revokeErr)
+	if leftover := l8JobCredentialFileTmpfsRegularFiles(t, activator.rootDir); len(leftover) != 1 {
+		t.Fatalf("failed revoke dropped host file ownership: leftover=%d", len(leftover))
+	}
+
+	if err := os.Chmod(uniqueDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("retry Revoke: %v", err)
+	}
+	if leftover := l8JobCredentialFileTmpfsRegularFiles(t, activator.rootDir); len(leftover) != 0 {
+		t.Fatalf("retry revoke left host files: %d", len(leftover))
+	}
+}
+
+func TestL8JobCredentialFileTmpfsActivatorFailClosedOnOversizeEmptyNilSourceCancelAndIdentity(t *testing.T) {
+	activator := l8JobCredentialFileTmpfsActivatorForTest(t)
+	identity, binding := l8JobCredentialFileTmpfsIdentity(t)
+	canary := []byte("sk_live_tmpfs_canary")
+
+	oversize := bytes.Repeat([]byte("x"), l8JobCredentialFileTmpfsMaxBytes+1)
+	oversize[0] = 's'
+	copy(oversize[1:], canary)
+	handle, err := activator.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsSource{payload: oversize, ignoreMax: true})
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("oversize = %#v, %v", handle, err)
+	}
+	l8JobCredentialFileTmpfsAssertSafeError(t, err, canary)
+	if files := l8JobCredentialFileTmpfsRegularFiles(t, activator.rootDir); len(files) != 0 {
+		t.Fatal("oversize created host files")
+	}
+
+	if handle, err := activator.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsSource{}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("empty = %#v, %v", handle, err)
+	}
+	if handle, err := activator.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsSource{skipWrite: true}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("empty-when-required = %#v, %v", handle, err)
+	}
+
+	var typedNil *l8JobCredentialFileTmpfsSource
+	var nilSource sandboxruntime.LiveSecretSource = typedNil
+	if handle, err := activator.Materialize(context.Background(), identity, binding, nil); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("nil source = %#v, %v", handle, err)
+	}
+	if handle, err := activator.Materialize(context.Background(), identity, binding, nilSource); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("typed-nil source = %#v, %v", handle, err)
+	}
+
+	var ctx context.Context
+	if handle, err := activator.Materialize(ctx, identity, binding, &l8JobCredentialFileTmpfsSource{payload: canary}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("nil context = %#v, %v", handle, err)
+	}
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if handle, err := activator.Materialize(canceled, identity, binding, &l8JobCredentialFileTmpfsSource{payload: canary}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled = %#v, %v", handle, err)
+	}
+
+	wrongMode := binding
+	wrongMode.Mode = sandboxruntime.JobCredentialDeliveryModeHTTPProxy
+	if handle, err := activator.Materialize(context.Background(), identity, wrongMode, &l8JobCredentialFileTmpfsSource{payload: canary}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("wrong mode = %#v, %v", handle, err)
+	}
+
+	unknown := binding
+	unknown.ID = "binding-unknown"
+	if handle, err := activator.Materialize(context.Background(), identity, unknown, &l8JobCredentialFileTmpfsSource{payload: canary}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("unknown binding = %#v, %v", handle, err)
+	}
+
+	httpIdentity := identity
+	httpIdentity.DeliveryModes = []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeHTTPProxy}
+	httpIdentity.NetworkPlanID = "network-plan-runtime"
+	httpIdentity.PolicySnapshotID = "policy-snapshot-runtime"
+	httpIdentity.ProxySessionID = "proxy-session-runtime"
+	httpIdentity.ProxyGenerationID = "proxy-generation-runtime"
+	httpIdentity.TopologyGenerationID = "topology-generation-runtime"
+	httpIdentity.RuleGenerationID = "rule-generation-runtime"
+	if handle, err := activator.Materialize(context.Background(), httpIdentity, binding, &l8JobCredentialFileTmpfsSource{payload: canary}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("mode mismatch identity = %#v, %v", handle, err)
+	}
+
+	partial := identity
+	partial.SandboxID = ""
+	if handle, err := activator.Materialize(context.Background(), partial, binding, &l8JobCredentialFileTmpfsSource{payload: canary}); !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("partial identity = %#v, %v", handle, err)
+	}
+
+	if files := l8JobCredentialFileTmpfsRegularFiles(t, activator.rootDir); len(files) != 0 {
+		t.Fatal("fail-closed paths created host files")
+	}
+}
+
+func TestL8JobCredentialFileTmpfsActivatorSanitizesSourceErrors(t *testing.T) {
+	activator := l8JobCredentialFileTmpfsActivatorForTest(t)
+	identity, binding := l8JobCredentialFileTmpfsIdentity(t)
+	canary := []byte("sk_live_tmpfs_canary path=/private/secret.sock")
+	handle, err := activator.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsSource{err: errors.New(string(canary))})
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialRuntimeUnavailable) {
+		t.Fatalf("source error = %#v, %v", handle, err)
+	}
+	l8JobCredentialFileTmpfsAssertSafeError(t, err, canary)
+}
+
+func TestL8JobCredentialFileTmpfsActivatorMaterializeMetadataReachesGuestPrepare(t *testing.T) {
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := l8JobCredentialRuntimePrepareRequest(t, identity)
+	payload := []byte("secret-bytes-" + identity.BindingIDs[0])
+	request.AuthorizedSources[0].Source = &l8JobCredentialFileTmpfsSource{payload: append([]byte(nil), payload...)}
+	tmpfs := l8JobCredentialFileTmpfsActivatorForTest(t)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, nil, tmpfs, nil)
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(session) {
+		t.Fatalf("PrepareJobCredentials = %#v, %v", session, err)
+	}
+	if len(guest.lastManifests) != 1 {
+		t.Fatalf("guest manifests = %d, want 1", len(guest.lastManifests))
+	}
+	sum := sha256.Sum256(payload)
+	manifest := guest.lastManifests[0]
+	if manifest.TargetPath != identity.BindingIDs[0] || filepath.IsAbs(manifest.TargetPath) || strings.Contains(manifest.TargetPath, tmpfs.rootDir) {
+		t.Fatalf("guest TargetPath = %q", manifest.TargetPath)
+	}
+	if manifest.DeclaredFileBytes != uint32(len(payload)) || manifest.FileSHA256 != hex.EncodeToString(sum[:]) {
+		t.Fatalf("guest file metadata = %d %q", manifest.DeclaredFileBytes, manifest.FileSHA256)
+	}
+	if _, err := session.Revoke(context.Background(), sandboxruntime.JobCredentialRevokeReason("requested")); err != nil {
+		t.Fatal(err)
+	}
+	if leftover := l8JobCredentialFileTmpfsRegularFiles(t, tmpfs.rootDir); len(leftover) != 0 {
+		t.Fatalf("session revoke left host files: %d", len(leftover))
+	}
+}
+
+func l8JobCredentialFileTmpfsActivatorForTest(t *testing.T) *L8JobCredentialFileTmpfsActivator {
+	t.Helper()
+	activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return activator
+}
+
+func l8JobCredentialFileTmpfsIdentity(t *testing.T) (sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest) {
+	t.Helper()
+	now := time.Date(2026, time.August, 28, 1, 2, 3, 0, time.UTC)
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeFileTmpfs, SourceReferenceID: "source-file",
+	}
+}
+
+func l8JobCredentialFileTmpfsRegularFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type().IsRegular() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return files
+}
+
+func l8JobCredentialFileTmpfsAssertSafeError(t *testing.T, err error, canary []byte) {
+	t.Helper()
+	l8JobCredentialRuntimeAssertSafeError(t, err)
+	if err == nil {
+		return
+	}
+	text := err.Error()
+	if strings.Contains(text, string(canary)) || strings.Contains(text, "sk_live") || strings.Contains(text, "/private/") {
+		t.Fatalf("error leaked canary: %v", err)
+	}
+}
+
+type l8JobCredentialFileTmpfsSource struct {
+	mu        sync.Mutex
+	payload   []byte
+	fills     int
+	skipWrite bool
+	ignoreMax bool
+	err       error
+}
+
+func (source *l8JobCredentialFileTmpfsSource) FillSecret(ctx context.Context, sink sandboxruntime.JobCredentialSecretSink) error {
+	source.mu.Lock()
+	defer source.mu.Unlock()
+	source.fills++
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+	if source.err != nil {
+		return source.err
+	}
+	if source.skipWrite {
+		return nil
+	}
+	if !source.ignoreMax && len(source.payload) > sink.MaxCredentialBytes() {
+		return ErrL8JobCredentialRuntimeInvalid
+	}
+	return sink.WriteCredential(source.payload)
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_other.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package firecrackerhost
+
+import "os"
+
+func materializeL8JobCredentialFileTmpfsPayload(string, []byte) (string, string, *os.File, error) {
+	return "", "", nil, ErrL8JobCredentialRuntimeUnsupported
+}
+
+func wipeL8JobCredentialFileTmpfsMaterialization(*os.File, string, string, uint32) (*os.File, error) {
+	return nil, ErrL8JobCredentialRuntimeUnsupported
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_other_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_other_test.go
@@ -1,0 +1,63 @@
+//go:build !linux
+
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8JobCredentialFileTmpfsActivatorNonLinuxFailsClosedBeforeFiles(t *testing.T) {
+	root := t.TempDir()
+	activator, err := NewProductionL8JobCredentialFileTmpfsActivator(L8JobCredentialFileTmpfsActivatorOptions{RootDir: root})
+	if activator != nil || !errors.Is(err, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("production constructor = %#v, %v", activator, err)
+	}
+	if files := l8JobCredentialFileTmpfsOtherFiles(t, root); len(files) != 0 {
+		t.Fatalf("non-Linux constructor created files: %d", len(files))
+	}
+
+	identity, binding := l8JobCredentialFileTmpfsOtherIdentity(t)
+	direct := &L8JobCredentialFileTmpfsActivator{rootDir: root}
+	handle, materializeErr := direct.Materialize(context.Background(), identity, binding, &l8JobCredentialFileTmpfsOtherSource{payload: []byte("tmpfs-canary-secret")})
+	if handle != nil || !errors.Is(materializeErr, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("non-Linux Materialize = %#v, %v", handle, materializeErr)
+	}
+	if files := l8JobCredentialFileTmpfsOtherFiles(t, root); len(files) != 0 {
+		t.Fatalf("non-Linux Materialize created files: %d", len(files))
+	}
+}
+
+func l8JobCredentialFileTmpfsOtherIdentity(t *testing.T) (sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest) {
+	t.Helper()
+	now := l8JobCredentialRuntimeNow()
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeFileTmpfs})
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeFileTmpfs, SourceReferenceID: "source-file",
+	}
+}
+
+func l8JobCredentialFileTmpfsOtherFiles(t *testing.T, root string) []os.DirEntry {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+type l8JobCredentialFileTmpfsOtherSource struct {
+	payload []byte
+}
+
+func (source *l8JobCredentialFileTmpfsOtherSource) FillSecret(context.Context, sandboxruntime.JobCredentialSecretSink) error {
+	return errors.New("non-linux source must not be filled")
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_test.go
@@ -108,6 +108,7 @@ func TestL8JobCredentialFileTmpfsActivatorRemainsDefaultOff(t *testing.T) {
 func TestL8JobCredentialFileHandleRedactsAndDeniesSerialization(t *testing.T) {
 	canary := "sk_live_tmpfs_canary /private/secret.sock /home/user/.hal/scratch"
 	values := []any{
+		L8JobCredentialFileTmpfsActivator{rootDir: "/home/user/.hal/scratch"},
 		&L8JobCredentialFileTmpfsActivator{rootDir: "/home/user/.hal/scratch"},
 		&l8JobCredentialFileHandleProduction{
 			targetPath: "binding-1",

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_tmpfs_activator_test.go
@@ -1,0 +1,151 @@
+package firecrackerhost
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+)
+
+func TestL8JobCredentialFileTmpfsActivatorPublicAPIIsExact(t *testing.T) {
+	constructor := reflect.TypeOf(NewProductionL8JobCredentialFileTmpfsActivator)
+	wantConstructor := reflect.TypeOf((func(L8JobCredentialFileTmpfsActivatorOptions) (*L8JobCredentialFileTmpfsActivator, error))(nil))
+	if constructor != wantConstructor {
+		t.Fatalf("NewProductionL8JobCredentialFileTmpfsActivator type = %v, want %v", constructor, wantConstructor)
+	}
+	activatorType := reflect.TypeOf((*L8JobCredentialFileTmpfsActivator)(nil))
+	l8D6AssertExactExportedMethodSet(t, activatorType, map[string]reflect.Type{
+		"Format":        reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator, fmt.State, rune))(nil)),
+		"GoString":      reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator) string)(nil)),
+		"MarshalBinary": reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator) ([]byte, error))(nil)),
+		"MarshalJSON":   reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator) ([]byte, error))(nil)),
+		"MarshalText":   reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator) ([]byte, error))(nil)),
+		"Materialize":   reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator, context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest, sandboxruntime.LiveSecretSource) (l8JobCredentialFileHandle, error))(nil)),
+		"String":        reflect.TypeOf((func(*L8JobCredentialFileTmpfsActivator) string)(nil)),
+	})
+	var _ l8JobCredentialFileTmpfsActivator = (*L8JobCredentialFileTmpfsActivator)(nil)
+	var _ l8JobCredentialFileHandle = (*l8JobCredentialFileHandleProduction)(nil)
+}
+
+func TestL8JobCredentialFileTmpfsActivatorRemainsDefaultOff(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", "..", ".."))
+	set := token.NewFileSet()
+	callers := 0
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(set, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch function := call.Fun.(type) {
+			case *ast.Ident:
+				name = function.Name
+			case *ast.SelectorExpr:
+				name = function.Sel.Name
+			}
+			if name == "NewProductionL8JobCredentialFileTmpfsActivator" {
+				callers++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callers != 0 {
+		t.Fatalf("production NewProductionL8JobCredentialFileTmpfsActivator callers = %d, want zero", callers)
+	}
+
+	runtimeSource, err := os.ReadFile("l8_job_credential_runtime.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(runtimeSource, []byte("NewProductionL8JobCredentialFileTmpfsActivator")) {
+		t.Fatal("NewProductionL8JobCredentialRuntime wires the production file-tmpfs activator")
+	}
+	for _, name := range []string{"adapter.go", "live_driver.go", "l7_live_composition.go"} {
+		source, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, forbidden := range []string{"NewProductionL8JobCredentialFileTmpfsActivator", "L8JobCredentialFileTmpfsActivator"} {
+			if bytes.Contains(source, []byte(forbidden)) {
+				t.Fatalf("%s wires file-tmpfs activator marker %q", name, forbidden)
+			}
+		}
+	}
+}
+
+func TestL8JobCredentialFileHandleRedactsAndDeniesSerialization(t *testing.T) {
+	canary := "sk_live_tmpfs_canary /private/secret.sock /home/user/.hal/scratch"
+	values := []any{
+		&L8JobCredentialFileTmpfsActivator{rootDir: "/home/user/.hal/scratch"},
+		&l8JobCredentialFileHandleProduction{
+			targetPath: "binding-1",
+			digest:     canary,
+			dir:        "/home/user/.hal/scratch",
+			filePath:   "/private/secret.sock",
+			owned:      true,
+		},
+	}
+	for _, value := range values {
+		if encoded, marshalErr := json.Marshal(value); marshalErr == nil || encoded != nil || !errors.Is(marshalErr, ErrL8JobCredentialRuntimeSerialization) {
+			t.Fatalf("json.Marshal(%T) = %q, %v", value, encoded, marshalErr)
+		}
+		for _, rendered := range []string{fmt.Sprint(value), fmt.Sprintf("%#v", value), fmt.Sprintf("%+v", value)} {
+			if rendered != l8JobCredentialFileTmpfsValuePlaceholder {
+				t.Fatalf("format %T = %q", value, rendered)
+			}
+			if strings.Contains(rendered, "sk_live") || strings.Contains(rendered, "/private/") || strings.Contains(rendered, ".hal") {
+				t.Fatalf("format leaked canary from %T: %q", value, rendered)
+			}
+		}
+	}
+}
+
+func TestL8JobCredentialFileHandleHasNoLiveSecretSourceField(t *testing.T) {
+	handleType := reflect.TypeOf(l8JobCredentialFileHandleProduction{})
+	sourceType := reflect.TypeOf((*sandboxruntime.LiveSecretSource)(nil)).Elem()
+	for index := 0; index < handleType.NumField(); index++ {
+		field := handleType.Field(index)
+		if field.Type == sourceType || field.Type.Kind() == reflect.Interface && field.Type.Implements(sourceType) {
+			t.Fatalf("file handle retains live secret source field %s", field.Name)
+		}
+	}
+	activatorType := reflect.TypeOf(L8JobCredentialFileTmpfsActivator{})
+	for index := 0; index < activatorType.NumField(); index++ {
+		field := activatorType.Field(index)
+		if field.Type == sourceType || field.Type.Kind() == reflect.Interface && field.Type.Implements(sourceType) {
+			t.Fatalf("file-tmpfs activator retains live secret source field %s", field.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Default-off host file-tmpfs activator. Materializes from `LiveSecretSource` into an injected scratch root, returns guest TargetPath from the binding ID, SHA-256 and size of the exact bytes, and revokes by wipe+unlink. Linux-only; non-Linux fails closed before creating files.

Stacked on #47.

## Default-off / non-goals
- No guest mount-monitor/PID1 wiring, no project `.hal/` writes, no D7 live tmpfs, no default constructor injection.

## Tests
- `go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'Tmpfs|FileTmpfs|FileHandle' -count=1`
- `go test ./cmd -run 'TmpfsActivator|FileTmpfs' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.