### PR TITLE
feat: US-049 - L8 production SSH-agent credential activator

### DIFF
--- a/cmd/l8_d6_ssh_activator_docs_test.go
+++ b/cmd/l8_d6_ssh_activator_docs_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestL8D6SSHActivatorVerificationContract(t *testing.T) {
+	document, err := os.ReadFile("../docs/design/sandbox-runtime-v2-l8-d6-ssh-activator-verification.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(document)
+	for _, required := range []string{
+		"default-off",
+		"NewProductionL8JobCredentialSSHRelayActivator",
+		"l8JobCredentialSSHRelayActivator",
+		"l8JobCredentialSSHRelayHandle",
+		"never invoked by sandboxd",
+		"`hal run`",
+		"`hal auto`",
+		"NewProductionL8JobCredentialRuntime",
+		"JobCredentialDeliveryModeSSHAgent",
+		"daemon-local sshrelay lease",
+		"PolicyID",
+		"PolicyRevision",
+		"does not persist entry, path, peer, or key",
+		"failed revoke must not drop ownership",
+		"liveValue",
+		"ErrSerialization",
+		"no agent paths, sockets, peer keys, or secrets",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'SSHRelay|SSHActivator|JobCredential.*SSH' -count=1",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost/sshrelay -count=1",
+		"go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^$' -count=1",
+		"go test ./cmd -run 'SSHActivator|SSHRelayActivator' -count=1",
+		"go vet ./internal/sandboxruntime/microvm/firecrackerhost ./internal/sandboxruntime/microvm/firecrackerhost/sshrelay",
+		"fake-only",
+		"no real ssh-agent sockets",
+		"do not use KVM",
+		"go test ./...",
+		"go vet ./...",
+		"make docs-check",
+		"make build",
+		"git diff --check",
+		"command -v golangci-lint",
+		"architecture document remains unchanged",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("verification document omits %q", required)
+		}
+	}
+}
+
+func TestL8D6SSHRelayActivatorRemainsDefaultOff(t *testing.T) {
+	root := filepath.Clean("..")
+	set := token.NewFileSet()
+	callers := 0
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(set, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch function := call.Fun.(type) {
+			case *ast.Ident:
+				name = function.Name
+			case *ast.SelectorExpr:
+				name = function.Sel.Name
+			}
+			if name == "NewProductionL8JobCredentialSSHRelayActivator" {
+				callers++
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if callers != 0 {
+		t.Fatalf("production NewProductionL8JobCredentialSSHRelayActivator callers = %d, want zero", callers)
+	}
+
+	for _, path := range []string{
+		"sandboxd.go", "run.go", "run_sandbox.go", "auto.go", "auto_sandbox.go",
+		"factory.go", "factory_sandbox_executor.go",
+		filepath.Join("..", "internal", "sandboxworker", "service.go"),
+		filepath.Join("..", "internal", "sandboxruntime", "microvm", "firecrackerhost", "l8_job_credential_runtime.go"),
+		filepath.Join("..", "internal", "sandboxruntime", "microvm", "firecrackerhost", "adapter.go"),
+		filepath.Join("..", "internal", "sandboxruntime", "microvm", "firecrackerhost", "live_driver.go"),
+	} {
+		payload, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if strings.Contains(string(payload), "NewProductionL8JobCredentialSSHRelayActivator") {
+			t.Fatalf("default production path %s constructs the SSH-agent activator", filepath.ToSlash(path))
+		}
+	}
+}
+
+func TestL8D6SSHActivatorProductionSourceGuards(t *testing.T) {
+	path := filepath.Join("..", "internal", "sandboxruntime", "microvm", "firecrackerhost", "l8_job_credential_ssh_activator.go")
+	source := readL8CredentialDeliveryFile(t, path)
+	for _, forbidden := range []string{
+		"SSH_AUTH_SOCK",
+		"OpenVerifiedConnection",
+		"NewLinuxAgentDialer",
+		"NewLinuxPeerVerifier",
+		"os/exec",
+		"net.Dial",
+		"net.Listen",
+		"/run/user/",
+		"agent.sock",
+		"WriteFile",
+		"KVM",
+		"kvm",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("SSH-agent activator production file contains forbidden marker %q", forbidden)
+		}
+	}
+
+	file, err := parser.ParseFile(token.NewFileSet(), path, source, parser.ImportsOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allowed := map[string]bool{
+		"context": true,
+		"errors":  true,
+		"fmt":     true,
+		"sync":    true,
+		"github.com/jywlabs/hal/internal/sandboxruntime":                                       true,
+		"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost/sshrelay":      true,
+		"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol": true,
+	}
+	for _, spec := range file.Imports {
+		importPath, unquoteErr := strconv.Unquote(spec.Path.Value)
+		if unquoteErr != nil {
+			t.Fatal(unquoteErr)
+		}
+		if !allowed[importPath] {
+			t.Fatalf("SSH-agent activator production file imports %q", importPath)
+		}
+	}
+}

--- a/docs/design/sandbox-runtime-v2-l8-d6-ssh-activator-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-ssh-activator-verification.md
@@ -1,0 +1,55 @@
+# Sandbox Runtime v2 L8 D6 SSH-Agent Credential Activator Verification
+
+## Scope
+
+This default-off D6 slice implements the production Firecracker host
+SSH-agent credential activator. It satisfies
+`firecrackerhost.l8JobCredentialSSHRelayActivator` /
+`l8JobCredentialSSHRelayHandle` by wrapping the existing daemon-local
+`internal/sandboxruntime/microvm/firecrackerhost/sshrelay` registry and lease.
+
+`NewProductionL8JobCredentialSSHRelayActivator` is explicit. It is never invoked by sandboxd,
+`hal run`, `hal auto`, factory, worker defaults, or `NewProductionL8JobCredentialRuntime`
+unless a caller injects the returned activator into `l8JobCredentialRuntimeDependencies.SSHRelay`.
+
+`Activate` requires `JobCredentialDeliveryModeSSHAgent`, acquires one daemon-local sshrelay lease
+against the host-admin `ConfigIdentity` injected at construction, and returns `PolicyID` /
+`PolicyRevision` from that lease's policy identity. It does not open ambient agents, does not
+call `OpenVerifiedConnection`, and does not persist entry, path, peer, or key selectors.
+`Renew` and `Revoke` operate on that exact lease. A failed revoke must not drop ownership.
+Live activator and handle values deny serialization using the sshrelay `liveValue` /
+`ErrSerialization` pattern. Errors contain no agent paths, sockets, peer keys, or secrets.
+
+This slice does not implement HTTP/tmpfs activators, recovery/finalize,
+`credentialclient`, `cmd/hal-guest-init`, worker v2, L10/L11, unrestricted
+host-agent forwarding, or sshrelay public-contract changes. The shared
+architecture document remains unchanged.
+
+## Focused verification
+
+```sh
+gofmt -w internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_ssh_activator.go \
+  internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_ssh_activator_test.go \
+  cmd/l8_d6_ssh_activator_docs_test.go
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'SSHRelay|SSHActivator|JobCredential.*SSH' -count=1
+go test ./internal/sandboxruntime/microvm/firecrackerhost/sshrelay -count=1
+go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^$' -count=1
+go test ./cmd -run 'SSHActivator|SSHRelayActivator' -count=1
+go vet ./internal/sandboxruntime/microvm/firecrackerhost ./internal/sandboxruntime/microvm/firecrackerhost/sshrelay
+```
+
+Default tests are fake-only. They inject a fake sshrelay registry/lease or a
+daemon-local `sshrelay.Registry` populated with a fake `LiveHostAgentEntry`.
+They open no real ssh-agent sockets, create no network listeners, and do not use KVM.
+
+## Broad verification
+
+```sh
+go test ./...
+go vet ./...
+make docs-check
+make build
+git diff --check
+```
+
+`golangci-lint` is reported only when `command -v golangci-lint` succeeds.

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_ssh_activator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_ssh_activator.go
@@ -1,0 +1,276 @@
+package firecrackerhost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost/sshrelay"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
+)
+
+const l8JobCredentialSSHRelayValuePlaceholder = "[firecracker-l8-job-credential-ssh-relay]"
+
+var (
+	ErrL8JobCredentialSSHRelayInvalid       = errors.New("Firecracker L8 SSH-agent credential activator invalid")
+	ErrL8JobCredentialSSHRelayUnavailable   = errors.New("Firecracker L8 SSH-agent credential activator unavailable")
+	ErrL8JobCredentialSSHRelaySerialization = errors.New("Firecracker L8 SSH-agent credential activator serialization denied")
+)
+
+type l8JobCredentialSSHRelayRegistry interface {
+	Acquire(context.Context, sshrelay.AcquireRequest) (sshrelay.Lease, error)
+}
+
+type l8JobCredentialSSHRelayLiveValue struct{}
+
+func (l8JobCredentialSSHRelayLiveValue) MarshalJSON() ([]byte, error) {
+	return nil, ErrL8JobCredentialSSHRelaySerialization
+}
+func (l8JobCredentialSSHRelayLiveValue) MarshalText() ([]byte, error) {
+	return nil, ErrL8JobCredentialSSHRelaySerialization
+}
+func (l8JobCredentialSSHRelayLiveValue) MarshalBinary() ([]byte, error) {
+	return nil, ErrL8JobCredentialSSHRelaySerialization
+}
+func (l8JobCredentialSSHRelayLiveValue) UnmarshalJSON([]byte) error {
+	return ErrL8JobCredentialSSHRelaySerialization
+}
+func (l8JobCredentialSSHRelayLiveValue) UnmarshalText([]byte) error {
+	return ErrL8JobCredentialSSHRelaySerialization
+}
+func (l8JobCredentialSSHRelayLiveValue) UnmarshalBinary([]byte) error {
+	return ErrL8JobCredentialSSHRelaySerialization
+}
+func (l8JobCredentialSSHRelayLiveValue) String() string {
+	return l8JobCredentialSSHRelayValuePlaceholder
+}
+func (l8JobCredentialSSHRelayLiveValue) GoString() string {
+	return l8JobCredentialSSHRelayValuePlaceholder
+}
+func (l8JobCredentialSSHRelayLiveValue) Format(state fmt.State, _ rune) {
+	_, _ = state.Write([]byte(l8JobCredentialSSHRelayValuePlaceholder))
+}
+
+// ProductionL8JobCredentialSSHRelayActivator is the explicit, default-off host
+// SSH-agent credential activator. It wraps one injected daemon-local sshrelay
+// registry and never opens ambient agents.
+type ProductionL8JobCredentialSSHRelayActivator struct {
+	l8JobCredentialSSHRelayLiveValue
+	registry l8JobCredentialSSHRelayRegistry
+	config   sshrelay.ConfigIdentity
+}
+
+type productionL8JobCredentialSSHRelayHandle struct {
+	l8JobCredentialSSHRelayLiveValue
+	mu       sync.Mutex
+	lease    sshrelay.Lease
+	config   sshrelay.ConfigIdentity
+	policyID string
+	revision uint64
+}
+
+// NewProductionL8JobCredentialSSHRelayActivator constructs the production
+// SSH-agent activator. It is never invoked by sandboxd, run, auto, factory,
+// worker, or NewProductionL8JobCredentialRuntime unless injected.
+func NewProductionL8JobCredentialSSHRelayActivator(registry *sshrelay.Registry, config sshrelay.ConfigIdentity) (*ProductionL8JobCredentialSSHRelayActivator, error) {
+	return newProductionL8JobCredentialSSHRelayActivator(registry, config)
+}
+
+func newProductionL8JobCredentialSSHRelayActivator(registry l8JobCredentialSSHRelayRegistry, config sshrelay.ConfigIdentity) (*ProductionL8JobCredentialSSHRelayActivator, error) {
+	if l8JobCredentialRuntimeValueIsNil(registry) || !sshrelay.ConfigIdentityEqual(config, config) {
+		return nil, ErrL8JobCredentialSSHRelayInvalid
+	}
+	return &ProductionL8JobCredentialSSHRelayActivator{registry: registry, config: config}, nil
+}
+
+func (activator *ProductionL8JobCredentialSSHRelayActivator) Activate(ctx context.Context, identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest) (handle l8JobCredentialSSHRelayHandle, err error) {
+	defer func() {
+		if recover() != nil {
+			if handle == nil {
+				err = ErrL8JobCredentialSSHRelayUnavailable
+			} else if err == nil {
+				err = ErrL8JobCredentialSSHRelayUnavailable
+			}
+		}
+	}()
+	if activator == nil || l8JobCredentialRuntimeValueIsNil(activator.registry) || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return nil, ErrL8JobCredentialSSHRelayInvalid
+	}
+	if binding.Mode != sandboxruntime.JobCredentialDeliveryModeSSHAgent ||
+		sandboxruntime.ValidateJobCredentialIdentity(identity) != nil ||
+		!l8JobCredentialSSHRelayBindingMatches(identity, binding) {
+		return nil, ErrL8JobCredentialSSHRelayInvalid
+	}
+	request, requestErr := sshrelay.NewAcquireRequest(
+		activator.config,
+		credentialprotocol.SafeID(identity.RuntimeGeneration),
+		credentialprotocol.SafeID(identity.FirecrackerProcessGeneration),
+		credentialprotocol.SafeID(identity.VsockGeneration),
+		credentialprotocol.SafeID(identity.WorkerJobID),
+		credentialprotocol.SafeID(identity.ActivationGeneration),
+		credentialprotocol.SafeID(identity.CredentialGeneration),
+	)
+	if requestErr != nil {
+		return nil, ErrL8JobCredentialSSHRelayInvalid
+	}
+	lease, acquireErr := callL8JobCredentialSSHRelayAcquire(activator.registry, ctx, request)
+	owned := newProductionL8JobCredentialSSHRelayHandle(lease, activator.config)
+	if !l8JobCredentialRuntimeValueIsNil(lease) {
+		handle = owned
+	}
+	if acquireErr != nil {
+		return handle, sanitizeL8JobCredentialSSHRelayError(acquireErr)
+	}
+	if l8JobCredentialRuntimeValueIsNil(lease) {
+		return nil, ErrL8JobCredentialSSHRelayInvalid
+	}
+	policyID, revision, policyErr := callL8JobCredentialSSHRelayPolicy(lease)
+	if policyErr != nil {
+		return handle, policyErr
+	}
+	if !validL8JobCredentialRuntimeToken(policyID) || revision == 0 {
+		return handle, ErrL8JobCredentialSSHRelayInvalid
+	}
+	owned.policyID = policyID
+	owned.revision = revision
+	return owned, nil
+}
+
+func (handle *productionL8JobCredentialSSHRelayHandle) PolicyID() string {
+	if handle == nil {
+		return ""
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	return handle.policyID
+}
+
+func (handle *productionL8JobCredentialSSHRelayHandle) PolicyRevision() uint64 {
+	if handle == nil {
+		return 0
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	return handle.revision
+}
+
+func (handle *productionL8JobCredentialSSHRelayHandle) Renew(ctx context.Context) error {
+	if handle == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return ErrL8JobCredentialSSHRelayInvalid
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if l8JobCredentialRuntimeValueIsNil(handle.lease) {
+		return ErrL8JobCredentialSSHRelayInvalid
+	}
+	if ctx.Err() != nil {
+		return ErrL8JobCredentialSSHRelayUnavailable
+	}
+	if !sshrelay.ConfigIdentityEqual(handle.lease.Identity(), handle.config) {
+		return ErrL8JobCredentialSSHRelayUnavailable
+	}
+	policyID, revision, err := callL8JobCredentialSSHRelayPolicy(handle.lease)
+	if err != nil {
+		return err
+	}
+	if policyID != handle.policyID || revision != handle.revision || revision == 0 {
+		return ErrL8JobCredentialSSHRelayUnavailable
+	}
+	return nil
+}
+
+func (handle *productionL8JobCredentialSSHRelayHandle) Revoke(ctx context.Context) error {
+	if handle == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return ErrL8JobCredentialSSHRelayInvalid
+	}
+	handle.mu.Lock()
+	defer handle.mu.Unlock()
+	if l8JobCredentialRuntimeValueIsNil(handle.lease) {
+		return nil
+	}
+	if err := callL8JobCredentialSSHRelayLeaseClose(handle.lease, ctx); err != nil {
+		return sanitizeL8JobCredentialSSHRelayError(err)
+	}
+	handle.lease = nil
+	return nil
+}
+
+func newProductionL8JobCredentialSSHRelayHandle(lease sshrelay.Lease, config sshrelay.ConfigIdentity) *productionL8JobCredentialSSHRelayHandle {
+	return &productionL8JobCredentialSSHRelayHandle{lease: lease, config: config}
+}
+
+func l8JobCredentialSSHRelayBindingMatches(identity sandboxruntime.JobCredentialIdentity, binding sandboxruntime.JobCredentialBindingRequest) bool {
+	if binding.Mode != sandboxruntime.JobCredentialDeliveryModeSSHAgent || binding.ID == "" {
+		return false
+	}
+	for index, bindingID := range identity.BindingIDs {
+		if bindingID != binding.ID {
+			continue
+		}
+		return index < len(identity.DeliveryModes) && identity.DeliveryModes[index] == sandboxruntime.JobCredentialDeliveryModeSSHAgent
+	}
+	return false
+}
+
+func callL8JobCredentialSSHRelayAcquire(registry l8JobCredentialSSHRelayRegistry, ctx context.Context, request sshrelay.AcquireRequest) (lease sshrelay.Lease, err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialSSHRelayUnavailable
+		}
+	}()
+	return registry.Acquire(ctx, request)
+}
+
+func callL8JobCredentialSSHRelayPolicy(lease sshrelay.Lease) (policyID string, revision uint64, err error) {
+	defer func() {
+		if recover() != nil {
+			policyID, revision = "", 0
+			err = ErrL8JobCredentialSSHRelayUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(lease) {
+		return "", 0, ErrL8JobCredentialSSHRelayInvalid
+	}
+	identity := lease.PolicyIdentity()
+	return string(identity.ID()), identity.Revision(), nil
+}
+
+func callL8JobCredentialSSHRelayLeaseClose(lease sshrelay.Lease, ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrL8JobCredentialSSHRelayUnavailable
+		}
+	}()
+	if l8JobCredentialRuntimeValueIsNil(lease) {
+		return nil
+	}
+	return lease.Close(ctx)
+}
+
+func sanitizeL8JobCredentialSSHRelayError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrL8JobCredentialSSHRelayInvalid),
+		errors.Is(err, sshrelay.ErrInvalidArgument),
+		errors.Is(err, sshrelay.ErrIdentityMismatch),
+		errors.Is(err, sshrelay.ErrPolicyInvalid),
+		errors.Is(err, sshrelay.ErrDependencyRequired),
+		errors.Is(err, sshrelay.ErrDuplicateEntry):
+		return ErrL8JobCredentialSSHRelayInvalid
+	case errors.Is(err, ErrL8JobCredentialSSHRelayUnavailable),
+		errors.Is(err, ErrL8JobCredentialSSHRelaySerialization),
+		errors.Is(err, sshrelay.ErrSerialization):
+		return err
+	default:
+		return ErrL8JobCredentialSSHRelayUnavailable
+	}
+}
+
+var (
+	_ l8JobCredentialSSHRelayActivator = (*ProductionL8JobCredentialSSHRelayActivator)(nil)
+	_ l8JobCredentialSSHRelayHandle    = (*productionL8JobCredentialSSHRelayHandle)(nil)
+	_ l8JobCredentialSSHRelayRegistry  = (*sshrelay.Registry)(nil)
+)

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_ssh_activator_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_ssh_activator_test.go
@@ -1,0 +1,403 @@
+package firecrackerhost
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost/sshrelay"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
+)
+
+func TestProductionL8JobCredentialSSHRelayActivatorPublicAPIIsExact(t *testing.T) {
+	constructor := reflect.TypeOf(NewProductionL8JobCredentialSSHRelayActivator)
+	wantConstructor := reflect.TypeOf((func(*sshrelay.Registry, sshrelay.ConfigIdentity) (*ProductionL8JobCredentialSSHRelayActivator, error))(nil))
+	if constructor != wantConstructor {
+		t.Fatalf("NewProductionL8JobCredentialSSHRelayActivator type = %v, want %v", constructor, wantConstructor)
+	}
+	activatorType := reflect.TypeOf((*ProductionL8JobCredentialSSHRelayActivator)(nil))
+	l8D6AssertExactExportedMethodSet(t, activatorType, map[string]reflect.Type{
+		"Activate":        reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator, context.Context, sandboxruntime.JobCredentialIdentity, sandboxruntime.JobCredentialBindingRequest) (l8JobCredentialSSHRelayHandle, error))(nil)),
+		"Format":          reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator, fmt.State, rune))(nil)),
+		"GoString":        reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator) string)(nil)),
+		"MarshalBinary":   reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator) ([]byte, error))(nil)),
+		"MarshalJSON":     reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator) ([]byte, error))(nil)),
+		"MarshalText":     reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator) ([]byte, error))(nil)),
+		"String":          reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator) string)(nil)),
+		"UnmarshalBinary": reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator, []byte) error)(nil)),
+		"UnmarshalJSON":   reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator, []byte) error)(nil)),
+		"UnmarshalText":   reflect.TypeOf((func(*ProductionL8JobCredentialSSHRelayActivator, []byte) error)(nil)),
+	})
+	var _ l8JobCredentialSSHRelayActivator = (*ProductionL8JobCredentialSSHRelayActivator)(nil)
+}
+
+func TestProductionL8JobCredentialSSHActivatorRequiresSSHAgentMode(t *testing.T) {
+	registry, config := l8JobCredentialSSHRelayFakeRegistry(t)
+	activator, err := newProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{
+		sandboxruntime.JobCredentialDeliveryModeHTTPProxy,
+		sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	handle, err := activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeHTTPProxy, ServiceID: "azure-openai-responses-v1",
+	})
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialSSHRelayInvalid) {
+		t.Fatalf("http activate = %#v, %v", handle, err)
+	}
+	if registry.acquires != 0 {
+		t.Fatalf("http mode acquired a lease: %d", registry.acquires)
+	}
+	handle, err = activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[1], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+		t.Fatalf("ssh activate = %#v, %v", handle, err)
+	}
+	if registry.acquires != 1 {
+		t.Fatalf("ssh acquires = %d, want 1", registry.acquires)
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorAcquiresExactLeaseAndPolicy(t *testing.T) {
+	registry, config := l8JobCredentialSSHRelayFakeRegistry(t)
+	activator, err := newProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeSSHAgent})
+	binding := sandboxruntime.JobCredentialBindingRequest{ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent}
+	handle, err := activator.Activate(context.Background(), identity, binding)
+	if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+		t.Fatalf("Activate = %#v, %v", handle, err)
+	}
+	if handle.PolicyID() != "ssh-policy-1" || handle.PolicyRevision() != 4 {
+		t.Fatalf("policy = %q/%d", handle.PolicyID(), handle.PolicyRevision())
+	}
+	if registry.acquires != 1 || len(registry.leases) != 1 {
+		t.Fatalf("acquires=%d leases=%d", registry.acquires, len(registry.leases))
+	}
+	request := registry.lastRequest
+	if !sshrelay.ConfigIdentityEqual(request.ConfigIdentity(), config) {
+		t.Fatal("acquire used a different registry entry identity")
+	}
+	if string(request.RuntimeGeneration()) != identity.RuntimeGeneration ||
+		string(request.ProcessGeneration()) != identity.FirecrackerProcessGeneration ||
+		string(request.VsockGeneration()) != identity.VsockGeneration ||
+		string(request.WorkerJobGeneration()) != identity.WorkerJobID ||
+		string(request.ActivationGeneration()) != identity.ActivationGeneration ||
+		string(request.RelayGeneration()) != identity.CredentialGeneration {
+		t.Fatalf("acquire generations = %#v", request)
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorRenewAndRevokeUseExactLease(t *testing.T) {
+	registry, config := l8JobCredentialSSHRelayFakeRegistry(t)
+	activator, err := newProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeSSHAgent})
+	handle, err := activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handle.Renew(context.Background()); err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if registry.leases[0].closes != 1 || !registry.leases[0].closed {
+		t.Fatalf("revoke closed lease = %+v", registry.leases[0])
+	}
+	if err := handle.Renew(context.Background()); !errors.Is(err, ErrL8JobCredentialSSHRelayInvalid) {
+		t.Fatalf("renew after revoke = %v", err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("idempotent revoke = %v", err)
+	}
+	if registry.leases[0].closes != 1 {
+		t.Fatalf("idempotent revoke reclosed lease: %d", registry.leases[0].closes)
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorFailedRevokeKeepsOwnership(t *testing.T) {
+	registry, config := l8JobCredentialSSHRelayFakeRegistry(t)
+	registry.closeErr = errors.New("token=ssh-secret path=/run/user/1000/agent.sock peer=ssh-ed25519-canary")
+	activator, err := newProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeSSHAgent})
+	handle, err := activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = handle.Revoke(context.Background())
+	if !errors.Is(err, ErrL8JobCredentialSSHRelayUnavailable) {
+		t.Fatalf("failed revoke = %v", err)
+	}
+	l8JobCredentialSSHRelayAssertSafeError(t, err)
+	if registry.leases[0].closed {
+		t.Fatal("failed revoke dropped lease ownership")
+	}
+	registry.closeErr = nil
+	if err := handle.Renew(context.Background()); err != nil {
+		t.Fatalf("renew after failed revoke: %v", err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("retry revoke: %v", err)
+	}
+	if !registry.leases[0].closed || registry.leases[0].closes != 2 {
+		t.Fatalf("retry revoke lease = %+v", registry.leases[0])
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorDeniesSerialization(t *testing.T) {
+	registry, config := l8JobCredentialSSHRelayFakeRegistry(t)
+	activator, err := newProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeSSHAgent})
+	handle, err := activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := []any{activator, handle, &ProductionL8JobCredentialSSHRelayActivator{}, &productionL8JobCredentialSSHRelayHandle{policyID: "ssh-policy-1"}}
+	for _, value := range values {
+		if encoded, marshalErr := json.Marshal(value); marshalErr == nil || encoded != nil || !errors.Is(marshalErr, ErrL8JobCredentialSSHRelaySerialization) {
+			t.Fatalf("json.Marshal(%T) = %q, %v", value, encoded, marshalErr)
+		}
+		if err := json.Unmarshal([]byte(`{}`), value); !errors.Is(err, ErrL8JobCredentialSSHRelaySerialization) {
+			t.Fatalf("json.Unmarshal(%T) = %v", value, err)
+		}
+		for _, rendered := range []string{fmt.Sprint(value), fmt.Sprintf("%#v", value), fmt.Sprintf("%+v", value)} {
+			if rendered != l8JobCredentialSSHRelayValuePlaceholder {
+				t.Fatalf("format %T = %q", value, rendered)
+			}
+			for _, seed := range []string{"ssh-policy-1", "/run/user/", "agent.sock", "ssh-ed25519"} {
+				if strings.Contains(rendered, seed) {
+					t.Fatalf("format leaked %q: %q", seed, rendered)
+				}
+			}
+		}
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorRedactsErrors(t *testing.T) {
+	registry, config := l8JobCredentialSSHRelayFakeRegistry(t)
+	canary := "token=ssh-secret path=/run/user/1000/agent.sock peer=ssh-ed25519-canary SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	registry.err = errors.New(canary)
+	activator, err := newProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeSSHAgent})
+	handle, err := activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	if !l8JobCredentialRuntimeValueIsNil(handle) || !errors.Is(err, ErrL8JobCredentialSSHRelayUnavailable) {
+		t.Fatalf("canary activate = %#v, %v", handle, err)
+	}
+	l8JobCredentialSSHRelayAssertSafeError(t, err)
+	if strings.Contains(err.Error(), canary) {
+		t.Fatalf("activate leaked canary: %v", err)
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorWrapsDaemonRegistry(t *testing.T) {
+	config, err := sshrelay.NewConfigIdentity("entry-a", "daemon-a", "entry-generation-a", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policyIdentity, err := sshrelay.NewPolicyIdentity("ssh-policy-1", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := sshrelay.NewLivePolicy(policyIdentity, []sshrelay.PolicyRule{{
+		Fingerprint:  "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		KeyAlgorithm: credentialprotocol.SSHAgentKeyAlgorithmED25519,
+		Flags:        []credentialprotocol.SSHAgentRSAFlags{0},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := &l8JobCredentialSSHRelayEntryFake{identity: config, policy: policy}
+	registry, err := sshrelay.NewRegistry(sshrelay.RegistryOptions{
+		DaemonGeneration: "daemon-a",
+		Entries:          []sshrelay.LiveHostAgentEntry{entry},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = registry.Close(context.Background()) })
+	activator, err := NewProductionL8JobCredentialSSHRelayActivator(registry, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := l8JobCredentialSSHRelayIdentity(t, []sandboxruntime.JobCredentialDeliveryMode{sandboxruntime.JobCredentialDeliveryModeSSHAgent})
+	handle, err := activator.Activate(context.Background(), identity, sandboxruntime.JobCredentialBindingRequest{
+		ID: identity.BindingIDs[0], Mode: sandboxruntime.JobCredentialDeliveryModeSSHAgent,
+	})
+	if err != nil || l8JobCredentialRuntimeValueIsNil(handle) {
+		t.Fatalf("Activate through sshrelay.Registry = %#v, %v", handle, err)
+	}
+	if handle.PolicyID() != "ssh-policy-1" || handle.PolicyRevision() != 4 {
+		t.Fatalf("policy = %q/%d", handle.PolicyID(), handle.PolicyRevision())
+	}
+	if entry.opens != 0 {
+		t.Fatalf("activator opened an agent connection: %d", entry.opens)
+	}
+	if err := handle.Renew(context.Background()); err != nil {
+		t.Fatalf("Renew: %v", err)
+	}
+	if err := handle.Revoke(context.Background()); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if entry.opens != 0 {
+		t.Fatalf("renew/revoke opened an agent connection: %d", entry.opens)
+	}
+}
+
+func TestProductionL8JobCredentialSSHRelayActivatorRejectsInvalidConstructor(t *testing.T) {
+	config, err := sshrelay.NewConfigIdentity("entry-a", "daemon-a", "entry-generation-a", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var typedNil *sshrelay.Registry
+	if activator, ctorErr := NewProductionL8JobCredentialSSHRelayActivator(nil, config); activator != nil || !errors.Is(ctorErr, ErrL8JobCredentialSSHRelayInvalid) {
+		t.Fatalf("nil registry = %#v, %v", activator, ctorErr)
+	}
+	if activator, ctorErr := NewProductionL8JobCredentialSSHRelayActivator(typedNil, config); activator != nil || !errors.Is(ctorErr, ErrL8JobCredentialSSHRelayInvalid) {
+		t.Fatalf("typed-nil registry = %#v, %v", activator, ctorErr)
+	}
+	if activator, ctorErr := NewProductionL8JobCredentialSSHRelayActivator(&sshrelay.Registry{}, sshrelay.ConfigIdentity{}); activator != nil || !errors.Is(ctorErr, ErrL8JobCredentialSSHRelayInvalid) {
+		t.Fatalf("zero config = %#v, %v", activator, ctorErr)
+	}
+}
+
+func l8JobCredentialSSHRelayIdentity(t *testing.T, modes []sandboxruntime.JobCredentialDeliveryMode) sandboxruntime.JobCredentialIdentity {
+	t.Helper()
+	seed := l8JobCredentialRuntimeSeed(t, l8JobCredentialRuntimeNow(), modes)
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func l8JobCredentialSSHRelayFakeRegistry(t *testing.T) (*l8JobCredentialSSHRelayRegistryFake, sshrelay.ConfigIdentity) {
+	t.Helper()
+	config, err := sshrelay.NewConfigIdentity("entry-a", "daemon-a", "entry-generation-a", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err := sshrelay.NewPolicyIdentity("ssh-policy-1", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &l8JobCredentialSSHRelayRegistryFake{config: config, policy: policy}, config
+}
+
+func l8JobCredentialSSHRelayAssertSafeError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	text := err.Error()
+	for _, forbidden := range []string{
+		"ssh-secret", "/run/user/", "agent.sock", "ssh-ed25519-canary", "SHA256:",
+		"token=", "/private/", "OPENAI_API_KEY", "sk_live",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("error leaked %q: %v", forbidden, err)
+		}
+	}
+}
+
+type l8JobCredentialSSHRelayRegistryFake struct {
+	mu          sync.Mutex
+	config      sshrelay.ConfigIdentity
+	policy      sshrelay.PolicyIdentity
+	acquires    int
+	lastRequest sshrelay.AcquireRequest
+	err         error
+	closeErr    error
+	leases      []*l8JobCredentialSSHRelayLeaseFake
+}
+
+func (fake *l8JobCredentialSSHRelayRegistryFake) Acquire(_ context.Context, request sshrelay.AcquireRequest) (sshrelay.Lease, error) {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	fake.acquires++
+	fake.lastRequest = request
+	if fake.err != nil {
+		return nil, fake.err
+	}
+	lease := &l8JobCredentialSSHRelayLeaseFake{parent: fake, config: fake.config, policy: fake.policy}
+	fake.leases = append(fake.leases, lease)
+	return lease, nil
+}
+
+type l8JobCredentialSSHRelayLeaseFake struct {
+	parent *l8JobCredentialSSHRelayRegistryFake
+	config sshrelay.ConfigIdentity
+	policy sshrelay.PolicyIdentity
+	mu     sync.Mutex
+	closes int
+	closed bool
+}
+
+func (lease *l8JobCredentialSSHRelayLeaseFake) Identity() sshrelay.ConfigIdentity {
+	return lease.config
+}
+func (lease *l8JobCredentialSSHRelayLeaseFake) PolicyIdentity() sshrelay.PolicyIdentity {
+	return lease.policy
+}
+func (*l8JobCredentialSSHRelayLeaseFake) OpenVerifiedConnection(context.Context) (sshrelay.VerifiedAgentConnection, error) {
+	panic("ssh relay activator must not open agent connections")
+}
+func (lease *l8JobCredentialSSHRelayLeaseFake) Close(context.Context) error {
+	lease.mu.Lock()
+	defer lease.mu.Unlock()
+	lease.closes++
+	if lease.parent.closeErr != nil {
+		return lease.parent.closeErr
+	}
+	lease.closed = true
+	return nil
+}
+
+type l8JobCredentialSSHRelayEntryFake struct {
+	identity sshrelay.ConfigIdentity
+	policy   sshrelay.LivePolicy
+	opens    int
+}
+
+func (entry *l8JobCredentialSSHRelayEntryFake) Identity() sshrelay.ConfigIdentity {
+	return entry.identity
+}
+func (entry *l8JobCredentialSSHRelayEntryFake) Policy() sshrelay.LivePolicy { return entry.policy }
+func (entry *l8JobCredentialSSHRelayEntryFake) Open(context.Context) (sshrelay.AgentConnection, error) {
+	entry.opens++
+	return nil, errors.New("test host-agent entry does not open agents")
+}
+func (*l8JobCredentialSSHRelayEntryFake) VerifyPeer(context.Context, sshrelay.AgentConnection) (sshrelay.PeerProof, error) {
+	return sshrelay.PeerProof{}, errors.New("test host-agent entry does not verify peers")
+}


### PR DESCRIPTION
## Summary
Default-off SSH-agent activator wrapping an injected `sshrelay.Registry` lease. Activate requires `ssh_agent`, returns PolicyID/PolicyRevision, and Renew/Revoke use that exact lease. Failed revoke keeps ownership. Live values deny serialization.

Stacked on #48.

## Default-off / non-goals
- No unrestricted host-agent forwarding, no registry persistence, no default wiring, no D7.

## Tests
- `go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'SSHRelay|SSHActivator|JobCredential.*SSH' -count=1`
- `go test ./internal/sandboxruntime/microvm/firecrackerhost/sshrelay -count=1`
- `go test ./cmd -run 'SSHActivator|SSHRelayActivator' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.