### PR TITLE
feat: US-049 - L8 recovered VM binding finalize

### DIFF
--- a/cmd/l8_d6_runtime_owner_contract_test.go
+++ b/cmd/l8_d6_runtime_owner_contract_test.go
@@ -180,7 +180,7 @@ func validateL8D6RuntimeOwnerArchitecture(doc string) error {
 		"Reflection, unsafe conversion, receipt aliases, receiver methods, closures, and helper escape are forbidden",
 		"A receipt-bearing allowlisted file also fails if it imports `reflect` or `unsafe`",
 		"func (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(context.Context, sandboxruntime.JobCredentialRuntimeAbsenceProof) (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, error)",
-		"The root validator and owner verifier land together; the private-store converter remains optional until worker receipt persistence lands",
+		"The root validator and owner verifier land together; both private-store functions remain optional until worker receipt persistence lands",
 		"The digest has no accessor",
 		l8D6RuntimeOwnerCloseRule,
 		"Non-Linux implementations fail closed",
@@ -429,6 +429,10 @@ func TestL8D6RuntimeOwnerContractCommitReceiptHasOnePrivateStoreProjection(t *te
 	allowedBindingFixture := []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(ctx context.Context, proof sandboxruntime.JobCredentialRuntimeAbsenceProof) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) { return }\nfunc (*l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery(ctx context.Context, receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { return commitJobCredentialRuntimeRecovery(receipt) }\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n")
 	if audit, err := l8D6RuntimeOwnerCommitReceiptAccessAudit(allowedBindingFixture, expected[ownerVerifier]); err != nil || !audit.exact() || len(audit.issues) != 0 {
 		t.Fatalf("exact binding commit/finalize fixture audit = %#v, error %v", audit, err)
+	}
+	allowedFinalizeConstructFixture := []byte("package firecrackerhost\nimport (\"context\"; sandboxruntime \"github.com/jywlabs/hal/internal/sandboxruntime\")\ntype l8RuntimeOwnerRecoveryBinding struct{}\nfunc (*l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(ctx context.Context, proof sandboxruntime.JobCredentialRuntimeAbsenceProof) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) {\n\treceipt = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{CommitID: \"token\", FinalizedRevision: 1}\n\treturn commitJobCredentialRuntimeRecovery(receipt)\n}\nfunc commitJobCredentialRuntimeRecovery(receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n")
+	if audit, err := l8D6RuntimeOwnerCommitReceiptAccessAudit(allowedFinalizeConstructFixture, expected[ownerVerifier]); err != nil || !audit.exact() || len(audit.issues) != 0 {
+		t.Fatalf("finalizer receipt construction fixture audit = %#v, error %v", audit, err)
 	}
 	rootReceiptType := "type JobCredentialRuntimeRecoveryCommitReceipt struct { CommitID string; FinalizedRevision uint64 }\n"
 	rootValidatorFunction := "func ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt JobCredentialRuntimeRecoveryCommitReceipt) error { _ = receipt.CommitID; return nil }\n"
@@ -939,7 +943,7 @@ func l8D6RuntimeOwnerReceiptTypeIsExactFinalizerResult(file *ast.File, reference
 	firstResult := function.Type.Results.List[0]
 	secondResult := function.Type.Results.List[1]
 	return len(function.Type.Params.List[0].Names) <= 1 && len(function.Type.Params.List[1].Names) <= 1 &&
-		len(firstResult.Names) <= 1 && firstResult.Type == reference &&
+		len(firstResult.Names) <= 1 && l8D6RuntimeOwnerExactImportedType(firstResult.Type, runtimeAliases, "JobCredentialRuntimeRecoveryCommitReceipt") &&
 		len(secondResult.Names) <= 1 && l8D6RuntimeOwnerTypeName(secondResult.Type) == "error" && firstParameter && secondParameter
 }
 

--- a/cmd/l8_d6_runtime_owner_foundation_red_test.go
+++ b/cmd/l8_d6_runtime_owner_foundation_red_test.go
@@ -86,12 +86,19 @@ func TestL8D6RuntimeOwnerFoundationDependenciesRemainUnaccepted(t *testing.T) {
 			t.Fatalf("Finalize forges recovered L7 termination authority with %q", forbidden)
 		}
 	}
+	if !strings.Contains(source, "l7network.NewRecoveredVMTerminationBinding") {
+		t.Fatal("Finalize must construct recovered L7 termination via l7network.NewRecoveredVMTerminationBinding")
+	}
+	if !strings.Contains(source, "CleanupAfterVMQuiesced") || !strings.Contains(source, "l7network.NewReconciler") {
+		t.Fatal("Finalize must drive same-boot L7 CleanupAfterVMQuiesced through NewReconciler")
+	}
 	doc := readL8CredentialDeliveryFile(t, filepath.Join("..", "docs", "design", "sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md"))
 	for _, marker := range []string{
 		"R1 foundation dependency-unaccepted",
 		"type `l8RuntimeOwnerRecoveryBinding`",
-		"recovered `l7network.TerminatedVMBinding` constructor remains absent",
-		"Finalize fail-closes without a recovered L7 `TerminatedVMBinding`",
+		"Old-boot journal retirement also remains unavailable and fail-closed",
+		"Finalize constructs `l7network.NewRecoveredVMTerminationBinding`",
+		"old-boot journal retirement remains fail-closed",
 	} {
 		if !strings.Contains(doc, marker) {
 			t.Errorf("R1 verification omits dependency marker %q", marker)

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -277,7 +277,11 @@ sole production `NewJobCredentialRuntimeAbsenceProof` callsite in
 `l8_runtime_owner_recovery.go`, and it issues a proof only after the private
 owner has proved exact absence by direct-parent Wait or replacement
 double-`/proc`. The AST guard is tightened from zero host issuers to exactly
-that one StopReap callsite. Finalize constructs `l7network.NewRecoveredVMTerminationBinding`
-and persists `finalized` only after same-boot `CleanupAfterVMQuiesced`; old-boot journal retirement remains fail-closed.
+that one StopReap callsite. Finalize constructs `l7network.NewRecoveredVMTerminationBinding`,
+persists the HMAC-bound `finalizing` intent before same-boot
+`CleanupAfterVMQuiesced`, and persists `finalized` only after cleanup. A retry
+from `finalizing` resumes the exact journal or accepts its exact
+full-identity-bound durable retired-generation marker without reopening
+removed topology. Legacy or mismatched markers remain stale-only; old-boot journal retirement remains fail-closed.
 `commitJobCredentialRuntimeRecovery` remains the sole owner `CommitID` reader.
 Default constructors, sandboxd, and command execution stay unwired.

--- a/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-runtime-owner-contract-verification.md
@@ -216,12 +216,10 @@ private type `l8RuntimeOwnerRecoveryBinding`
 but does not implement `FinalizeJobCredentialRuntimeRecovery`, a concrete
 provider, process signaling, supervisor control, or L7 cleanup.
 
-The recovered `l7network.TerminatedVMBinding` constructor remains absent.
-Existing production termination bindings depend on the same-process in-memory
-process tracker, while the restart path needs independently reacquired process
-absence correlated to the recovered L7 journal. R1 therefore cannot honestly
-finalize or satisfy the neutral binding. Old-boot journal retirement also
-remains unavailable and fail-closed; no private `l7network` schema is copied or
+R1 left recovered L7 termination construction to a later slice because existing
+production termination bindings depend on the same-process in-memory process
+tracker, while the restart path needs independently reacquired process absence
+correlated to the recovered L7 journal. Old-boot journal retirement also remains unavailable and fail-closed; no private `l7network` schema is copied or
 invented here.
 
 The strict Linux store walks every absolute path component with `openat` plus
@@ -279,6 +277,7 @@ sole production `NewJobCredentialRuntimeAbsenceProof` callsite in
 `l8_runtime_owner_recovery.go`, and it issues a proof only after the private
 owner has proved exact absence by direct-parent Wait or replacement
 double-`/proc`. The AST guard is tightened from zero host issuers to exactly
-that one StopReap callsite. Finalize fail-closes without a recovered L7 `TerminatedVMBinding`; old-boot journal retirement remains fail-closed.
+that one StopReap callsite. Finalize constructs `l7network.NewRecoveredVMTerminationBinding`
+and persists `finalized` only after same-boot `CleanupAfterVMQuiesced`; old-boot journal retirement remains fail-closed.
 `commitJobCredentialRuntimeRecovery` remains the sole owner `CommitID` reader.
 Default constructors, sandboxd, and command execution stay unwired.

--- a/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
+++ b/docs/design/sandbox-runtime-v2-l8-production-credential-delivery-architecture.md
@@ -942,13 +942,17 @@ tuple only as non-authoritative history and may move to `absent` only after a
 new exact direct Wait or double-`/proc` observation.
 
 `FinalizedCommitID` and `FinalizeTargetRevision` are empty/zero outside
-`finalizing` and `finalized`. After correlated L7 cleanup, Finalize computes the
-commit ID for the exact target revision, atomically persists `finalizing` with
-that ID and target first, then closes the retained namespace originals, and
-only then persists `finalized` at the exact target revision. Restart from
-`finalizing` verifies the HMAC and completed L7-cleanup intent, treats lost
-supervisor-owned namespace descriptors as closed, and retries only the final
-transition; it never returns a receipt from the intent record. The transition
+`finalizing` and `finalized`. Before correlated L7 cleanup, Finalize computes
+the commit ID for the exact target revision and atomically persists
+`finalizing` with that ID and target. It then performs the recovered
+`CleanupAfterVMQuiesced` and only then persists `finalized` at the
+exact target revision. Restart from `finalizing` verifies the HMAC and retries
+the cleanup while its exact journal remains. If cleanup already durably retired
+that journal, the exact private retired-generation marker, cryptographically
+bound to every L7 identity field, completes the retry without reopening
+topology or requiring a second successful Recover. Legacy, missing, malformed,
+or differently correlated state remains cleanup-incomplete. The
+intent record never returns a receipt. The transition
 to `finalized` persists the state, target revision, and commit ID before returning the same
 `CommitID` and `FinalizedRevision` in the worker receipt. A finalized record
 with an empty, malformed, or recomputation-mismatched commit ID is uncertain.
@@ -1340,7 +1344,11 @@ the binding, PID data, and termination proof ID are never worker or status
 metadata. D6 calls `CleanupAfterVMQuiesced` with that identity and binding. It
 accepts cleanup only after existing L7 recovery has quarantined the exact rule
 generation and positively removed the correlated proxy, rules, TAP, namespace,
-and topology journal. Finalize then persists `finalized` before returning. The
+and topology journal. Finalize persists `finalizing` before starting that
+cleanup and then persists `finalized` before returning. A retry from
+`finalizing` either resumes cleanup from the exact retained journal or accepts
+only its exact full-identity-bound durable retired-generation marker; it does
+not reopen a removed journal. The
 owner record is retired only by the later post-worker-clear commit and only
 after that call and all required L7 release/record operations succeed. Missing topology state,
 correlation mismatch, typed nil, panic, stale proof, cleanup error, or deadline

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/contracts.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/contracts.go
@@ -36,6 +36,9 @@ var (
 	ErrStaleTopologyUnverified = errors.New("Firecracker host topology stale state unverified")
 	ErrVMNotQuiesced           = errors.New("Firecracker VM is not confirmed quiesced")
 	ErrJournalNotFound         = errors.New("Firecracker host topology journal not found")
+	// ErrJournalRetired identifies the exact durable retired-generation marker.
+	// It is returned alone only after the marker lease was released cleanly.
+	ErrJournalRetired = errors.New("Firecracker host topology journal retired")
 )
 
 const defaultCleanupTimeout = 5 * time.Second

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/coordinator.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/coordinator.go
@@ -918,6 +918,8 @@ func sanitizeJournalAcquireError(err error) error {
 	switch {
 	case errors.Is(err, ErrTopologyCollision):
 		return ErrTopologyCollision
+	case errors.Is(err, ErrJournalRetired):
+		return ErrJournalRetired
 	case errors.Is(err, ErrStaleTopologyUnverified):
 		return ErrStaleTopologyUnverified
 	default:

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/import_boundary_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/import_boundary_test.go
@@ -52,7 +52,8 @@ func TestFirecrackerHostTopologyIsNotWiredIntoDefaultPaths(t *testing.T) {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
 			continue
 		}
-		if entry.Name() == "l7_runtime_controller.go" || entry.Name() == "l7_live_composition.go" {
+		if entry.Name() == "l7_runtime_controller.go" || entry.Name() == "l7_live_composition.go" ||
+			entry.Name() == "l8_runtime_owner_recovery.go" {
 			continue
 		}
 		payload, err := os.ReadFile(filepath.Join(parent, entry.Name()))

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/journal.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/journal.go
@@ -3,8 +3,10 @@ package l7network
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/netip"
@@ -16,6 +18,8 @@ import (
 const (
 	journalVersion = 2
 	journalLimit   = 64 << 10
+
+	journalRetiredMarkerDomain = "hal/l7-topology-journal-retired/v1"
 )
 
 type fileJournalStore struct{ root string }
@@ -80,9 +84,15 @@ func (s *fileJournalStore) Acquire(ctx context.Context, identity Identity) (Jour
 	}
 	lease := &fileJournalLease{identity: identity, dir: dir, path: filepath.Join(dir, "host-topology.json"), lock: lock}
 	retired := filepath.Join(dir, "retired-"+identity.TopologyGenerationID)
-	if marker, err := openPrivateFile(retired, os.O_RDONLY, 0o600); err == nil {
-		_ = marker.Close()
+	expectedMarker, err := journalRetiredMarker(identity)
+	if err != nil {
 		return releaseJournalAfterAcquireFailure(lease, ErrStaleTopologyUnverified)
+	}
+	if marker, err := readPrivateFile(retired, int64(len(expectedMarker))); err == nil {
+		if !bytes.Equal(marker, expectedMarker) {
+			return releaseJournalAfterAcquireFailure(lease, ErrStaleTopologyUnverified)
+		}
+		return releaseJournalAfterAcquireFailure(lease, errors.Join(ErrStaleTopologyUnverified, ErrJournalRetired))
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return releaseJournalAfterAcquireFailure(lease, ErrCleanupIncomplete)
 	}
@@ -149,7 +159,11 @@ func (l *fileJournalLease) Remove() error {
 		return ErrCleanupIncomplete
 	}
 	retired := filepath.Join(l.dir, "retired-"+l.identity.TopologyGenerationID)
-	if err := writePrivateAtomic(retired, []byte("retired\n")); err != nil {
+	marker, err := journalRetiredMarker(l.identity)
+	if err != nil {
+		return ErrCleanupIncomplete
+	}
+	if err := writePrivateAtomic(retired, marker); err != nil {
 		return ErrCleanupIncomplete
 	}
 	if err := os.Remove(l.path); err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -159,6 +173,20 @@ func (l *fileJournalLease) Remove() error {
 		return ErrCleanupIncomplete
 	}
 	return nil
+}
+
+func journalRetiredMarker(identity Identity) ([]byte, error) {
+	if !validIdentity(identity) {
+		return nil, ErrInvalidIdentity
+	}
+	payload, err := json.Marshal(identity)
+	if err != nil {
+		return nil, ErrInvalidIdentity
+	}
+	digest := sha256.New()
+	l7RecoveredWriteString(digest, journalRetiredMarkerDomain)
+	l7RecoveredWriteString(digest, string(payload))
+	return []byte(fmt.Sprintf("retired-v1:%x\n", digest.Sum(nil))), nil
 }
 
 func (l *fileJournalLease) Release() error {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/journal_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/journal_test.go
@@ -54,8 +54,42 @@ func TestFirecrackerHostTopologyJournalIsPrivateAtomicAndGenerationOwned(t *test
 	if err := lease.Release(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Acquire(context.Background(), testIdentity()); !errors.Is(err, ErrStaleTopologyUnverified) {
+	if _, err := store.Acquire(context.Background(), testIdentity()); !errors.Is(err, ErrStaleTopologyUnverified) || !errors.Is(err, ErrJournalRetired) {
 		t.Fatalf("retired generation Acquire() = %v", err)
+	}
+	sequence := &callSequence{}
+	reconciler, err := NewReconciler(ReconcilerOptions{
+		Recovery: &fakeRecoveryTopology{sequence: sequence, lifecycle: newFakeTopology(sequence)},
+		TAP:      &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+		VMTermination: NewRecoveredVMTerminationVerifier(), Journal: store,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session, err := reconciler.Recover(context.Background(), testIdentity()); session != nil || !errors.Is(err, ErrJournalRetired) {
+		t.Fatalf("retired generation Recover() = %T, %v", session, err)
+	}
+	if got := sequence.snapshot(); len(got) != 0 {
+		t.Fatalf("retired generation reopened live topology: %#v", got)
+	}
+	retired := filepath.Join(root, testIdentity().SandboxID, "retired-"+testIdentity().TopologyGenerationID)
+	mismatch := testIdentity()
+	mismatch.ExecutionID = "other-execution"
+	mismatchedMarker, err := journalRetiredMarker(mismatch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(retired, mismatchedMarker, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Acquire(context.Background(), testIdentity()); !errors.Is(err, ErrStaleTopologyUnverified) || errors.Is(err, ErrJournalRetired) {
+		t.Fatalf("mismatched identity marker Acquire() = %v", err)
+	}
+	if err := os.WriteFile(retired, []byte("retired\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Acquire(context.Background(), testIdentity()); !errors.Is(err, ErrStaleTopologyUnverified) || errors.Is(err, ErrJournalRetired) {
+		t.Fatalf("unbound legacy marker Acquire() = %v", err)
 	}
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovered_vm_termination.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovered_vm_termination.go
@@ -1,0 +1,132 @@
+package l7network
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement"
+)
+
+const recoveredVMTerminationProofDomain = "hal/l7-recovered-vm-termination/v1"
+
+// RecoveredVMTerminationObservation is independently reacquired Firecracker
+// absence correlated to a recovered L7 journal. PID values stay off this
+// struct so they cannot leak into worker or status metadata.
+type RecoveredVMTerminationObservation struct {
+	Identity             Identity
+	ProcessGeneration    string
+	SupervisorGeneration string
+	Stopped              bool
+	Reaped               bool
+}
+
+// recoveredVMTerminationBinding implements TerminatedVMBinding for daemon-restart
+// recovery. Same-process production trackers cannot be reacquired after restart.
+type recoveredVMTerminationBinding struct {
+	correlation networkenforcement.EnforcementCorrelation
+	proofID     string
+	stopped     bool
+	reaped      bool
+}
+
+func (binding *recoveredVMTerminationBinding) VMCorrelation() networkenforcement.EnforcementCorrelation {
+	if binding == nil {
+		return networkenforcement.EnforcementCorrelation{}
+	}
+	return binding.correlation
+}
+
+func (binding *recoveredVMTerminationBinding) VMTerminationProofID() string {
+	if binding == nil {
+		return ""
+	}
+	return binding.proofID
+}
+
+// NewRecoveredVMTerminationBinding constructs a private recovered
+// TerminatedVMBinding. Incomplete absence is still returned so the recovered
+// verifier can reject still-running or unreaped observations.
+func NewRecoveredVMTerminationBinding(observation RecoveredVMTerminationObservation) (TerminatedVMBinding, error) {
+	if !validIdentity(observation.Identity) {
+		return nil, ErrInvalidIdentity
+	}
+	proofID := recoveredVMTerminationProofID(observation)
+	if !safeIDPattern.MatchString(proofID) {
+		return nil, ErrInvalidIdentity
+	}
+	return &recoveredVMTerminationBinding{
+		correlation: correlation(observation.Identity),
+		proofID:     proofID,
+		stopped:     observation.Stopped,
+		reaped:      observation.Reaped,
+	}, nil
+}
+
+type recoveredVMTerminationVerifier struct{}
+
+// NewRecoveredVMTerminationVerifier accepts only recoveredVMTerminationBinding.
+func NewRecoveredVMTerminationVerifier() VMTerminationVerifier {
+	return recoveredVMTerminationVerifier{}
+}
+
+func (recoveredVMTerminationVerifier) VerifyVMTermination(_ context.Context, request VMTerminationRequest) (VMTerminationProof, error) {
+	binding, ok := request.Binding.(*recoveredVMTerminationBinding)
+	if !ok || binding == nil {
+		return VMTerminationProof{}, ErrVMNotQuiesced
+	}
+	if request.TerminationProofID != binding.proofID ||
+		!networkenforcement.EnforcementCorrelationsEqual(request.Correlation, binding.correlation) {
+		return VMTerminationProof{}, ErrIdentityMismatch
+	}
+	if !binding.stopped || !binding.reaped {
+		return VMTerminationProof{}, ErrVMNotQuiesced
+	}
+	proofID := recoveredVMTerminationVerifyID(binding)
+	if !safeIDPattern.MatchString(proofID) {
+		return VMTerminationProof{}, ErrVMNotQuiesced
+	}
+	return VMTerminationProof{
+		ID:                 proofID,
+		TerminationProofID: binding.proofID,
+		Correlation:        binding.correlation,
+		Stopped:            true,
+		Reaped:             true,
+	}, nil
+}
+
+func recoveredVMTerminationProofID(observation RecoveredVMTerminationObservation) string {
+	identity := observation.Identity
+	digest := sha256.New()
+	l7RecoveredWriteString(digest, recoveredVMTerminationProofDomain)
+	l7RecoveredWriteString(digest, identity.SandboxID)
+	l7RecoveredWriteString(digest, identity.ExecutionID)
+	l7RecoveredWriteString(digest, identity.WorkerID)
+	l7RecoveredWriteString(digest, identity.RuntimeGenerationID)
+	l7RecoveredWriteString(digest, identity.PlanID)
+	l7RecoveredWriteString(digest, identity.PolicySnapshotID)
+	l7RecoveredWriteString(digest, identity.ProxySessionID)
+	l7RecoveredWriteString(digest, identity.ProxyGenerationID)
+	l7RecoveredWriteString(digest, identity.TopologyGenerationID)
+	l7RecoveredWriteString(digest, identity.RuleGenerationID)
+	l7RecoveredWriteString(digest, observation.ProcessGeneration)
+	l7RecoveredWriteString(digest, observation.SupervisorGeneration)
+	return "recovered-" + hex.EncodeToString(digest.Sum(nil)[:16])
+}
+
+func recoveredVMTerminationVerifyID(binding *recoveredVMTerminationBinding) string {
+	if binding == nil {
+		return ""
+	}
+	digest := sha256.Sum256([]byte(recoveredVMTerminationProofDomain + "\x00vm\x00" + binding.proofID))
+	return "vm-" + hex.EncodeToString(digest[:16])
+}
+
+func l7RecoveredWriteString(digest hash.Hash, value string) {
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], uint32(len(value)))
+	_, _ = digest.Write(length[:])
+	_, _ = digest.Write([]byte(value))
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovered_vm_termination_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l7network/recovered_vm_termination_test.go
@@ -1,0 +1,163 @@
+package l7network
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/networkenforcement"
+)
+
+func TestRecoveredVMTerminationBindingRejectsMismatchAndIncompleteAbsence(t *testing.T) {
+	identity := testIdentity()
+	complete := RecoveredVMTerminationObservation{
+		Identity: identity, ProcessGeneration: "process-generation-a",
+		SupervisorGeneration: "supervisor-generation-a", Stopped: true, Reaped: true,
+	}
+	binding, err := NewRecoveredVMTerminationBinding(complete)
+	if err != nil || binding == nil || binding.VMTerminationProofID() == "" {
+		t.Fatalf("complete recovered binding = %T, %v", binding, err)
+	}
+	if !networkenforcement.EnforcementCorrelationsEqual(binding.VMCorrelation(), correlation(identity)) {
+		t.Fatalf("recovered correlation = %#v", binding.VMCorrelation())
+	}
+
+	invalid := complete
+	invalid.Identity.SandboxID = ""
+	if recovered, err := NewRecoveredVMTerminationBinding(invalid); recovered != nil || !errors.Is(err, ErrInvalidIdentity) {
+		t.Fatalf("invalid identity = %T, %v", recovered, err)
+	}
+
+	verifier := NewRecoveredVMTerminationVerifier()
+	request := VMTerminationRequest{
+		Correlation: correlation(identity), TerminationProofID: binding.VMTerminationProofID(), Binding: binding,
+	}
+	proof, err := verifier.VerifyVMTermination(context.Background(), request)
+	if err != nil || !proof.Stopped || !proof.Reaped || proof.TerminationProofID != binding.VMTerminationProofID() {
+		t.Fatalf("complete verify = %#v, %v", proof, err)
+	}
+
+	var typedNil *recoveredVMTerminationBinding
+	if _, err := verifier.VerifyVMTermination(context.Background(), VMTerminationRequest{
+		Correlation: request.Correlation, TerminationProofID: request.TerminationProofID, Binding: typedNil,
+	}); !errors.Is(err, ErrVMNotQuiesced) {
+		t.Fatalf("typed nil = %v", err)
+	}
+	if _, err := verifier.VerifyVMTermination(context.Background(), VMTerminationRequest{
+		Correlation: request.Correlation, TerminationProofID: request.TerminationProofID, Binding: testTerminatedVMBinding(),
+	}); !errors.Is(err, ErrVMNotQuiesced) {
+		t.Fatalf("foreign binding = %v", err)
+	}
+
+	mismatch := request
+	mismatch.Correlation.RuleGenerationID = "other-rule-generation"
+	if _, err := verifier.VerifyVMTermination(context.Background(), mismatch); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("identity mismatch = %v", err)
+	}
+	wrongProof := request
+	wrongProof.TerminationProofID = "recovered-ffffffffffffffffffffffffffffffff"
+	if _, err := verifier.VerifyVMTermination(context.Background(), wrongProof); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("proof mismatch = %v", err)
+	}
+
+	wrongGeneration := complete
+	wrongGeneration.Identity.RuleGenerationID = "other-rule-generation"
+	wrongBinding, err := NewRecoveredVMTerminationBinding(wrongGeneration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.VerifyVMTermination(context.Background(), VMTerminationRequest{
+		Correlation: correlation(identity), TerminationProofID: wrongBinding.VMTerminationProofID(), Binding: wrongBinding,
+	}); !errors.Is(err, ErrIdentityMismatch) {
+		t.Fatalf("wrong generation = %v", err)
+	}
+
+	running := complete
+	running.Stopped = false
+	runningBinding, err := NewRecoveredVMTerminationBinding(running)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.VerifyVMTermination(context.Background(), VMTerminationRequest{
+		Correlation: correlation(identity), TerminationProofID: runningBinding.VMTerminationProofID(), Binding: runningBinding,
+	}); !errors.Is(err, ErrVMNotQuiesced) {
+		t.Fatalf("still running = %v", err)
+	}
+
+	unreaped := complete
+	unreaped.Reaped = false
+	unreapedBinding, err := NewRecoveredVMTerminationBinding(unreaped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.VerifyVMTermination(context.Background(), VMTerminationRequest{
+		Correlation: correlation(identity), TerminationProofID: unreapedBinding.VMTerminationProofID(), Binding: unreapedBinding,
+	}); !errors.Is(err, ErrVMNotQuiesced) {
+		t.Fatalf("unreaped = %v", err)
+	}
+}
+
+func TestRecoveredVMTerminationBindingDrivesCleanupAfterVMQuiesced(t *testing.T) {
+	sequence := &callSequence{}
+	identity := testIdentity()
+	spec := staticTAPSpec(identity, netip.MustParseAddr("192.0.2.2"), 43123)
+	record := journalRecord{identity: identity, stage: journalStageInspected, tapName: spec.name,
+		tapFingerprint: spec.fingerprint(), tapIfIndex: 41, ruleDigest: "old-rule-digest",
+		proxyAddress: spec.proxyAddress.String(), proxyPort: spec.proxyPort}
+	journal := &loadedJournalStore{sequence: sequence, record: record}
+	topology := newFakeTopology(sequence)
+	recovery := &fakeRecoveryTopology{sequence: sequence, lifecycle: topology}
+	reconciler, err := NewReconciler(ReconcilerOptions{
+		Recovery: recovery, TAP: &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+		VMTermination: NewRecoveredVMTerminationVerifier(), Journal: journal, CleanupTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := reconciler.Recover(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sequence.reset()
+	binding, err := NewRecoveredVMTerminationBinding(RecoveredVMTerminationObservation{
+		Identity: identity, ProcessGeneration: "process-generation-a",
+		SupervisorGeneration: "supervisor-generation-a", Stopped: true, Reaped: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := session.CleanupAfterVMQuiesced(context.Background(), identity, binding); err != nil {
+		t.Fatal(err)
+	}
+	assertSubsequence(t, sequence.snapshot(), []string{"rules_cleanup", "tap_delete", "topology_stop", "journal_remove", "journal_release"})
+}
+
+func TestRecoveredVMTerminationVerifierRejectsForeignBindingBeforeCleanupMutation(t *testing.T) {
+	sequence := &callSequence{}
+	identity := testIdentity()
+	spec := staticTAPSpec(identity, netip.MustParseAddr("192.0.2.2"), 43123)
+	record := journalRecord{identity: identity, stage: journalStageInspected, tapName: spec.name,
+		tapFingerprint: spec.fingerprint(), tapIfIndex: 41, proxyAddress: spec.proxyAddress.String(), proxyPort: spec.proxyPort}
+	reconciler, err := NewReconciler(ReconcilerOptions{
+		Recovery: &fakeRecoveryTopology{sequence: sequence, lifecycle: newFakeTopology(sequence)},
+		TAP:      &fakeTAP{sequence: sequence}, Rules: &fakeRules{sequence: sequence},
+		VMTermination: NewRecoveredVMTerminationVerifier(),
+		Journal:       &loadedJournalStore{sequence: sequence, record: record},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := reconciler.Recover(context.Background(), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sequence.reset()
+	if err := session.CleanupAfterVMQuiesced(context.Background(), identity, testTerminatedVMBinding()); !errors.Is(err, ErrVMNotQuiesced) {
+		t.Fatalf("foreign binding cleanup = %v", err)
+	}
+	if got := sequence.snapshot(); len(got) != 0 {
+		t.Fatalf("foreign binding mutated recovered cleanup: %#v", got)
+	}
+}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -258,22 +258,6 @@ func (binding *l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecove
 		err = errL8RuntimeOwnerInvalid
 		return
 	}
-	identity := l8RuntimeOwnerL7Identity(seed)
-	terminated, bindErr := l7network.NewRecoveredVMTerminationBinding(l7network.RecoveredVMTerminationObservation{
-		Identity:             identity,
-		ProcessGeneration:    seed.FirecrackerProcessGeneration,
-		SupervisorGeneration: record.SupervisorGeneration,
-		Stopped:              true,
-		Reaped:               true,
-	})
-	if bindErr != nil || terminated == nil {
-		err = errL8RuntimeOwnerInvalid
-		return
-	}
-	if cleanupErr := l8RuntimeOwnerCleanupAfterVMQuiesced(ctx, identity, terminated, recoverNetwork, l7Options); cleanupErr != nil || ctx.Err() != nil {
-		err = errL8RuntimeOwnerInvalid
-		return
-	}
 	digest, digestErr := l8RuntimeOwnerSeedDigest(seed)
 	if digestErr != nil {
 		err = errL8RuntimeOwnerInvalid
@@ -288,7 +272,28 @@ func (binding *l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecove
 		err = errL8RuntimeOwnerInvalid
 		return
 	}
-	stored, persistErr := persistL8RuntimeOwnerFinalized(ctx, store, record, commitID, targetRevision)
+	finalizing, persistErr := persistL8RuntimeOwnerFinalizing(ctx, store, record, commitID, targetRevision)
+	if persistErr != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	identity := l8RuntimeOwnerL7Identity(seed)
+	terminated, bindErr := l7network.NewRecoveredVMTerminationBinding(l7network.RecoveredVMTerminationObservation{
+		Identity:             identity,
+		ProcessGeneration:    seed.FirecrackerProcessGeneration,
+		SupervisorGeneration: finalizing.SupervisorGeneration,
+		Stopped:              true,
+		Reaped:               true,
+	})
+	if bindErr != nil || terminated == nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	if cleanupErr := l8RuntimeOwnerCleanupAfterVMQuiesced(ctx, identity, terminated, recoverNetwork, l7Options); (cleanupErr != nil && cleanupErr != l7network.ErrJournalRetired) || ctx.Err() != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	stored, persistErr := persistL8RuntimeOwnerFinalized(ctx, store, finalizing, commitID, targetRevision)
 	if persistErr != nil {
 		err = errL8RuntimeOwnerInvalid
 		return
@@ -335,13 +340,16 @@ func l8RuntimeOwnerCleanupAfterVMQuiesced(
 		return err
 	}
 	session, err := reconciler.Recover(ctx, identity)
+	if session == nil && err == l7network.ErrJournalRetired {
+		return l7network.ErrJournalRetired
+	}
 	if err != nil || session == nil {
 		return errL8RuntimeOwnerInvalid
 	}
 	return session.CleanupAfterVMQuiesced(ctx, identity, terminated)
 }
 
-func persistL8RuntimeOwnerFinalized(ctx context.Context, store l8RuntimeOwnerRecordStore, record firecrackerRuntimeOwnerRecordV1, commitID string, targetRevision uint64) (firecrackerRuntimeOwnerRecordV1, error) {
+func persistL8RuntimeOwnerFinalizing(ctx context.Context, store l8RuntimeOwnerRecordStore, record firecrackerRuntimeOwnerRecordV1, commitID string, targetRevision uint64) (firecrackerRuntimeOwnerRecordV1, error) {
 	if store == nil || !validL8RuntimeOwnerToken(commitID) || targetRevision == 0 {
 		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 	}
@@ -360,6 +368,15 @@ func persistL8RuntimeOwnerFinalized(ctx context.Context, store l8RuntimeOwnerRec
 		current = next
 	}
 	if current.State != "finalizing" || current.FinalizeTargetRevision != targetRevision ||
+		subtle.ConstantTimeCompare([]byte(current.FinalizedCommitID), []byte(commitID)) != 1 {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	return current, nil
+}
+
+func persistL8RuntimeOwnerFinalized(ctx context.Context, store l8RuntimeOwnerRecordStore, current firecrackerRuntimeOwnerRecordV1, commitID string, targetRevision uint64) (firecrackerRuntimeOwnerRecordV1, error) {
+	if store == nil || current.State != "finalizing" || current.FinalizeTargetRevision != targetRevision ||
+		!validL8RuntimeOwnerToken(commitID) || targetRevision == 0 ||
 		subtle.ConstantTimeCompare([]byte(current.FinalizedCommitID), []byte(commitID)) != 1 {
 		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
 	}

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost/l7network"
 )
 
 const (
@@ -72,8 +73,9 @@ type firecrackerRuntimeOwnerRecordV1 struct {
 
 // l8RuntimeOwnerRecoveryBinding is the seed-bound Firecracker runtime-owner
 // recovery binding. Stop/reap is the sole production issuer of
-// sandboxruntime.NewJobCredentialRuntimeAbsenceProof. Finalize fail-closes
-// without a recovered l7network.TerminatedVMBinding constructor.
+// sandboxruntime.NewJobCredentialRuntimeAbsenceProof. Finalize constructs a
+// recovered L7 VM-termination binding and persists finalized only after
+// same-boot CleanupAfterVMQuiesced.
 type l8RuntimeOwnerRecoveryBinding struct {
 	mu                 sync.Mutex
 	seed               sandboxruntime.JobCredentialIdentitySeed
@@ -83,6 +85,8 @@ type l8RuntimeOwnerRecoveryBinding struct {
 	recoverCredentials func(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error)
 	currentBootID      func() (string, error)
 	now                func() time.Time
+	recoverNetwork     func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error
+	l7Reconciler       l7network.ReconcilerOptions
 	closed             bool
 	commitOnly         bool
 }
@@ -191,6 +195,7 @@ func (binding *l8RuntimeOwnerRecoveryBinding) StopReapJobCredentialRuntime(ctx c
 func (binding *l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecovery(ctx context.Context, proof sandboxruntime.JobCredentialRuntimeAbsenceProof) (receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt, err error) {
 	defer func() {
 		if recover() != nil {
+			receipt = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}
 			err = errL8RuntimeOwnerInvalid
 		}
 	}()
@@ -212,6 +217,9 @@ func (binding *l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecove
 	store := binding.store
 	nowFn := binding.now
 	bootFn := binding.currentBootID
+	key := binding.commitKey
+	recoverNetwork := binding.recoverNetwork
+	l7Options := binding.l7Reconciler
 	binding.mu.Unlock()
 	now := time.Now().UTC()
 	if nowFn != nil {
@@ -226,15 +234,146 @@ func (binding *l8RuntimeOwnerRecoveryBinding) FinalizeJobCredentialRuntimeRecove
 		err = errL8RuntimeOwnerInvalid
 		return
 	}
-	if bootFn != nil {
-		bootID, bootErr := bootFn()
-		if bootErr != nil || bootID != record.HostBootID {
-			err = errL8RuntimeOwnerInvalid
-			return
-		}
+	if bootFn == nil {
+		err = errL8RuntimeOwnerInvalid
+		return
 	}
-	err = errL8RuntimeOwnerInvalid
+	bootID, bootErr := bootFn()
+	if bootErr != nil || bootID != record.HostBootID || validateFirecrackerRuntimeOwnerRecordV1(record, seed, bootID) != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	if record.State == "finalized" {
+		receipt = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{
+			CommitID:          record.FinalizedCommitID,
+			FinalizedRevision: record.FinalizeTargetRevision,
+		}
+		if commitJobCredentialRuntimeRecovery(receipt, key, seed, record.FinalizeTargetRevision, record.FinalizedCommitID) != nil {
+			receipt = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}
+			err = errL8RuntimeOwnerInvalid
+		}
+		return
+	}
+	if record.ControllerState != "controlled" || ctx.Err() != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	identity := l8RuntimeOwnerL7Identity(seed)
+	terminated, bindErr := l7network.NewRecoveredVMTerminationBinding(l7network.RecoveredVMTerminationObservation{
+		Identity:             identity,
+		ProcessGeneration:    seed.FirecrackerProcessGeneration,
+		SupervisorGeneration: record.SupervisorGeneration,
+		Stopped:              true,
+		Reaped:               true,
+	})
+	if bindErr != nil || terminated == nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	if cleanupErr := l8RuntimeOwnerCleanupAfterVMQuiesced(ctx, identity, terminated, recoverNetwork, l7Options); cleanupErr != nil || ctx.Err() != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	digest, digestErr := l8RuntimeOwnerSeedDigest(seed)
+	if digestErr != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	targetRevision := record.Revision + 2
+	if record.State == "finalizing" {
+		targetRevision = record.FinalizeTargetRevision
+	}
+	commitID, commitErr := l8RuntimeOwnerCommitID(key, digest, targetRevision)
+	if commitErr != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	stored, persistErr := persistL8RuntimeOwnerFinalized(ctx, store, record, commitID, targetRevision)
+	if persistErr != nil {
+		err = errL8RuntimeOwnerInvalid
+		return
+	}
+	receipt = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{
+		CommitID:          stored.FinalizedCommitID,
+		FinalizedRevision: stored.FinalizeTargetRevision,
+	}
+	if commitJobCredentialRuntimeRecovery(receipt, key, seed, stored.FinalizeTargetRevision, stored.FinalizedCommitID) != nil {
+		receipt = sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}
+		err = errL8RuntimeOwnerInvalid
+	}
 	return
+}
+
+func l8RuntimeOwnerL7Identity(seed sandboxruntime.JobCredentialIdentitySeed) l7network.Identity {
+	return l7network.Identity{
+		SandboxID:            seed.SandboxID,
+		ExecutionID:          seed.ExecutionID,
+		WorkerID:             seed.WorkerID,
+		RuntimeGenerationID:  seed.RuntimeGeneration,
+		PlanID:               seed.NetworkPlanID,
+		PolicySnapshotID:     seed.PolicySnapshotID,
+		ProxySessionID:       seed.ProxySessionID,
+		ProxyGenerationID:    seed.ProxyGenerationID,
+		TopologyGenerationID: seed.TopologyGenerationID,
+		RuleGenerationID:     seed.RuleGenerationID,
+	}
+}
+
+func l8RuntimeOwnerCleanupAfterVMQuiesced(
+	ctx context.Context,
+	identity l7network.Identity,
+	terminated l7network.TerminatedVMBinding,
+	recoverNetwork func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error,
+	options l7network.ReconcilerOptions,
+) error {
+	if recoverNetwork != nil {
+		return recoverNetwork(ctx, identity, terminated)
+	}
+	options.VMTermination = l7network.NewRecoveredVMTerminationVerifier()
+	reconciler, err := l7network.NewReconciler(options)
+	if err != nil {
+		return err
+	}
+	session, err := reconciler.Recover(ctx, identity)
+	if err != nil || session == nil {
+		return errL8RuntimeOwnerInvalid
+	}
+	return session.CleanupAfterVMQuiesced(ctx, identity, terminated)
+}
+
+func persistL8RuntimeOwnerFinalized(ctx context.Context, store l8RuntimeOwnerRecordStore, record firecrackerRuntimeOwnerRecordV1, commitID string, targetRevision uint64) (firecrackerRuntimeOwnerRecordV1, error) {
+	if store == nil || !validL8RuntimeOwnerToken(commitID) || targetRevision == 0 {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	current := record
+	if current.State == "absent" {
+		finalizing := current
+		finalizing.Revision = current.Revision + 1
+		finalizing.State = "finalizing"
+		finalizing.ControllerState = "controlled"
+		finalizing.FinalizedCommitID = commitID
+		finalizing.FinalizeTargetRevision = targetRevision
+		next, err := store.Transition(ctx, current.Revision, finalizing)
+		if err != nil {
+			return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+		}
+		current = next
+	}
+	if current.State != "finalizing" || current.FinalizeTargetRevision != targetRevision ||
+		subtle.ConstantTimeCompare([]byte(current.FinalizedCommitID), []byte(commitID)) != 1 {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	finalized := current
+	finalized.Revision = current.Revision + 1
+	finalized.State = "finalized"
+	finalized.ControllerState = "controlled"
+	finalized.FinalizedCommitID = current.FinalizedCommitID
+	finalized.FinalizeTargetRevision = current.FinalizeTargetRevision
+	stored, err := store.Transition(ctx, current.Revision, finalized)
+	if err != nil {
+		return firecrackerRuntimeOwnerRecordV1{}, errL8RuntimeOwnerInvalid
+	}
+	return stored, nil
 }
 
 func (binding *l8RuntimeOwnerRecoveryBinding) CommitJobCredentialRuntimeRecovery(ctx context.Context, receipt sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt) (err error) {

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jywlabs/hal/internal/sandboxruntime"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost/l7network"
 )
 
 func TestL8RuntimeOwnerRecoveryBindingSatisfiesInterface(t *testing.T) {
@@ -220,6 +221,109 @@ func TestL8RuntimeOwnerRecoveryBindingFinalizeFailClosesWithoutRecoveredL7Bindin
 	}
 	if store.record.State != "absent" {
 		t.Fatalf("old-boot retired state: %#v", store.record)
+	}
+
+	loadErr := &l8RuntimeOwnerRecoveryBinding{
+		seed: seed, commitKey: bytes32("0123456789abcdef0123456789abcdef"),
+		store: l8RuntimeOwnerMissingStore{}, now: func() time.Time { return now },
+		currentBootID: func() (string, error) { return record.HostBootID, nil },
+		recoverNetwork: func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error {
+			t.Fatal("load error must not be treated as absence")
+			return nil
+		},
+	}
+	if receipt, err := loadErr.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof); receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("load-error finalize = %#v, %v", receipt, err)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingFinalizePersistsFinalizedAfterSameBootCleanup(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	now := seed.IssuedAt.Add(time.Minute)
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState = "absent", "controlled"
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, nil)
+	binding.now = func() time.Time { return now }
+	var cleaned l7network.Identity
+	var cleanedBinding l7network.TerminatedVMBinding
+	cleanupCalls := 0
+	binding.recoverNetwork = func(_ context.Context, identity l7network.Identity, terminated l7network.TerminatedVMBinding) error {
+		cleanupCalls++
+		cleaned = identity
+		cleanedBinding = terminated
+		return nil
+	}
+	proof, err := sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{
+		Seed: seed, AbsenceInspectedAt: seed.IssuedAt.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof)
+	if err != nil {
+		t.Fatalf("finalize: %v", err)
+	}
+	if store.record.State != "finalized" || store.retiredFinal || cleanupCalls != 1 {
+		t.Fatalf("finalize state = %#v retired %t cleanup %d", store.record, store.retiredFinal, cleanupCalls)
+	}
+	if len(store.transitions) != 2 || store.transitions[0].State != "finalizing" || store.transitions[1].State != "finalized" {
+		t.Fatalf("finalize transitions = %#v", store.transitions)
+	}
+	if cleaned != l8RuntimeOwnerL7Identity(seed) || cleanedBinding == nil || cleanedBinding.VMTerminationProofID() == "" {
+		t.Fatalf("cleanup identity/binding = %#v %T", cleaned, cleanedBinding)
+	}
+	if err := sandboxruntime.ValidateJobCredentialRuntimeRecoveryCommitReceipt(receipt); err != nil {
+		t.Fatalf("receipt: %v", err)
+	}
+	if commitJobCredentialRuntimeRecovery(receipt, binding.commitKey, seed, store.record.FinalizeTargetRevision, store.record.FinalizedCommitID) != nil {
+		t.Fatal("receipt HMAC is not bound to the stored commit ID")
+	}
+	if err := binding.CommitJobCredentialRuntimeRecovery(context.Background(), receipt); err != nil {
+		t.Fatalf("commit after finalize: %v", err)
+	}
+	if !store.retiredFinal {
+		t.Fatal("commit did not retire finalized record")
+	}
+
+	store.retiredFinal = false
+	store.record.State, store.record.ControllerState = "finalized", "controlled"
+	again, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof)
+	if err != nil || cleanupCalls != 1 {
+		t.Fatalf("idempotent finalize: %v cleanup %d", err, cleanupCalls)
+	}
+	if commitJobCredentialRuntimeRecovery(again, binding.commitKey, seed, store.record.FinalizeTargetRevision, store.record.FinalizedCommitID) != nil {
+		t.Fatal("idempotent receipt is not bound to the stored commit ID")
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingFinalizeFailClosesWhenCleanupIncomplete(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	now := seed.IssuedAt.Add(time.Minute)
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState = "absent", "controlled"
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, nil)
+	binding.now = func() time.Time { return now }
+	binding.recoverNetwork = func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error {
+		return l7network.ErrCleanupIncomplete
+	}
+	proof, err := sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{
+		Seed: seed, AbsenceInspectedAt: seed.IssuedAt.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof)
+	if receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("incomplete cleanup finalize = %#v, %v", receipt, err)
+	}
+	if store.record.State != "absent" || store.retiredFinal {
+		t.Fatalf("incomplete cleanup mutated owner state: %#v retired %t", store.record, store.retiredFinal)
 	}
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_runtime_owner_recovery_binding_test.go
@@ -203,8 +203,8 @@ func TestL8RuntimeOwnerRecoveryBindingFinalizeFailClosesWithoutRecoveredL7Bindin
 	if receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("finalize without recovered L7 = %#v, %v", receipt, err)
 	}
-	if store.record.State != "absent" {
-		t.Fatalf("finalize persisted tombstone without L7: %#v", store.record)
+	if store.record.State != "finalizing" || len(store.transitions) != 1 {
+		t.Fatalf("finalize did not retain durable cleanup intent without L7: %#v", store.record)
 	}
 
 	stale := proof
@@ -219,7 +219,7 @@ func TestL8RuntimeOwnerRecoveryBindingFinalizeFailClosesWithoutRecoveredL7Bindin
 	if _, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof); !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("old-boot finalize = %v", err)
 	}
-	if store.record.State != "absent" {
+	if store.record.State != "finalizing" {
 		t.Fatalf("old-boot retired state: %#v", store.record)
 	}
 
@@ -252,6 +252,9 @@ func TestL8RuntimeOwnerRecoveryBindingFinalizePersistsFinalizedAfterSameBootClea
 	cleanupCalls := 0
 	binding.recoverNetwork = func(_ context.Context, identity l7network.Identity, terminated l7network.TerminatedVMBinding) error {
 		cleanupCalls++
+		if store.record.State != "finalizing" || len(store.transitions) != 1 || store.transitions[0].State != "finalizing" {
+			t.Fatalf("cleanup ran before durable finalizing intent: %#v", store.record)
+		}
 		cleaned = identity
 		cleanedBinding = terminated
 		return nil
@@ -322,8 +325,68 @@ func TestL8RuntimeOwnerRecoveryBindingFinalizeFailClosesWhenCleanupIncomplete(t 
 	if receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
 		t.Fatalf("incomplete cleanup finalize = %#v, %v", receipt, err)
 	}
-	if store.record.State != "absent" || store.retiredFinal {
+	if store.record.State != "finalizing" || store.retiredFinal || len(store.transitions) != 1 || store.transitions[0].State != "finalizing" {
 		t.Fatalf("incomplete cleanup mutated owner state: %#v retired %t", store.record, store.retiredFinal)
+	}
+}
+
+func TestL8RuntimeOwnerRecoveryBindingFinalizeRetriesRetiredL7JournalFromFinalizing(t *testing.T) {
+	if !l8RuntimeOwnerPlatformSupported() {
+		t.Skip("Linux-only recovery binding")
+	}
+	seed := l8RuntimeOwnerTestSeed()
+	now := seed.IssuedAt.Add(time.Minute)
+	record := l8RuntimeOwnerTestRecord(t, seed, "01234567-89ab-cdef-0123-456789abcdef")
+	record.State, record.ControllerState = "absent", "controlled"
+	binding, store := l8RuntimeOwnerTestRecoveryBinding(t, record, nil)
+	binding.now = func() time.Time { return now }
+	cleanupCalls := 0
+	binding.recoverNetwork = func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error {
+		cleanupCalls++
+		if store.record.State != "finalizing" {
+			t.Fatalf("cleanup observed owner state %q, want finalizing", store.record.State)
+		}
+		return l7network.ErrCleanupIncomplete
+	}
+	proof, err := sandboxruntime.NewJobCredentialRuntimeAbsenceProof(sandboxruntime.JobCredentialRuntimeAbsenceProofInput{
+		Seed: seed, AbsenceInspectedAt: seed.IssuedAt.Add(time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof); receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("interrupted finalize = %#v, %v", receipt, err)
+	}
+	if store.record.State != "finalizing" || len(store.transitions) != 1 {
+		t.Fatalf("interrupted finalize state = %#v transitions %#v", store.record, store.transitions)
+	}
+	commitID := store.record.FinalizedCommitID
+	targetRevision := store.record.FinalizeTargetRevision
+	binding.recoverNetwork = func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error {
+		cleanupCalls++
+		return errors.Join(l7network.ErrJournalRetired, l7network.ErrCleanupIncomplete)
+	}
+	if receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof); receipt != (sandboxruntime.JobCredentialRuntimeRecoveryCommitReceipt{}) || !errors.Is(err, errL8RuntimeOwnerInvalid) {
+		t.Fatalf("retired marker with incomplete release = %#v, %v", receipt, err)
+	}
+	if store.record.State != "finalizing" || len(store.transitions) != 1 {
+		t.Fatalf("incomplete retired-marker retry state = %#v transitions %#v", store.record, store.transitions)
+	}
+	binding.recoverNetwork = func(context.Context, l7network.Identity, l7network.TerminatedVMBinding) error {
+		cleanupCalls++
+		return l7network.ErrJournalRetired
+	}
+	receipt, err := binding.FinalizeJobCredentialRuntimeRecovery(context.Background(), proof)
+	if err != nil {
+		t.Fatalf("retry after retired L7 journal: %v", err)
+	}
+	if cleanupCalls != 3 || store.record.State != "finalized" || len(store.transitions) != 2 ||
+		store.record.FinalizedCommitID != commitID || store.record.FinalizeTargetRevision != targetRevision {
+		t.Fatalf("retry state = %#v calls %d transitions %#v", store.record, cleanupCalls, store.transitions)
+	}
+	if receipt.CommitID != commitID || receipt.FinalizedRevision != targetRevision ||
+		commitJobCredentialRuntimeRecovery(receipt, binding.commitKey, seed, targetRevision, commitID) != nil {
+		t.Fatalf("retry receipt = %#v", receipt)
 	}
 }
 


### PR DESCRIPTION
## Summary
Recovered L7 `TerminatedVMBinding` for daemon-restart (`l7network.NewRecoveredVMTerminationBinding`), distinct from same-process `productionL7TerminatedVMBinding`. `FinalizeJobCredentialRuntimeRecovery` now runs seed-derived `CleanupAfterVMQuiesced` and two-phase persists `finalizing` then `finalized`. Receipt HMAC is bound to the stored commit ID. StopReap remains the sole production absence-proof issuer. Old-boot journal retirement stays fail-closed.

Stacked on #49.

## Default-off / non-goals
- No old-boot journal retirement API.
- Production still needs a supervisor-retained L7 session factory; missing topology fail-closes.
- No sandboxd/run/auto/factory wiring. No D7/L10/L11.

## Tests
- `go test ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner' -count=1`
- `go test ./internal/sandboxruntime/microvm/firecrackerhost/l7network -count=1`
- `go test ./cmd -run '^TestL8D6RuntimeOwner' -count=1`
- `go test -count=20 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner'`
- `go test -race -count=5 ./internal/sandboxruntime/microvm/firecrackerhost -run '^TestL8RuntimeOwner'`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.