### PR TITLE
feat: US-049 - L8 PID1 guest-init start-gate (honest RED sealed digest)

### DIFF
--- a/cmd/hal-guest-init/main_linux.go
+++ b/cmd/hal-guest-init/main_linux.go
@@ -51,6 +51,9 @@ func run(arguments []string) int {
 		}
 		childEnvironment = l7NetworkBootstrapEnvironment(network)
 	}
+	if code := releasePID1AgentStartGate(); code != 0 {
+		return code
+	}
 	signals := make(chan os.Signal, 32)
 	signal.Notify(signals, syscall.SIGCHLD, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP, syscall.SIGQUIT)
 	defer signal.Stop(signals)

--- a/cmd/hal-guest-init/pid1_start_gate_linux.go
+++ b/cmd/hal-guest-init/pid1_start_gate_linux.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package main
+
+import "github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/l8composition"
+
+// loadPID1StartGateExpected would snapshot sealed image-profile helper, client,
+// and composition digests. This binary has no compiled-in or inherited sealed
+// digest channel; unsigned file/env/cmdline reads are rejected.
+func loadPID1StartGateExpected() (l8composition.PID1StartGateExpected, bool, error) {
+	return l8composition.PID1StartGateExpected{}, false, nil
+}
+
+// releasePID1AgentStartGate admits helper-then-client descriptors before the
+// L7 child start. Missing sealed expected leaves the L7 supervisor path;
+// a claimed expected without authenticated descriptors fails closed.
+func releasePID1AgentStartGate() int {
+	_, present, err := loadPID1StartGateExpected()
+	if err != nil {
+		return 127
+	}
+	if !present {
+		return 0
+	}
+	return 127
+}
+
+// admitPID1StartGate is the exact helper-then-client start-gate. Tests inject
+// sealed expected plus descriptors; PID1 never constructs helper or client.
+func admitPID1StartGate(
+	expected l8composition.PID1StartGateExpected,
+	helper l8composition.ProcessDescriptor,
+	client l8composition.ProcessDescriptor,
+) int {
+	state, err := l8composition.NewPID1StartGateState(expected)
+	if err != nil {
+		return 127
+	}
+	decision, err := state.AcceptHelperDescriptor(helper)
+	if err != nil || decision != l8composition.PID1StartGateDecisionContinue {
+		return 127
+	}
+	decision, err = state.AcceptClientDescriptor(client)
+	if err != nil || decision != l8composition.PID1StartGateDecisionRelease {
+		return 127
+	}
+	return 0
+}

--- a/cmd/hal-guest-init/pid1_start_gate_linux_test.go
+++ b/cmd/hal-guest-init/pid1_start_gate_linux_test.go
@@ -1,0 +1,206 @@
+//go:build linux
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
+	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/l8composition"
+)
+
+func TestL8PID1StartGateAdmitsHelperThenClientBeforeRelease(t *testing.T) {
+	fixture := newPID1GuestInitStartGateFixture(t)
+	if code := admitPID1StartGate(fixture.expected, fixture.helper, fixture.client); code != 0 {
+		t.Fatalf("admitPID1StartGate() = %d, want 0", code)
+	}
+}
+
+func TestL8PID1StartGateFailsClosedOnZeroAliasMismatchAndOrder(t *testing.T) {
+	fixture := newPID1GuestInitStartGateFixture(t)
+	tests := []struct {
+		name     string
+		expected l8composition.PID1StartGateExpected
+		helper   l8composition.ProcessDescriptor
+		client   l8composition.ProcessDescriptor
+	}{
+		{
+			name: "zero helper digest",
+			expected: l8composition.PID1StartGateExpected{
+				ClientDescriptorSHA256: fixture.expected.ClientDescriptorSHA256,
+				CompositionSHA256:      fixture.expected.CompositionSHA256,
+			},
+			helper: fixture.helper,
+			client: fixture.client,
+		},
+		{
+			name: "zero client digest",
+			expected: l8composition.PID1StartGateExpected{
+				HelperDescriptorSHA256: fixture.expected.HelperDescriptorSHA256,
+				CompositionSHA256:      fixture.expected.CompositionSHA256,
+			},
+			helper: fixture.helper,
+			client: fixture.client,
+		},
+		{
+			name: "zero composition digest",
+			expected: l8composition.PID1StartGateExpected{
+				HelperDescriptorSHA256: fixture.expected.HelperDescriptorSHA256,
+				ClientDescriptorSHA256: fixture.expected.ClientDescriptorSHA256,
+			},
+			helper: fixture.helper,
+			client: fixture.client,
+		},
+		{
+			name: "aliased helper and client digests",
+			expected: l8composition.PID1StartGateExpected{
+				HelperDescriptorSHA256: fixture.expected.ClientDescriptorSHA256,
+				ClientDescriptorSHA256: fixture.expected.ClientDescriptorSHA256,
+				CompositionSHA256:      fixture.expected.CompositionSHA256,
+			},
+			helper: fixture.helper,
+			client: fixture.client,
+		},
+		{
+			name:     "client descriptor supplied as helper",
+			expected: fixture.expected,
+			helper:   fixture.client,
+			client:   fixture.helper,
+		},
+		{
+			name:     "helper digest mismatch",
+			expected: fixture.expected,
+			helper:   xorPID1DescriptorPolicy(fixture.helper),
+			client:   fixture.client,
+		},
+		{
+			name:     "client digest mismatch",
+			expected: fixture.expected,
+			helper:   fixture.helper,
+			client:   xorPID1DescriptorPolicy(fixture.client),
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			if code := admitPID1StartGate(test.expected, test.helper, test.client); code != 127 {
+				t.Fatalf("admitPID1StartGate() = %d, want 127", code)
+			}
+		})
+	}
+}
+
+func TestL8PID1StartGateSealedExpectedChannelIsMissing(t *testing.T) {
+	expected, present, err := loadPID1StartGateExpected()
+	if err != nil || present || expected != (l8composition.PID1StartGateExpected{}) {
+		t.Fatalf("loadPID1StartGateExpected() = %#v, %t, %v, want absent sealed expected", expected, present, err)
+	}
+	if code := releasePID1AgentStartGate(); code != 0 {
+		t.Fatalf("releasePID1AgentStartGate() = %d, want L7 supervisor continue", code)
+	}
+
+	source, err := os.ReadFile("pid1_start_gate_linux.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	for _, forbidden := range []string{
+		"go:embed",
+		"os.Getenv",
+		"os.ReadFile",
+		"os.Open",
+		"/proc/cmdline",
+		"hal_l8_",
+		"json.Unmarshal",
+		"l8composition.NewHelper",
+		"l8composition.NewClient",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("PID1 start-gate loader contains unsigned or live marker %q", forbidden)
+		}
+	}
+	for _, required := range []string{
+		"l8composition.NewPID1StartGateState",
+		"AcceptHelperDescriptor",
+		"AcceptClientDescriptor",
+	} {
+		if !strings.Contains(text, required) {
+			t.Errorf("PID1 start-gate omits %q", required)
+		}
+	}
+}
+
+func TestL8PID1GuestInitReleasesStartGateBeforeChildStart(t *testing.T) {
+	source, err := os.ReadFile("main_linux.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(source)
+	gate := strings.Index(text, "releasePID1AgentStartGate()")
+	child := strings.Index(text, "os.StartProcess(")
+	if gate < 0 || child < 0 || gate > child {
+		t.Fatal("PID1 must consult the start-gate before os.StartProcess")
+	}
+	if !strings.Contains(text, requireL7NetworkArgument) {
+		t.Fatal("L7 --require-l7-network argument was removed")
+	}
+}
+
+type pid1GuestInitStartGateFixture struct {
+	helper   l8composition.ProcessDescriptor
+	client   l8composition.ProcessDescriptor
+	expected l8composition.PID1StartGateExpected
+}
+
+func newPID1GuestInitStartGateFixture(t *testing.T) pid1GuestInitStartGateFixture {
+	t.Helper()
+	ssh := []credentialprotocol.ExtensionDescriptor{credentialprotocol.SSHRelayV1ExtensionDescriptor()}
+	helper := pid1CanonicalDescriptor(t, l8composition.ProcessRoleHelper, ssh)
+	client := pid1CanonicalDescriptor(t, l8composition.ProcessRoleClient, ssh)
+	composition, err := l8composition.ValidateProcessDescriptors(helper, client)
+	if err != nil {
+		t.Fatalf("ValidateProcessDescriptors() error = %v", err)
+	}
+	return pid1GuestInitStartGateFixture{
+		helper: helper,
+		client: client,
+		expected: l8composition.PID1StartGateExpected{
+			HelperDescriptorSHA256: composition.HelperSHA256,
+			ClientDescriptorSHA256: composition.ClientSHA256,
+			CompositionSHA256:      composition.CompositionSHA256,
+		},
+	}
+}
+
+func pid1CanonicalDescriptor(t *testing.T, role l8composition.ProcessRole, extensions []credentialprotocol.ExtensionDescriptor) l8composition.ProcessDescriptor {
+	t.Helper()
+	policyID := "helper-policy-v1"
+	if role == l8composition.ProcessRoleClient {
+		policyID = "client-policy-v1"
+	}
+	return l8composition.ProcessDescriptor{
+		ContractVersion: l8composition.ProcessDescriptorContractVersion,
+		Role:            role,
+		Extensions:      credentialprotocol.CloneExtensionDescriptors(extensions),
+		PolicySHA256:    pid1PolicyDigest(policyID),
+	}
+}
+
+func pid1PolicyDigest(policyID string) [32]byte {
+	return sha256.Sum256(append(pid1Opaque16("hal/l8/process-policy/v1"), pid1Opaque16(policyID)...))
+}
+
+func pid1Opaque16(value string) []byte {
+	encoded := make([]byte, 2, len(value)+2)
+	binary.BigEndian.PutUint16(encoded, uint16(len(value)))
+	return append(encoded, value...)
+}
+
+func xorPID1DescriptorPolicy(descriptor l8composition.ProcessDescriptor) l8composition.ProcessDescriptor {
+	descriptor.PolicySHA256[0] ^= 0xff
+	return descriptor
+}

--- a/cmd/l8_credential_delivery_source_guard_test.go
+++ b/cmd/l8_credential_delivery_source_guard_test.go
@@ -84,6 +84,12 @@ func TestL8CredentialDeliverySourceGuardsCommandCompositionHasNoPrematureLiveImp
 			if err != nil {
 				return fmt.Errorf("unquote command import in %s: %w", filepath.ToSlash(path), err)
 			}
+			if importPath == l8CompositionImportPath || strings.HasPrefix(importPath, l8CompositionImportPath+"/") {
+				if !l8GuestInitProductionFile(path) {
+					t.Errorf("command production file %s prematurely imports L8 live package %q", filepath.ToSlash(path), importPath)
+				}
+				continue
+			}
 			for _, forbidden := range []string{
 				"github.com/jywlabs/hal/internal/credentialmemory",
 				"github.com/jywlabs/hal/internal/credentialsource",
@@ -93,7 +99,6 @@ func TestL8CredentialDeliverySourceGuardsCommandCompositionHasNoPrematureLiveImp
 				"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/session",
 				"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/v2control",
 				"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/server/credentialclient",
-				"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/l8composition",
 				"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/rolebootstrap",
 				"github.com/jywlabs/hal/internal/sandboxruntime/microvm/firecrackerhost/sshrelay",
 			} {
@@ -122,6 +127,20 @@ func TestL8CredentialDeliverySourceGuardsCommandCompositionHasNoPrematureLiveImp
 	if err != nil {
 		t.Fatalf("walk command production files: %v", err)
 	}
+}
+
+const l8CompositionImportPath = "github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/l8composition"
+
+func l8GuestInitProductionFile(path string) bool {
+	normalized := filepath.ToSlash(path)
+	if strings.HasPrefix(normalized, "./") {
+		normalized = normalized[2:]
+	}
+	const prefix = "hal-guest-init/"
+	if !strings.HasPrefix(normalized, prefix) || !strings.HasSuffix(normalized, ".go") || strings.HasSuffix(normalized, "_test.go") {
+		return false
+	}
+	return !strings.Contains(normalized[len(prefix):], "/")
 }
 
 func TestL8CredentialDeliverySourceGuardsV1SchemasCannotCarryProductionIntent(t *testing.T) {

--- a/cmd/l8_d6_pid1_guest_init_test.go
+++ b/cmd/l8_d6_pid1_guest_init_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestL8PID1GuestInitVerificationDocumentNamesMissingSealedChannel(t *testing.T) {
+	doc := readL8CredentialDeliveryFile(t, filepath.Join("..", "docs", "design", "sandbox-runtime-v2-l8-d6-pid1-guest-init-verification.md"))
+	for _, required := range []string{
+		"missing sealed expected-digest channel",
+		"L8ProcessCompositionFacts",
+		"helperDescriptorSha256",
+		"clientDescriptorSha256",
+		"compositionSha256",
+		"native-bootstrap sealed config pipe",
+		"NewPID1StartGateState",
+		"AcceptHelperDescriptor",
+		"AcceptClientDescriptor",
+		"does not construct helper or client",
+		"l8composition.NewHelper",
+		"l8composition.NewClient",
+		"--require-l7-network",
+		"go test ./internal/sandboxruntime/microvm/guestagent/l8composition -run 'PID1StartGate' -count=1",
+		"go test ./cmd/hal-guest-init -count=1",
+		"go test ./cmd -run 'L8CredentialDeliverySourceGuardsCommandComposition|PID1|GuestInit' -count=1",
+		"go vet ./cmd/hal-guest-init ./internal/sandboxruntime/microvm/guestagent/l8composition",
+		"does not claim live start-gate release",
+		"Unsigned file/env/cmdline",
+	} {
+		if !strings.Contains(doc, required) {
+			t.Fatalf("PID1 guest-init verification omits %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"live start-gate is production-complete",
+		"fixture-as-strict",
+		"os.Getenv",
+		"hal_l8_helper_digest",
+	} {
+		if strings.Contains(doc, forbidden) {
+			t.Fatalf("PID1 guest-init verification contains forbidden claim %q", forbidden)
+		}
+	}
+}
+
+func TestL8PID1GuestInitProductionImportBoundaryIsExact(t *testing.T) {
+	entries, err := os.ReadDir("hal-guest-init")
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundCompositionImport := false
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join("hal-guest-init", entry.Name())
+		source := readL8CredentialDeliveryFile(t, path)
+		if strings.Contains(source, "l8composition.NewHelper") || strings.Contains(source, "l8composition.NewClient") {
+			t.Errorf("PID1 production file %s constructs helper or client", filepath.ToSlash(path))
+		}
+		parsed, err := parser.ParseFile(token.NewFileSet(), path, source, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", filepath.ToSlash(path), err)
+		}
+		for _, spec := range parsed.Imports {
+			importPath, err := strconv.Unquote(spec.Path.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if importPath == l8CompositionImportPath || strings.HasPrefix(importPath, l8CompositionImportPath+"/") {
+				foundCompositionImport = true
+			}
+		}
+	}
+	if !foundCompositionImport {
+		t.Fatal("cmd/hal-guest-init production files do not import l8composition")
+	}
+	agentEntries, err := os.ReadDir("hal-guest-agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range agentEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join("hal-guest-agent", entry.Name())
+		source := readL8CredentialDeliveryFile(t, path)
+		if strings.Contains(source, l8CompositionImportPath) {
+			t.Errorf("hal-guest-agent production file %s imports l8composition", filepath.ToSlash(path))
+		}
+	}
+}
+
+func TestL8GuestInitDoesNotInventUnsignedExpectedDigestInputs(t *testing.T) {
+	source := readL8CredentialDeliveryFile(t, filepath.Join("hal-guest-init", "pid1_start_gate_linux.go"))
+	for _, forbidden := range []string{
+		"go:embed",
+		"os.Getenv",
+		"os.LookupEnv",
+		"os.ReadFile",
+		"os.Open(",
+		"/proc/cmdline",
+		"hal_l8_",
+		"json.Unmarshal",
+		"ioutil",
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("PID1 start-gate production file invents unsigned digest input %q", forbidden)
+		}
+	}
+	if !strings.Contains(source, "return l8composition.PID1StartGateExpected{}, false, nil") {
+		t.Fatal("PID1 start-gate loader must fail closed to a missing sealed channel, not a fixture digest")
+	}
+}

--- a/docs/design/sandbox-runtime-v2-l8-d6-pid1-guest-init-verification.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-pid1-guest-init-verification.md
@@ -1,0 +1,41 @@
+# L8 D6 PID1 guest-init start-gate verification
+
+This slice wires `cmd/hal-guest-init` (Linux) to `l8composition.PID1StartGateState`.
+PID1 admits canonical helper then client process descriptors through
+`NewPID1StartGateState`, `AcceptHelperDescriptor`, and `AcceptClientDescriptor`
+before `os.StartProcess`. It does not construct helper or client objects
+(`l8composition.NewHelper` / `l8composition.NewClient`).
+
+## Honest RED: missing sealed expected-digest channel
+
+Expected helper, client, and composition digests must come from sealed
+image-profile process-composition correlation already owned by PID1:
+`L8ProcessCompositionFacts.helperDescriptorSha256`,
+`clientDescriptorSha256`, and `compositionSha256`, compiled or inherited at
+D7 image issuance, or from the native-bootstrap sealed config pipe specified
+in the syscall-policy FD table.
+
+This binary has **no** such sealed channel. `loadPID1StartGateExpected`
+returns absent. Unsigned file/env/cmdline parsing is rejected. Missing
+expected leaves the L7 supervisor path so `--require-l7-network` is not
+regressed. A claimed expected without authenticated helper-then-client
+descriptors fails closed (exit 127). This slice does not claim live start-gate release.
+
+Authenticated HL8L `controller_attestation` and HL8A `client_attestation`
+receive paths are also absent from PID1; tests inject descriptors into the
+extracted helper only.
+
+## Focused verification
+
+```
+go test ./internal/sandboxruntime/microvm/guestagent/l8composition -run 'PID1StartGate' -count=1
+go test ./cmd/hal-guest-init -count=1
+go test ./cmd -run 'L8CredentialDeliverySourceGuardsCommandComposition|PID1|GuestInit' -count=1
+go vet ./cmd/hal-guest-init ./internal/sandboxruntime/microvm/guestagent/l8composition
+```
+
+Fake-only: no KVM, Firecracker, network, or cloud. Default tests do not require
+PID 1. `golangci-lint` is reported only when `command -v golangci-lint` succeeds.
+
+This slice does not wire `sandboxd`, `hal run`, `hal auto`, factory, or
+`cmd/hal-guest-agent`.


### PR DESCRIPTION
## Summary
PID1 (`cmd/hal-guest-init`) now consults `l8composition.PID1StartGateState` with exact helper-then-client admission before starting the child. Import of `l8composition` is allowlisted **only** for `cmd/hal-guest-init/*.go`. `NewHelper`/`NewClient` remain forbidden in cmd.

This is an **honest RED** for the missing sealed expected-digest channel. There is no in-tree D7 `L8ProcessCompositionFacts` compiled into PID1 and no native-bootstrap sealed config pipe. `loadPID1StartGateExpected` returns absent (no unsigned file/env/cmdline). Missing expected keeps the existing L7 supervisor path. A claimed expected without authenticated descriptors fails closed. **Do not treat this as live start-gate complete.**

Stacked on current `feature/sandbox-runtime-secure-default-v2` after PRs 46-50.

## Tests
- `go test ./cmd/hal-guest-init -count=1`
- `go test ./cmd -run 'L8CredentialDeliverySourceGuardsCommandComposition|PID1|GuestInit' -count=1`
- `go test ./internal/sandboxruntime/microvm/guestagent/l8composition -run 'PID1StartGate' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`. Do not invent unsigned digest loading to fake-green.