### PR TITLE
feat: US-049 - L8 host RecoverJobCredentials fail-closed

### DIFF
--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime.go
@@ -189,7 +189,23 @@ func (runtime *L8JobCredentialRuntime) PreflightJobCredentials(ctx context.Conte
 	return preflight, nil
 }
 
-func (runtime *L8JobCredentialRuntime) RecoverJobCredentials(context.Context, sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+// RecoverJobCredentials is ordinary complete-identity recovery used before
+// StopReap. HTTP tickets, tmpfs files, and SSH leases exist only as in-memory
+// handles after Prepare. A durable handle store that could reacquire them after
+// restart remains unaccepted, so this method never mints a cleanup proof.
+func (runtime *L8JobCredentialRuntime) RecoverJobCredentials(ctx context.Context, request sandboxruntime.JobCredentialRecoveryRequest) (sandboxruntime.JobCredentialCleanupProof, error) {
+	if runtime == nil || l8JobCredentialRuntimeValueIsNil(ctx) {
+		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
+	}
+	if runtime.production && !l8JobCredentialRuntimePlatformSupported() {
+		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeUnsupported
+	}
+	if sandboxruntime.ValidateJobCredentialIdentity(request.Identity) != nil {
+		return sandboxruntime.JobCredentialCleanupProof{}, sandboxruntime.ErrJobCredentialIdentityMismatch
+	}
+	if request.Revision == 0 {
+		return sandboxruntime.JobCredentialCleanupProof{}, ErrL8JobCredentialRuntimeInvalid
+	}
 	return sandboxruntime.JobCredentialCleanupProof{}, errL8JobCredentialRuntimeDependencyUnaccepted
 }
 

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_other_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_other_test.go
@@ -45,4 +45,18 @@ func TestL8JobCredentialRuntimeNonLinuxFailsClosedBeforeSession(t *testing.T) {
 	if opener.calls != 0 {
 		t.Fatalf("non-Linux production preflight opened a guest session: calls=%d", opener.calls)
 	}
+
+	identity, err := sandboxruntime.CompleteJobCredentialIdentity(seed, l8JobCredentialRuntimeGuestSessionGeneration(), "helper-generation-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	proof, recoverErr := production.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{
+		Identity: identity, Revision: 1,
+	})
+	if sandboxruntime.CleanupProofKind(proof) != "" || !errors.Is(recoverErr, ErrL8JobCredentialRuntimeUnsupported) {
+		t.Fatalf("non-Linux production recover = %#v, %v", proof, recoverErr)
+	}
+	if opener.calls != 0 {
+		t.Fatalf("non-Linux production recover opened a guest session: calls=%d", opener.calls)
+	}
 }

--- a/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_test.go
+++ b/internal/sandboxruntime/microvm/firecrackerhost/l8_job_credential_runtime_test.go
@@ -329,22 +329,121 @@ func TestL8JobCredentialRuntimeLossEmitsOneValueThenCloses(t *testing.T) {
 	}
 }
 
-func TestL8JobCredentialRuntimeRecoverIsDependencyUnaccepted(t *testing.T) {
+func TestL8JobCredentialRuntimeRecoverFailsClosedWithoutDurableHandleStore(t *testing.T) {
 	now := l8JobCredentialRuntimeNow()
-	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: l8JobCredentialGuestSessionFakeForTest(t, now)}, nil, nil, nil)
-	proof, err := runtime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{})
+	_, identity, request := l8JobCredentialRuntimePrepareFixture(t, now)
+	guest := l8JobCredentialGuestSessionFakeForTest(t, now)
+	httpProxy := &l8JobCredentialHTTPProxyFake{}
+	tmpfs := &l8JobCredentialFileTmpfsFake{payload: []byte("tmpfs-canary")}
+	ssh := &l8JobCredentialSSHRelayFake{policyID: "ssh-policy-1", policyRevision: 4}
+	runtime := l8JobCredentialRuntimeForTest(t, now, &l8JobCredentialGuestSessionOpenerFake{session: guest}, httpProxy, tmpfs, ssh)
+
+	proof, err := runtime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{
+		Identity: identity, Revision: 1,
+	})
 	if sandboxruntime.CleanupProofKind(proof) != "" || !errors.Is(err, errL8JobCredentialRuntimeDependencyUnaccepted) {
-		t.Fatalf("RecoverJobCredentials = %#v, %v", proof, err)
+		t.Fatalf("valid recover = %#v, %v", proof, err)
 	}
 	if err.Error() != "dependency_unaccepted" {
 		t.Fatalf("recover error = %q, want dependency_unaccepted", err)
 	}
+	l8JobCredentialRuntimeAssertSafeError(t, err)
+	if guest.prepares != 0 || guest.renews != 0 || guest.revokes != 0 || guest.closed != 0 {
+		t.Fatalf("recover opened guest state prepares=%d renews=%d revokes=%d closed=%d", guest.prepares, guest.renews, guest.revokes, guest.closed)
+	}
+	if httpProxy.activates != 0 || httpProxy.revokes != 0 || tmpfs.materializes != 0 || tmpfs.revokes != 0 || ssh.activates != 0 || ssh.revokes != 0 {
+		t.Fatalf("recover touched delivery adapters http=%d/%d tmpfs=%d/%d ssh=%d/%d", httpProxy.activates, httpProxy.revokes, tmpfs.materializes, tmpfs.revokes, ssh.activates, ssh.revokes)
+	}
+
+	empty, emptyErr := runtime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{})
+	if sandboxruntime.CleanupProofKind(empty) != "" || !errors.Is(emptyErr, sandboxruntime.ErrJobCredentialIdentityMismatch) {
+		t.Fatalf("empty recover = %#v, %v", empty, emptyErr)
+	}
+	zeroRevision, zeroErr := runtime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{Identity: identity})
+	if sandboxruntime.CleanupProofKind(zeroRevision) != "" || !errors.Is(zeroErr, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("zero-revision recover = %#v, %v", zeroRevision, zeroErr)
+	}
+	nilCtx, nilCtxErr := runtime.RecoverJobCredentials(nil, sandboxruntime.JobCredentialRecoveryRequest{Identity: identity, Revision: 1})
+	if sandboxruntime.CleanupProofKind(nilCtx) != "" || !errors.Is(nilCtxErr, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("nil-context recover = %#v, %v", nilCtx, nilCtxErr)
+	}
+	var nilRuntime *L8JobCredentialRuntime
+	nilProof, nilErr := nilRuntime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{Identity: identity, Revision: 1})
+	if sandboxruntime.CleanupProofKind(nilProof) != "" || !errors.Is(nilErr, ErrL8JobCredentialRuntimeInvalid) {
+		t.Fatalf("nil-runtime recover = %#v, %v", nilProof, nilErr)
+	}
+
+	seed := l8JobCredentialRuntimeSeed(t, now, []sandboxruntime.JobCredentialDeliveryMode{
+		sandboxruntime.JobCredentialDeliveryModeHTTPProxy,
+		sandboxruntime.JobCredentialDeliveryModeFileTmpfs,
+	})
+	preflight, err := runtime.PreflightJobCredentials(context.Background(), seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := preflight.PrepareJobCredentials(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveProof, liveErr := runtime.RecoverJobCredentials(context.Background(), sandboxruntime.JobCredentialRecoveryRequest{
+		Identity: identity, Revision: 1,
+	})
+	if sandboxruntime.CleanupProofKind(liveProof) != "" || !errors.Is(liveErr, errL8JobCredentialRuntimeDependencyUnaccepted) {
+		t.Fatalf("live recover = %#v, %v", liveProof, liveErr)
+	}
+	if sandboxruntime.ActiveProofKind(session.ActiveProof()) == "" {
+		t.Fatal("fail-closed recover revoked a live session it does not own")
+	}
+	if httpProxy.revokes != 0 || tmpfs.revokes != 0 {
+		t.Fatalf("fail-closed recover revoked live handles http=%d tmpfs=%d", httpProxy.revokes, tmpfs.revokes)
+	}
+
 	source, err := os.ReadFile("l8_job_credential_runtime.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if bytes.Contains(source, []byte("NewJobCredentialRuntimeAbsenceProof")) {
 		t.Fatal("job credential runtime issued a runtime absence proof")
+	}
+	if !bytes.Contains(source, []byte("durable handle store")) || !bytes.Contains(source, []byte("remains unaccepted")) {
+		t.Fatal("recover does not document the missing durable handle store as unaccepted")
+	}
+	l8JobCredentialRuntimeAssertRecoverDoesNotMintProofs(t)
+}
+
+func l8JobCredentialRuntimeAssertRecoverDoesNotMintProofs(t *testing.T) {
+	t.Helper()
+	set := token.NewFileSet()
+	file, err := parser.ParseFile(set, "l8_job_credential_runtime.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		fn, ok := node.(*ast.FuncDecl)
+		if !ok || fn.Name == nil || fn.Name.Name != "RecoverJobCredentials" || fn.Recv == nil {
+			return true
+		}
+		found = true
+		ast.Inspect(fn.Body, func(child ast.Node) bool {
+			name := ""
+			switch node := child.(type) {
+			case *ast.Ident:
+				name = node.Name
+			case *ast.SelectorExpr:
+				if node.Sel != nil {
+					name = node.Sel.Name
+				}
+			}
+			if name == "NewJobCredentialCleanupProof" || name == "NewJobCredentialRuntimeAbsenceProof" {
+				t.Fatalf("RecoverJobCredentials minted %s", name)
+			}
+			return true
+		})
+		return true
+	})
+	if !found {
+		t.Fatal("RecoverJobCredentials method not found")
 	}
 }
 


### PR DESCRIPTION
## Summary
`L8JobCredentialRuntime.RecoverJobCredentials` no longer panics or silently succeeds. Complete-identity recovery is still **before** StopReap; this method never skips containment.

There is no durable handle store for HTTP tickets, tmpfs files, or SSH leases after restart. Recover therefore **never mints a cleanup proof**. Valid identity+revision fail closed with `dependency_unaccepted`. Invalid identity/revision fail closed as mismatch/invalid. Non-Linux production is unsupported.

This is honest fail-closed, not GREEN live recovery.

Independent of PID1 PR #51 (different files). Base is current feature after PRs 46-50.

## Tests
- `go test ./internal/sandboxruntime/microvm/firecrackerhost -run 'Recover' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`. Do not mint a synthetic cleanup proof.