### PR TITLE
feat: US-049 - L8 guest v2 Serve dispatch

### DIFF
--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -7,7 +7,8 @@ authenticated control session on fixed VSOCK port 1025. Controller credential
 operations prepare, renew, revoke, and exec are accepted packet constructors
 alongside readiness. First prepare is admitted with `expectedIdentitySet=false`
 and derives the session-bound credential digest through
-`DecodeInitialCredentialPrepareRequest`; later receive expectations pin that
+`DecodeInitialCredentialPrepareRequest`, while bounding the requested expiry by
+the authenticated transport hard expiry; later receive expectations pin that
 digest rather than raw session bytes. Renew, revoke, and exec require
 `expectedIdentitySet`. Each success constructor consumes the exact originating
 controller packet as its sequence, session, request-ID, identity-digest, and

--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -1,15 +1,21 @@
 # L8 D6 guest control contract verification
 
 This candidate implements the accepted default-off guest-side request inspector,
-readiness dispatcher, and process-local lifecycle composition around the frozen
-contracts for a persistent authenticated control session on fixed VSOCK port
-1025. Controller credential operations prepare, renew, revoke, and exec are
-accepted packet constructors alongside readiness. Each success constructor
-consumes the exact originating controller packet as its sequence, session,
-request-ID, identity-digest, and lifecycle-correlation authority. Helper
-packets, unknown and malformed controller arms, private/stream/credit/close-notify controller
-packets, helper receive construction, and helper `writeCanonicalBody` remain
-`dependency_unaccepted`.
+readiness dispatcher, controller prepare/renew/revoke/exec identity dispatch, and
+process-local lifecycle composition around the frozen contracts for a persistent
+authenticated control session on fixed VSOCK port 1025. Controller credential
+operations prepare, renew, revoke, and exec are accepted packet constructors
+alongside readiness. First prepare is admitted with `expectedIdentitySet=false`
+and derives the session-bound credential digest through
+`DecodeInitialCredentialPrepareRequest`; later receive expectations pin that
+digest rather than raw session bytes. Renew, revoke, and exec require
+`expectedIdentitySet`. Each success constructor consumes the exact originating
+controller packet as its sequence, session, request-ID, identity-digest, and
+lifecycle-correlation authority. Helper packets, unknown and malformed
+controller arms, private/stream/credit/close-notify controller packets, helper
+receive construction, and helper `writeCanonicalBody` remain
+`dependency_unaccepted`. Serve fails closed on that helper dependency instead of
+synthesizing proofs.
 
 The frozen surface is limited to:
 

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
@@ -61,7 +61,7 @@ func (client *Client) serveCredentialLifecycle(ctx context.Context) (err error) 
 			continue
 		}
 		if prepare, ok := packet.prepareValue(); ok {
-			digest, digestErr := acceptControllerPrepareIdentity(identity.sessionIDValue(), prepare, expectedIdentity, expectedIdentitySet)
+			digest, digestErr := acceptControllerPrepareIdentity(identity.sessionIDValue(), identity.hardExpiryValue().UnixNano(), prepare, expectedIdentity, expectedIdentitySet)
 			if digestErr != nil {
 				return digestErr
 			}
@@ -94,7 +94,7 @@ func (client *Client) serveCredentialLifecycle(ctx context.Context) (err error) 
 	}
 }
 
-func acceptControllerPrepareIdentity(sessionID [32]byte, prepare v2control.CredentialPrepareRequest, expectedIdentity v2control.IdentityDigest, expectedIdentitySet bool) (v2control.IdentityDigest, error) {
+func acceptControllerPrepareIdentity(sessionID [32]byte, hardExpiryUnixNano int64, prepare v2control.CredentialPrepareRequest, expectedIdentity v2control.IdentityDigest, expectedIdentitySet bool) (v2control.IdentityDigest, error) {
 	if expectedIdentitySet {
 		if prepare.IdentityDigest() != expectedIdentity {
 			return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
@@ -107,6 +107,9 @@ func acceptControllerPrepareIdentity(sessionID [32]byte, prepare v2control.Crede
 	}
 	decoded, err := v2control.DecodeInitialCredentialPrepareRequest(sessionID, wire)
 	if err != nil {
+		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	if v2control.ValidateCredentialPrepareRequestExpiry(decoded, hardExpiryUnixNano) != nil {
 		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
 	}
 	reconstructed, err := v2control.NewGuestCredentialSessionIdentity(sessionID, decoded.Identity())

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
@@ -27,11 +27,13 @@ func (client *Client) serveCredentialLifecycle(ctx context.Context) (err error) 
 		return clientError(ClientContractDependency, ClientFieldDependency)
 	}
 	nextSequence := uint64(1)
+	var expectedIdentity v2control.IdentityDigest
+	expectedIdentitySet := false
 	for {
 		if client.drainStarted() {
 			return nil
 		}
-		receive, receiveErr := newControlReceiveRequest(nextSequence, v2control.NewIdentityDigest(identity.sessionIDValue()), true, session.MaxControlPlaintextBytes)
+		receive, receiveErr := newControlReceiveRequest(nextSequence, expectedIdentity, expectedIdentitySet, session.MaxControlPlaintextBytes)
 		if receiveErr != nil {
 			return clientError(ClientContractPacket, ClientFieldPacketType)
 		}
@@ -45,21 +47,96 @@ func (client *Client) serveCredentialLifecycle(ctx context.Context) (err error) 
 			}
 			return clientError(ClientContractPacket, ClientFieldPacketType)
 		}
-		if packet.sessionIDValue() != identity.sessionIDValue() {
+		if packet.sequenceValue() != nextSequence || packet.sessionIDValue() != identity.sessionIDValue() {
 			return clientError(ClientContractPacket, ClientFieldPacketType)
 		}
 		nextSequence++
 		if readiness, ready := packet.readinessValue(); ready {
+			if expectedIdentitySet {
+				return clientError(ClientContractPacket, ClientFieldIdentity)
+			}
 			if sendErr := client.dispatchReadinessResponse(ctx, identity, packet, readiness); sendErr != nil {
 				return sendErr
 			}
 			continue
+		}
+		if prepare, ok := packet.prepareValue(); ok {
+			digest, digestErr := acceptControllerPrepareIdentity(identity.sessionIDValue(), prepare, expectedIdentity, expectedIdentitySet)
+			if digestErr != nil {
+				return digestErr
+			}
+			expectedIdentity = digest
+			expectedIdentitySet = true
+			return helperPacketDependencyUnaccepted(expectedIdentity)
+		}
+		if renew, ok := packet.renewValue(); ok {
+			if err := requirePinnedCredentialIdentity(expectedIdentitySet, expectedIdentity, renew.IdentityDigest()); err != nil {
+				return err
+			}
+			return helperPacketDependencyUnaccepted(expectedIdentity)
+		}
+		if revoke, ok := packet.revokeValue(); ok {
+			if err := requirePinnedCredentialIdentity(expectedIdentitySet, expectedIdentity, revoke.IdentityDigest()); err != nil {
+				return err
+			}
+			return helperPacketDependencyUnaccepted(expectedIdentity)
+		}
+		if exec, ok := packet.execValue(); ok {
+			if err := requirePinnedCredentialIdentity(expectedIdentitySet, expectedIdentity, exec.IdentityDigest()); err != nil {
+				return err
+			}
+			return helperPacketDependencyUnaccepted(expectedIdentity)
 		}
 		if client.drainStarted() || ctx.Err() != nil {
 			return nil
 		}
 		return clientError(ClientContractPacket, ClientFieldPacketType)
 	}
+}
+
+func acceptControllerPrepareIdentity(sessionID [32]byte, prepare v2control.CredentialPrepareRequest, expectedIdentity v2control.IdentityDigest, expectedIdentitySet bool) (v2control.IdentityDigest, error) {
+	if expectedIdentitySet {
+		if prepare.IdentityDigest() != expectedIdentity {
+			return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+		}
+		return expectedIdentity, nil
+	}
+	wire, err := v2control.EncodeCredentialPrepareRequest(prepare)
+	if err != nil {
+		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	decoded, err := v2control.DecodeInitialCredentialPrepareRequest(sessionID, wire)
+	if err != nil {
+		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	reconstructed, err := v2control.NewGuestCredentialSessionIdentity(sessionID, decoded.Identity())
+	if err != nil {
+		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	digestBytes, err := v2control.GuestCredentialSessionIdentityDigest(reconstructed)
+	if err != nil {
+		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	digest := v2control.NewIdentityDigest(digestBytes)
+	if digest != decoded.IdentityDigest() || digest == v2control.NewIdentityDigest(sessionID) {
+		return v2control.IdentityDigest{}, clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	return digest, nil
+}
+
+func requirePinnedCredentialIdentity(expectedIdentitySet bool, expected, observed v2control.IdentityDigest) error {
+	if !expectedIdentitySet || expected == (v2control.IdentityDigest{}) || observed != expected {
+		return clientError(ClientContractPacket, ClientFieldIdentity)
+	}
+	return nil
+}
+
+func helperPacketDependencyUnaccepted(identity v2control.IdentityDigest) error {
+	_, err := newHelperControlReceiveRequest(1, 1, 0, [16]byte{}, true, identity.Bytes())
+	if err != nil {
+		return err
+	}
+	return ErrClientControlDependencyUnaccepted
 }
 
 func (client *Client) dispatchReadinessResponse(ctx context.Context, identity transportIdentity, packet ControllerPacket, readiness v2control.ReadinessRequest) error {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red_test.go
@@ -32,8 +32,8 @@ func TestL8D6GuestCredentialClientServeDispatchesCanonicalReadiness(t *testing.T
 		receiveCount++
 		if receiveCount == 1 {
 			expected, set := receive.expectedIdentityValue()
-			if receive.nextSequenceValue() != 1 || !set || expected != v2control.NewIdentityDigest(identity.sessionID) || receive.maximumPlaintextBytesValue() != session.MaxControlPlaintextBytes {
-				return ControllerPacket{}, errors.New("readiness admission was not bound to the authenticated session")
+			if receive.nextSequenceValue() != 1 || set || expected != (v2control.IdentityDigest{}) || receive.maximumPlaintextBytesValue() != session.MaxControlPlaintextBytes {
+				return ControllerPacket{}, errors.New("readiness admission must use first-prepare-legal unset expected identity")
 			}
 			return ControllerPacket{
 				sequence:  1,
@@ -190,6 +190,160 @@ func TestL8D6GuestCredentialClientRejectsCrossSessionReadinessPacket(t *testing.
 	}
 }
 
+func TestL8D6GuestCredentialClientServeFirstPrepareUsesUnsetSessionBoundIdentity(t *testing.T) {
+	identity := testDispatchTransportIdentity()
+	prepare := testDispatchPrepareRequest(t, identity)
+	digest := identityDigestForSession(t, testCredentialPacketSessionIdentity(t, identity.sessionID))
+	if digest == v2control.NewIdentityDigest(identity.sessionID) {
+		t.Fatal("fixture digest collided with raw session bytes")
+	}
+
+	var receiveCount atomic.Uint32
+	var sends atomic.Uint32
+	var helperSends atomic.Uint32
+	transport := &dispatchRedTransport{identity: identity}
+	transport.receiveController = func(_ context.Context, receive ControllerReceiveRequest) (ControllerPacket, error) {
+		count := receiveCount.Add(1)
+		expected, set := receive.expectedIdentityValue()
+		if count != 1 || receive.nextSequenceValue() != 1 || set || expected != (v2control.IdentityDigest{}) ||
+			expected == v2control.NewIdentityDigest(identity.sessionID) || receive.maximumPlaintextBytesValue() != session.MaxControlPlaintextBytes {
+			return ControllerPacket{}, errors.New("first prepare was not admitted with expectedIdentitySet=false")
+		}
+		return ControllerPacket{
+			sequence:  1,
+			sessionID: identity.sessionID,
+			arm:       controllerPacketArm{kind: controllerPacketArmPrepare, prepare: prepare},
+		}, nil
+	}
+	transport.sendController = func(context.Context, ControllerSendPacket) error {
+		sends.Add(1)
+		return errors.New("prepare success must not be sent without helper packets")
+	}
+	transport.sendHelper = func(context.Context, HelperSendPacket) error {
+		helperSends.Add(1)
+		return errors.New("helper send constructor is unaccepted")
+	}
+
+	err := newDispatchRedClient(t, transport).Serve(context.Background())
+	if !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("Serve() error = %v, want helper packet dependency unaccepted", err)
+	}
+	if receiveCount.Load() != 1 {
+		t.Fatalf("controller receives = %d, want 1; subsequent receive identity pin requires helper packets", receiveCount.Load())
+	}
+	if sends.Load() != 0 || helperSends.Load() != 0 {
+		t.Fatalf("controller/helper sends = %d/%d, want zero without helper constructors", sends.Load(), helperSends.Load())
+	}
+}
+
+func TestL8D6GuestCredentialClientServeRejectsFirstPrepareIdentityMismatch(t *testing.T) {
+	identity := testDispatchTransportIdentity()
+	otherSessionID := identity.sessionID
+	otherSessionID[31] ^= 0xff
+	prepare := testDispatchPrepareRequest(t, transportIdentity{sessionID: otherSessionID})
+
+	var sends atomic.Uint32
+	transport := &dispatchRedTransport{identity: identity}
+	transport.receiveController = func(context.Context, ControllerReceiveRequest) (ControllerPacket, error) {
+		return ControllerPacket{
+			sequence:  1,
+			sessionID: identity.sessionID,
+			arm:       controllerPacketArm{kind: controllerPacketArmPrepare, prepare: prepare},
+		}, nil
+	}
+	transport.sendController = func(context.Context, ControllerSendPacket) error {
+		sends.Add(1)
+		return errors.New("mismatched first prepare must not be answered")
+	}
+	if err := newDispatchRedClient(t, transport).Serve(context.Background()); clientContractCode(err) != ClientContractPacket {
+		t.Fatalf("Serve() error = %v, want identity packet rejection", err)
+	}
+	if sends.Load() != 0 {
+		t.Fatalf("mismatched first prepare sends = %d, want zero", sends.Load())
+	}
+}
+
+func TestL8D6GuestCredentialClientServeRenewRevokeExecRequireExpectedIdentitySet(t *testing.T) {
+	identity := testDispatchTransportIdentity()
+	sessionIdentity := testCredentialPacketSessionIdentity(t, identity.sessionID)
+	requestID := testPacketRequestID(t)
+	cases := []struct {
+		name   string
+		packet ControllerPacket
+	}{
+		{
+			name: "renew",
+			packet: ControllerPacket{
+				sequence:  1,
+				sessionID: identity.sessionID,
+				arm:       controllerPacketArm{kind: controllerPacketArmRenew, renew: testCredentialRenewPacketRequest(t, requestID, sessionIdentity)},
+			},
+		},
+		{
+			name: "revoke",
+			packet: ControllerPacket{
+				sequence:  1,
+				sessionID: identity.sessionID,
+				arm:       controllerPacketArm{kind: controllerPacketArmRevoke, revoke: testCredentialRevokePacketRequest(t, requestID, sessionIdentity)},
+			},
+		},
+		{
+			name: "exec",
+			packet: ControllerPacket{
+				sequence:  1,
+				sessionID: identity.sessionID,
+				arm:       controllerPacketArm{kind: controllerPacketArmExec, exec: testCredentialExecPacketRequest(t, requestID, sessionIdentity)},
+			},
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			var receiveCount atomic.Uint32
+			var sends atomic.Uint32
+			transport := &dispatchRedTransport{identity: identity}
+			transport.receiveController = func(_ context.Context, receive ControllerReceiveRequest) (ControllerPacket, error) {
+				receiveCount.Add(1)
+				if _, set := receive.expectedIdentityValue(); set {
+					return ControllerPacket{}, errors.New("renew/revoke/exec before prepare must not set expected identity")
+				}
+				return test.packet, nil
+			}
+			transport.sendController = func(context.Context, ControllerSendPacket) error {
+				sends.Add(1)
+				return errors.New("renew/revoke/exec without expectedIdentitySet must not be answered")
+			}
+			if err := newDispatchRedClient(t, transport).Serve(context.Background()); clientContractCode(err) != ClientContractPacket {
+				t.Fatalf("Serve() error = %v, want identity requirement", err)
+			}
+			if receiveCount.Load() != 1 || sends.Load() != 0 {
+				t.Fatalf("receives/sends = %d/%d, want 1/0", receiveCount.Load(), sends.Load())
+			}
+		})
+	}
+}
+
+func TestL8D6GuestCredentialClientServeCredentialOperationsRequireHelperPackets(t *testing.T) {
+	identity := testDispatchTransportIdentity()
+	prepare := testDispatchPrepareRequest(t, identity)
+	transport := &dispatchRedTransport{identity: identity}
+	transport.receiveController = func(context.Context, ControllerReceiveRequest) (ControllerPacket, error) {
+		return ControllerPacket{
+			sequence:  1,
+			sessionID: identity.sessionID,
+			arm:       controllerPacketArm{kind: controllerPacketArmPrepare, prepare: prepare},
+		}, nil
+	}
+	err := newDispatchRedClient(t, transport).Serve(context.Background())
+	if !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("Serve() error = %v, want named helper packet dependency", err)
+	}
+}
+
+func testDispatchPrepareRequest(t *testing.T, identity transportIdentity) v2control.CredentialPrepareRequest {
+	t.Helper()
+	return testCredentialPreparePacketRequest(t, testPacketRequestID(t), testCredentialPacketSessionIdentity(t, identity.sessionID))
+}
+
 func newDispatchRedClient(t *testing.T, transport Transport) *Client {
 	t.Helper()
 	registry, err := NewExtensionRegistry()
@@ -221,6 +375,7 @@ type dispatchRedTransport struct {
 	identity          transportIdentity
 	receiveController func(context.Context, ControllerReceiveRequest) (ControllerPacket, error)
 	sendController    func(context.Context, ControllerSendPacket) error
+	sendHelper        func(context.Context, HelperSendPacket) error
 	close             func(context.Context) error
 	closeOnce         sync.Once
 }
@@ -241,8 +396,11 @@ func (transport *dispatchRedTransport) SendController(ctx context.Context, packe
 func (*dispatchRedTransport) ReceiveHelper(context.Context, HelperReceiveRequest) (HelperPacket, error) {
 	return HelperPacket{}, errors.New("unexpected helper receive")
 }
-func (*dispatchRedTransport) SendHelper(context.Context, HelperSendPacket) error {
-	return errors.New("unexpected helper send")
+func (transport *dispatchRedTransport) SendHelper(ctx context.Context, packet HelperSendPacket) error {
+	if transport.sendHelper == nil {
+		return errors.New("unexpected helper send")
+	}
+	return transport.sendHelper(ctx, packet)
 }
 func (transport *dispatchRedTransport) Close(ctx context.Context) error {
 	if transport.close == nil {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red_test.go
@@ -263,6 +263,24 @@ func TestL8D6GuestCredentialClientServeRejectsFirstPrepareIdentityMismatch(t *te
 	}
 }
 
+func TestL8D6GuestCredentialClientServeRejectsPrepareBeyondSessionHardExpiry(t *testing.T) {
+	identity := testDispatchTransportIdentity()
+	identity.hardExpiry = time.Unix(0, 1700000000623456789).UTC()
+	prepare := testDispatchPrepareRequest(t, identity)
+
+	transport := &dispatchRedTransport{identity: identity}
+	transport.receiveController = func(context.Context, ControllerReceiveRequest) (ControllerPacket, error) {
+		return ControllerPacket{
+			sequence:  1,
+			sessionID: identity.sessionID,
+			arm:       controllerPacketArm{kind: controllerPacketArmPrepare, prepare: prepare},
+		}, nil
+	}
+	if err := newDispatchRedClient(t, transport).Serve(context.Background()); clientContractCode(err) != ClientContractPacket {
+		t.Fatalf("Serve() error = %v, want expiry packet rejection", err)
+	}
+}
+
 func TestL8D6GuestCredentialClientServeRenewRevokeExecRequireExpectedIdentitySet(t *testing.T) {
 	identity := testDispatchTransportIdentity()
 	sessionIdentity := testCredentialPacketSessionIdentity(t, identity.sessionID)
@@ -367,7 +385,7 @@ func testDispatchTransportIdentity() transportIdentity {
 	sessionID[0] = 1
 	return transportIdentity{
 		sessionID: sessionID, identity: identity,
-		hardExpiry: time.Unix(1_700_000_000, 0).UTC(), helperGeneration: "helper-generation-1",
+		hardExpiry: time.Unix(0, 1700000001123456789).UTC(), helperGeneration: "helper-generation-1",
 	}
 }
 


### PR DESCRIPTION
## Summary
`credentialclient.Client.Serve` now identity-dispatches prepare/renew/revoke/exec.

- First prepare: `expectedIdentitySet=false`; job identity from body + session.
- After validated prepare, pin the session-bound credential digest, not raw session bytes.
- Renew/revoke/exec require the pinned expected digest.
- Completing those operations still needs helper packets. Serve returns `ErrClientControlDependencyUnaccepted` at `newHelperControlReceiveRequest`. No synthetic proofs.

Helper/private/stream/credit/close remain unaccepted.

## Tests
- `go test ./internal/sandboxruntime/microvm/guestagent/server/credentialclient -run '^TestL8D6Guest(Control|Transport|Packet|CredentialClient)' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.