### PR TITLE
feat: US-049 - L8 guest v2 helper packets

### DIFF
--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -12,11 +12,14 @@ the authenticated transport hard expiry; later receive expectations pin that
 digest rather than raw session bytes. Renew, revoke, and exec require
 `expectedIdentitySet`. Each success constructor consumes the exact originating
 controller packet as its sequence, session, request-ID, identity-digest, and
-lifecycle-correlation authority. Helper packets, unknown and malformed
-controller arms, private/stream/credit/close-notify controller packets, helper
-receive construction, and helper `writeCanonicalBody` remain
-`dependency_unaccepted`. Serve fails closed on that helper dependency instead of
-synthesizing proofs.
+lifecycle-correlation authority. Helper receive construction, helper packet
+unions, and helper `writeCanonicalBody` for non-payload send arms follow that
+same consume-once sequence and identity discipline as metadata constructors.
+Live helper transport, SCM_RIGHTS, bind/listen/dial, and helper send constructors
+remain unaccepted. Unknown and malformed controller arms and
+private/stream/credit/close-notify controller packets remain
+`dependency_unaccepted`. Serve fails closed when a later operation needs an
+unimplemented helper send issuer instead of synthesizing proofs.
 
 The frozen surface is limited to:
 

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
@@ -135,7 +135,10 @@ func requirePinnedCredentialIdentity(expectedIdentitySet bool, expected, observe
 }
 
 func helperPacketDependencyUnaccepted(identity v2control.IdentityDigest) error {
-	_, err := newHelperControlReceiveRequest(1, 1, 0, [16]byte{}, true, identity.Bytes())
+	// Helper receive is implemented; first helper receive after a controller
+	// credential op has no expected request ID yet. Helper send constructors
+	// remain unaccepted.
+	_, err := newHelperControlReceiveRequest(1, credentialprotocol.MaxHelperPacketBodyBytes, 0, [16]byte{}, false, identity.Bytes())
 	if err != nil {
 		return err
 	}

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
@@ -841,6 +841,7 @@ func newHelperExecStreamPacket(request HelperReceiveRequest, header credentialpr
 	}
 	bodyLength := helperExecStreamCanonicalPrefixBytes + payloadLength
 	if validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeExecStream, true, false, bodyLength) != nil ||
+		(payloadLength > 0 && !configuredDependency(body)) ||
 		validateOptionalHelperBodyLength(body, bodyLength) != nil {
 		return HelperPacket{}, errInvalidHelperPacket
 	}

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
@@ -3,6 +3,7 @@ package credentialclient
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"errors"
 	"io"
 	"sync"
@@ -21,7 +22,12 @@ var (
 	errInvalidControlReceiveRequest      = errors.New("credential client control receive request is invalid")
 	errInvalidControllerPacket           = errors.New("credential client controller packet is invalid")
 	errInvalidControllerSendPacket       = errors.New("credential client controller send packet is invalid")
+	errInvalidHelperReceiveRequest       = errors.New("credential client helper receive request is invalid")
+	errInvalidHelperPacket               = errors.New("credential client helper packet is invalid")
+	errInvalidHelperSendPacket           = errors.New("credential client helper send packet is invalid")
 )
+
+const helperExecStreamCanonicalPrefixBytes = 56
 
 // ControlAcceptExpectation is the private-snapshot expectation presented only
 // to the inherited, preopened control listener owner. It carries no FD.
@@ -360,8 +366,38 @@ func consumeControllerReceiveRequest(request ControllerReceiveRequest) error {
 	return nil
 }
 
-func newHelperControlReceiveRequest(uint64, uint32, uint32, [16]byte, bool, [32]byte) (HelperReceiveRequest, error) {
-	return HelperReceiveRequest{}, ErrClientControlDependencyUnaccepted
+func newHelperControlReceiveRequest(sequence uint64, maximumBodyBytes, maximumRights uint32, expectedRequestID [16]byte, expectedRequestIDSet bool, expectedIdentity [32]byte) (HelperReceiveRequest, error) {
+	if sequence == 0 || maximumBodyBytes > credentialprotocol.MaxHelperPacketBodyBytes || maximumRights > 1 {
+		return HelperReceiveRequest{}, errInvalidHelperReceiveRequest
+	}
+	if expectedIdentity == ([32]byte{}) {
+		return HelperReceiveRequest{}, errInvalidHelperReceiveRequest
+	}
+	if expectedRequestIDSet != (expectedRequestID != ([16]byte{})) {
+		return HelperReceiveRequest{}, errInvalidHelperReceiveRequest
+	}
+	return HelperReceiveRequest{
+		nextSequence:         sequence,
+		maximumBodyBytes:     maximumBodyBytes,
+		maximumRights:        maximumRights,
+		expectedRequestID:    expectedRequestID,
+		expectedRequestIDSet: expectedRequestIDSet,
+		expectedIdentity:     expectedIdentity,
+		state:                &helperReceiveRequestState{},
+	}, nil
+}
+
+func consumeHelperReceiveRequest(request HelperReceiveRequest) error {
+	if request.state == nil {
+		return errInvalidHelperReceiveRequest
+	}
+	request.state.mu.Lock()
+	defer request.state.mu.Unlock()
+	if request.state.consumed {
+		return errInvalidHelperReceiveRequest
+	}
+	request.state.consumed = true
+	return nil
 }
 
 func (request ControllerReceiveRequest) nextSequenceValue() uint64 { return request.nextSequence }
@@ -736,23 +772,324 @@ func controllerSendArmValue[T any](packet ControllerSendPacket, expected control
 	return selectValue(packet.state.owner.arm), true
 }
 
-func newHelperResponsePacket(HelperReceiveRequest, credentialprotocol.HelperPacketHeader, helperBodyCapability, credentialprotocol.HelperResponseBody) (HelperPacket, error) {
-	return HelperPacket{}, ErrClientControlDependencyUnaccepted
+func newHelperResponsePacket(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, body helperBodyCapability, response credentialprotocol.HelperResponseBody) (packet HelperPacket, err error) {
+	released := false
+	defer func() {
+		if err != nil && !released {
+			_ = destroyHelperBody(body)
+		}
+	}()
+	encoded, encodeErr := credentialprotocol.EncodeHelperResponseBody(response)
+	if consumeErr := consumeHelperReceiveRequest(request); consumeErr != nil {
+		return HelperPacket{}, consumeErr
+	}
+	if encodeErr != nil || validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeResponse, true, false, uint32(len(encoded))) != nil ||
+		validateOptionalHelperBody(body, encoded) != nil {
+		clear(encoded)
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	clear(encoded)
+	released = true
+	if destroyErr := destroyHelperBody(body); destroyErr != nil {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	return HelperPacket{
+		header: header,
+		arm:    helperPacketArm{kind: helperPacketArmResponse, response: cloneHelperResponseBody(response)},
+	}, nil
 }
-func newHelperEventPacket(HelperReceiveRequest, credentialprotocol.HelperPacketHeader, helperBodyCapability, credentialprotocol.HelperEventBody) (HelperPacket, error) {
-	return HelperPacket{}, ErrClientControlDependencyUnaccepted
+
+func newHelperEventPacket(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, body helperBodyCapability, event credentialprotocol.HelperEventBody) (packet HelperPacket, err error) {
+	released := false
+	defer func() {
+		if err != nil && !released {
+			_ = destroyHelperBody(body)
+		}
+	}()
+	encoded, encodeErr := credentialprotocol.EncodeHelperEventBody(event)
+	if consumeErr := consumeHelperReceiveRequest(request); consumeErr != nil {
+		return HelperPacket{}, consumeErr
+	}
+	if encodeErr != nil || validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeEvent, false, false, uint32(len(encoded))) != nil ||
+		validateOptionalHelperBody(body, encoded) != nil {
+		clear(encoded)
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	clear(encoded)
+	released = true
+	if destroyErr := destroyHelperBody(body); destroyErr != nil {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	return HelperPacket{
+		header: header,
+		arm:    helperPacketArm{kind: helperPacketArmEvent, event: event},
+	}, nil
 }
-func newHelperExecStreamPacket(HelperReceiveRequest, credentialprotocol.HelperPacketHeader, helperBodyCapability, uint64, credentialprotocol.HelperExecStreamKind, credentialprotocol.HelperExecStreamFlags, uint64, uint32, [32]byte) (HelperPacket, error) {
-	return HelperPacket{}, ErrClientControlDependencyUnaccepted
+
+func newHelperExecStreamPacket(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, body helperBodyCapability, revision uint64, kind credentialprotocol.HelperExecStreamKind, flags credentialprotocol.HelperExecStreamFlags, offset uint64, payloadLength uint32, payloadSHA256 [32]byte) (packet HelperPacket, err error) {
+	retainedBody := false
+	defer func() {
+		if err != nil && !retainedBody {
+			_ = destroyHelperBody(body)
+		}
+	}()
+	if consumeErr := consumeHelperReceiveRequest(request); consumeErr != nil {
+		return HelperPacket{}, consumeErr
+	}
+	if !validHelperReceiveExecStream(kind, flags, payloadLength, payloadSHA256) || revision == 0 {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	bodyLength := helperExecStreamCanonicalPrefixBytes + payloadLength
+	if validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeExecStream, true, false, bodyLength) != nil ||
+		validateOptionalHelperBodyLength(body, bodyLength) != nil {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	retainedBody = configuredDependency(body)
+	return HelperPacket{
+		header: header,
+		arm: helperPacketArm{
+			kind: helperPacketArmExecStream,
+			execStream: helperExecStreamRecord{
+				revision:      revision,
+				kind:          kind,
+				flags:         flags,
+				offset:        offset,
+				payloadLength: payloadLength,
+				payloadSHA256: payloadSHA256,
+			},
+		},
+		body: body,
+	}, nil
 }
-func newHelperExecCreditPacket(HelperReceiveRequest, credentialprotocol.HelperPacketHeader, helperBodyCapability, credentialprotocol.HelperExecCreditBody) (HelperPacket, error) {
-	return HelperPacket{}, ErrClientControlDependencyUnaccepted
+
+func newHelperExecCreditPacket(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, body helperBodyCapability, credit credentialprotocol.HelperExecCreditBody) (packet HelperPacket, err error) {
+	released := false
+	defer func() {
+		if err != nil && !released {
+			_ = destroyHelperBody(body)
+		}
+	}()
+	encoded, encodeErr := credentialprotocol.EncodeHelperExecCreditBody(credit)
+	if consumeErr := consumeHelperReceiveRequest(request); consumeErr != nil {
+		return HelperPacket{}, consumeErr
+	}
+	if encodeErr != nil || credit.StreamKind != credentialprotocol.HelperExecStreamStdin ||
+		validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeExecCredit, true, false, uint32(len(encoded))) != nil ||
+		validateOptionalHelperBody(body, encoded) != nil {
+		clear(encoded)
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	clear(encoded)
+	released = true
+	if destroyErr := destroyHelperBody(body); destroyErr != nil {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	return HelperPacket{
+		header: header,
+		arm:    helperPacketArm{kind: helperPacketArmExecCredit, execCredit: credit},
+	}, nil
 }
-func newHelperSSHAcceptedPacket(HelperReceiveRequest, credentialprotocol.HelperPacketHeader, helperBodyCapability, uint64, uint16, uint8, [32]byte, SSHConnectionCapability) (HelperPacket, error) {
-	return HelperPacket{}, ErrClientControlDependencyUnaccepted
+
+func newHelperSSHAcceptedPacket(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, body helperBodyCapability, revision uint64, bindingIndex uint16, ordinal uint8, digest [32]byte, capability SSHConnectionCapability) (packet HelperPacket, err error) {
+	releasedBody := false
+	retainedRight := false
+	defer func() {
+		if err != nil && !releasedBody {
+			_ = destroyHelperBody(body)
+		}
+		if err != nil && !retainedRight && configuredDependency(capability) {
+			_ = closeRejectedSSHCapability(capability)
+		}
+	}()
+	encodedLength := credentialprotocol.HelperSSHAcceptedFDBodyEncodedLength()
+	encoded := make([]byte, encodedLength)
+	encodeErr := credentialprotocol.EncodeHelperSSHAcceptedFDBodyTo(encoded, revision, bindingIndex, ordinal, digest)
+	if consumeErr := consumeHelperReceiveRequest(request); consumeErr != nil {
+		clear(encoded)
+		return HelperPacket{}, consumeErr
+	}
+	if encodeErr != nil || request.maximumRights != 1 ||
+		validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeSSHAcceptedFD, false, false, encodedLength) != nil ||
+		validateOptionalHelperBody(body, encoded) != nil || !configuredDependency(capability) {
+		clear(encoded)
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	clear(encoded)
+	capabilityDigest, valid := safeSSHIssuerDigest(capability)
+	if !valid || capabilityDigest == ([32]byte{}) || subtle.ConstantTimeCompare(capabilityDigest[:], digest[:]) != 1 {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	releasedBody = true
+	if destroyErr := destroyHelperBody(body); destroyErr != nil {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	ownership := newSSHConnectionOwnership(capabilityDigest, capability)
+	view := sshConnectionView{ownership: ownership}
+	retainedRight = true
+	return HelperPacket{
+		header: header,
+		arm: helperPacketArm{
+			kind: helperPacketArmSSHAccepted,
+			sshAccepted: SSHAcceptedPacket{
+				revision:         revision,
+				bindingIndex:     bindingIndex,
+				ordinal:          ordinal,
+				capabilitySHA256: digest,
+				connection:       view,
+				ownership:        ownership,
+			},
+		},
+		right: view,
+	}, nil
 }
-func newHelperCloseNotifyPacket(HelperReceiveRequest, credentialprotocol.HelperPacketHeader, helperBodyCapability, credentialprotocol.HelperCloseNotifyBody) (HelperPacket, error) {
-	return HelperPacket{}, ErrClientControlDependencyUnaccepted
+
+func newHelperCloseNotifyPacket(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, body helperBodyCapability, closeBody credentialprotocol.HelperCloseNotifyBody) (packet HelperPacket, err error) {
+	released := false
+	defer func() {
+		if err != nil && !released {
+			_ = destroyHelperBody(body)
+		}
+	}()
+	encoded, encodeErr := credentialprotocol.EncodeHelperCloseNotifyBody(closeBody)
+	if consumeErr := consumeHelperReceiveRequest(request); consumeErr != nil {
+		return HelperPacket{}, consumeErr
+	}
+	if encodeErr != nil || validateHelperReceiveHeader(request, header, credentialprotocol.PacketTypeCloseNotify, false, true, uint32(len(encoded))) != nil ||
+		validateOptionalHelperBody(body, encoded) != nil {
+		clear(encoded)
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	clear(encoded)
+	released = true
+	if destroyErr := destroyHelperBody(body); destroyErr != nil {
+		return HelperPacket{}, errInvalidHelperPacket
+	}
+	return HelperPacket{
+		header: header,
+		arm:    helperPacketArm{kind: helperPacketArmClose, close: closeBody},
+	}, nil
+}
+
+func validateHelperReceiveHeader(request HelperReceiveRequest, header credentialprotocol.HelperPacketHeader, wantType credentialprotocol.PacketType, requireExpectedID, requireZeroRequestID bool, encodedLength uint32) error {
+	if header.Type != wantType || header.Sequence == 0 || header.Sequence != request.nextSequence ||
+		credentialprotocol.ValidateHelperPacketHeaderSemantics(header) != nil ||
+		header.BodyLength != encodedLength || header.BodyLength > request.maximumBodyBytes ||
+		header.GuestCredentialIdentityDigest != request.expectedIdentity {
+		return errInvalidHelperPacket
+	}
+	if requireExpectedID && !request.expectedRequestIDSet {
+		return errInvalidHelperPacket
+	}
+	if requireZeroRequestID {
+		if request.expectedRequestIDSet || header.RequestID != ([16]byte{}) {
+			return errInvalidHelperPacket
+		}
+		return nil
+	}
+	if request.expectedRequestIDSet && header.RequestID != request.expectedRequestID {
+		return errInvalidHelperPacket
+	}
+	return nil
+}
+
+func validHelperReceiveExecStream(kind credentialprotocol.HelperExecStreamKind, flags credentialprotocol.HelperExecStreamFlags, payloadLength uint32, payloadSHA256 [32]byte) bool {
+	if kind != credentialprotocol.HelperExecStreamStdout && kind != credentialprotocol.HelperExecStreamStderr {
+		return false
+	}
+	if flags != credentialprotocol.HelperExecStreamFlagsNone && flags != credentialprotocol.HelperExecStreamFlagEOF {
+		return false
+	}
+	if payloadLength > credentialprotocol.MaxHelperExecStreamPayloadBytes {
+		return false
+	}
+	if flags == credentialprotocol.HelperExecStreamFlagsNone && payloadLength == 0 {
+		return false
+	}
+	if flags == credentialprotocol.HelperExecStreamFlagEOF && payloadLength != 0 {
+		return false
+	}
+	if payloadLength == 0 {
+		return payloadSHA256 == sha256.Sum256(nil)
+	}
+	return payloadSHA256 != ([32]byte{})
+}
+
+func validateOptionalHelperBody(body helperBodyCapability, encoded []byte) error {
+	if body == nil {
+		return nil
+	}
+	if !configuredDependency(body) {
+		return errInvalidHelperPacket
+	}
+	length, digest, ok := helperBodyMetadata(body)
+	if !ok || uint64(length) != uint64(len(encoded)) || digest != sha256.Sum256(encoded) {
+		return errInvalidHelperPacket
+	}
+	return nil
+}
+
+func validateOptionalHelperBodyLength(body helperBodyCapability, length uint32) error {
+	if body == nil {
+		return nil
+	}
+	if !configuredDependency(body) {
+		return errInvalidHelperPacket
+	}
+	got, _, ok := helperBodyMetadata(body)
+	if !ok || got != length {
+		return errInvalidHelperPacket
+	}
+	return nil
+}
+
+func helperBodyMetadata(body helperBodyCapability) (length uint32, digest [32]byte, ok bool) {
+	defer func() {
+		if recover() != nil {
+			length = 0
+			digest = [32]byte{}
+			ok = false
+		}
+	}()
+	return body.Len(), body.SHA256(), true
+}
+
+func destroyHelperBody(body helperBodyCapability) (err error) {
+	if !configuredDependency(body) {
+		return nil
+	}
+	defer func() {
+		if recover() != nil {
+			err = errInvalidHelperPacket
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), sshConnectionCleanupTimeout)
+	defer cancel()
+	if destroyErr := body.Destroy(ctx); destroyErr != nil {
+		return errInvalidHelperPacket
+	}
+	return nil
+}
+
+func cloneHelperResponseBody(body credentialprotocol.HelperResponseBody) credentialprotocol.HelperResponseBody {
+	clone := body
+	if body.Prepare != nil {
+		prepare := *body.Prepare
+		prepare.BindingProofs = cloneValues(body.Prepare.BindingProofs)
+		clone.Prepare = &prepare
+	}
+	if body.Renew != nil {
+		renew := *body.Renew
+		clone.Renew = &renew
+	}
+	if body.Revoke != nil {
+		revoke := *body.Revoke
+		clone.Revoke = &revoke
+	}
+	if body.Exec != nil {
+		exec := *body.Exec
+		clone.Exec = &exec
+	}
+	return clone
 }
 
 func (packet HelperPacket) packetTypeValue() credentialprotocol.PacketType { return packet.header.Type }
@@ -786,8 +1123,106 @@ func (packet HelperSendPacket) headerValue() credentialprotocol.HelperPacketHead
 }
 func (packet HelperSendPacket) encodedBodyLengthValue() uint32 { return packet.encodedBodyLength }
 func (packet HelperSendPacket) bodySHA256Value() [32]byte      { return packet.bodySHA256 }
-func (packet HelperSendPacket) writeCanonicalBody(bodySegmentSink) error {
-	return ErrClientControlDependencyUnaccepted
+func (packet HelperSendPacket) writeCanonicalBody(sink bodySegmentSink) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errInvalidHelperSendPacket
+		}
+	}()
+	switch packet.arm {
+	case helperSendArmPrepareBegin, helperSendArmPrepareCommit, helperSendArmRenew, helperSendArmRevoke, helperSendArmExec, helperSendArmExecCredit, helperSendArmClose:
+	default:
+		return ErrClientControlDependencyUnaccepted
+	}
+	if packet.state == nil {
+		return errInvalidHelperSendPacket
+	}
+	packet.state.mu.Lock()
+	if packet.state.consumed || packet.state.owner == nil {
+		packet.state.mu.Unlock()
+		return errInvalidHelperSendPacket
+	}
+	owner := packet.state.owner
+	packet.state.consumed = true
+	packet.state.owner = nil
+	packet.state.mu.Unlock()
+	defer func() { _ = destroyHelperBody(owner.body) }()
+	body, encodeErr := encodeHelperSendCanonicalBody(packet.arm, owner.arm)
+	if encodeErr != nil || uint64(len(body)) != uint64(packet.encodedBodyLength) || packet.header.BodyLength != packet.encodedBodyLength || sha256.Sum256(body) != packet.bodySHA256 {
+		return errInvalidHelperSendPacket
+	}
+	if sink == nil || sink.Capacity() != packet.encodedBodyLength {
+		return errInvalidHelperSendPacket
+	}
+	if writeErr := sink.WriteSegment(0, body); writeErr != nil {
+		return errInvalidHelperSendPacket
+	}
+	return nil
+}
+
+func finishHelperSendPacket(header credentialprotocol.HelperPacketHeader, kind helperSendArmKind, arm helperSendArm) (HelperSendPacket, error) {
+	body, err := encodeHelperSendCanonicalBody(kind, arm)
+	if err != nil || len(body) == 0 || header.BodyLength != uint32(len(body)) ||
+		credentialprotocol.ValidateHelperPacketHeaderSemantics(header) != nil || header.Type != helperSendArmPacketType(kind) {
+		return HelperSendPacket{}, errInvalidHelperSendPacket
+	}
+	return HelperSendPacket{
+		header:            header,
+		arm:               kind,
+		encodedBodyLength: uint32(len(body)),
+		bodySHA256:        sha256.Sum256(body),
+		state: &helperSendPacketState{
+			owner: &helperSendPacketOwner{arm: arm},
+		},
+	}, nil
+}
+
+func encodeHelperSendCanonicalBody(kind helperSendArmKind, arm helperSendArm) ([]byte, error) {
+	switch kind {
+	case helperSendArmPrepareBegin:
+		return credentialprotocol.EncodeHelperPrepareBeginBody(arm.prepareBegin)
+	case helperSendArmPrepareCommit:
+		return credentialprotocol.EncodeHelperPrepareCommitBody(arm.prepareCommit)
+	case helperSendArmRenew:
+		return credentialprotocol.EncodeHelperRenewBody(arm.renew)
+	case helperSendArmRevoke:
+		return credentialprotocol.EncodeHelperRevokeBody(arm.revoke)
+	case helperSendArmExec:
+		return credentialprotocol.EncodeHelperExecBody(arm.exec)
+	case helperSendArmExecCredit:
+		return credentialprotocol.EncodeHelperExecCreditBody(arm.execCredit)
+	case helperSendArmClose:
+		return credentialprotocol.EncodeHelperCloseNotifyBody(arm.close)
+	default:
+		return nil, ErrClientControlDependencyUnaccepted
+	}
+}
+
+func helperSendArmPacketType(kind helperSendArmKind) credentialprotocol.PacketType {
+	switch kind {
+	case helperSendArmPrepareBegin:
+		return credentialprotocol.PacketTypePrepareBegin
+	case helperSendArmPrepareFile:
+		return credentialprotocol.PacketTypePrepareFile
+	case helperSendArmPrepareCommit:
+		return credentialprotocol.PacketTypePrepareCommit
+	case helperSendArmRenew:
+		return credentialprotocol.PacketTypeRenew
+	case helperSendArmRevoke:
+		return credentialprotocol.PacketTypeRevoke
+	case helperSendArmExec:
+		return credentialprotocol.PacketTypeExec
+	case helperSendArmExecPrivate:
+		return credentialprotocol.PacketTypeExecPrivate
+	case helperSendArmExecStream:
+		return credentialprotocol.PacketTypeExecStream
+	case helperSendArmExecCredit:
+		return credentialprotocol.PacketTypeExecCredit
+	case helperSendArmClose:
+		return credentialprotocol.PacketTypeCloseNotify
+	default:
+		return 0
+	}
 }
 
 var _ io.Reader = VerifiedControlStream(nil)

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
@@ -755,6 +755,22 @@ func TestL8D6GuestPacketHelperUnionsMirrorReadinessDiscipline(t *testing.T) {
 		if _, err := newHelperExecStreamPacket(stdin, header, nil, 3, credentialprotocol.HelperExecStreamStdin, credentialprotocol.HelperExecStreamFlagsNone, 0, 7, payloadDigest); !errors.Is(err, errInvalidHelperPacket) {
 			t.Fatalf("stdin stream error = %v", err)
 		}
+		missingPayload := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperExecStreamPacket(missingPayload, header, nil, 3, credentialprotocol.HelperExecStreamStdout, credentialprotocol.HelperExecStreamFlagsNone, 0, 7, payloadDigest); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("nonempty stream without owned payload error = %v", err)
+		}
+		retryBody := &testHelperBody{length: helperExecStreamCanonicalPrefixBytes + 7, digest: payloadDigest}
+		if _, err := newHelperExecStreamPacket(missingPayload, header, retryBody, 3, credentialprotocol.HelperExecStreamStdout, credentialprotocol.HelperExecStreamFlagsNone, 0, 7, payloadDigest); !errors.Is(err, errInvalidHelperReceiveRequest) {
+			t.Fatalf("failed missing-payload issue did not consume receive request: %v", err)
+		}
+		if !retryBody.destroyed {
+			t.Fatal("replayed receive request did not destroy the newly supplied body")
+		}
+		var typedNilBody *testHelperBody
+		typedNilPayload := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperExecStreamPacket(typedNilPayload, header, typedNilBody, 3, credentialprotocol.HelperExecStreamStderr, credentialprotocol.HelperExecStreamFlagsNone, 0, 7, payloadDigest); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("nonempty stream with typed-nil payload error = %v", err)
+		}
 	})
 
 	t.Run("exec-credit", func(t *testing.T) {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
@@ -1,6 +1,7 @@
 package credentialclient
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jywlabs/hal/internal/credentialmemory"
 	"github.com/jywlabs/hal/internal/sandboxruntime"
 	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/credentialprotocol"
 	"github.com/jywlabs/hal/internal/sandboxruntime/microvm/guestagent/session"
@@ -592,14 +594,265 @@ func TestL8D6GuestControllerRemainingPacketsStayUnaccepted(t *testing.T) {
 	if _, err := newControllerCloseNotifyPacket(receive, 1, sessionID, 0); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
 		t.Fatalf("close notify packet error = %v", err)
 	}
-	if _, err := newHelperControlReceiveRequest(1, 1, 0, [16]byte{}, false, [32]byte{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("helper receive error = %v", err)
+}
+
+func TestL8D6GuestPacketHelperReceiveRequestMirrorsControlDiscipline(t *testing.T) {
+	identity := testHelperPacketIdentity()
+	requestID := testHelperPacketRequestID()
+	receive, err := newHelperControlReceiveRequest(1, credentialprotocol.MaxHelperPacketBodyBytes, 0, requestID, true, identity)
+	if err != nil {
+		t.Fatalf("newHelperControlReceiveRequest() error = %v", err)
 	}
-	if _, err := newHelperResponsePacket(HelperReceiveRequest{}, credentialprotocol.HelperPacketHeader{}, nil, credentialprotocol.HelperResponseBody{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("helper response error = %v", err)
+	if receive.nextSequenceValue() != 1 || receive.maximumBodyBytesValue() != credentialprotocol.MaxHelperPacketBodyBytes || receive.maximumRightsValue() != 0 {
+		t.Fatal("helper receive request lost sequence or budget")
+	}
+	gotID, set := receive.expectedRequestIDValue()
+	if !set || gotID != requestID || receive.expectedIdentityDigestValue() != identity {
+		t.Fatal("helper receive request lost expected identity")
+	}
+	unset, err := newHelperControlReceiveRequest(2, 1, 1, [16]byte{}, false, identity)
+	if err != nil || unset.maximumRightsValue() != 1 {
+		t.Fatalf("unset request-id receive error = %v rights=%d", err, unset.maximumRightsValue())
+	}
+	if _, set := unset.expectedRequestIDValue(); set {
+		t.Fatal("unset expected request ID was reported set")
+	}
+
+	for _, test := range []struct {
+		name string
+		call func() error
+	}{
+		{name: "zero sequence", call: func() error {
+			_, err := newHelperControlReceiveRequest(0, 1, 0, [16]byte{}, false, identity)
+			return err
+		}},
+		{name: "oversize body", call: func() error {
+			_, err := newHelperControlReceiveRequest(1, credentialprotocol.MaxHelperPacketBodyBytes+1, 0, [16]byte{}, false, identity)
+			return err
+		}},
+		{name: "too many rights", call: func() error {
+			_, err := newHelperControlReceiveRequest(1, 1, 2, [16]byte{}, false, identity)
+			return err
+		}},
+		{name: "zero identity", call: func() error {
+			_, err := newHelperControlReceiveRequest(1, 1, 0, [16]byte{}, false, [32]byte{})
+			return err
+		}},
+		{name: "expected id missing", call: func() error {
+			_, err := newHelperControlReceiveRequest(1, 1, 0, [16]byte{}, true, identity)
+			return err
+		}},
+		{name: "unexpected id present", call: func() error {
+			_, err := newHelperControlReceiveRequest(1, 1, 0, requestID, false, identity)
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.call(); !errors.Is(err, errInvalidHelperReceiveRequest) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestL8D6GuestPacketHelperUnionsMirrorReadinessDiscipline(t *testing.T) {
+	identity := testHelperPacketIdentity()
+	requestID := testHelperPacketRequestID()
+	nonce := testHelperPacketNonce()
+	response := testHelperPrepareResponseBody()
+	event := credentialprotocol.HelperEventBody{Code: credentialprotocol.EventCodeExpired, Revision: 1, EventID: "event:1"}
+	credit := credentialprotocol.HelperExecCreditBody{Revision: 1, StreamKind: credentialprotocol.HelperExecStreamStdin, NextOffset: 8}
+	closeBody := credentialprotocol.HelperCloseNotifyBody{Reason: credentialprotocol.CloseReasonNormal}
+	emptyPayloadDigest := sha256.Sum256(nil)
+	payloadDigest := sha256.Sum256([]byte("payload"))
+	encodedResponse := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperResponseBody(response) })
+	encodedEvent := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperEventBody(event) })
+	encodedCredit := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperExecCreditBody(credit) })
+	encodedClose := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperCloseNotifyBody(closeBody) })
+	otherIdentity := identity
+	otherIdentity[31] ^= 0xff
+
+	t.Run("response", func(t *testing.T) {
+		receive := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		header := testHelperHeader(credentialprotocol.PacketTypeResponse, 1, requestID, identity, nonce, uint32(len(encodedResponse)))
+		owned := &testHelperBody{length: uint32(len(encodedResponse)), digest: sha256.Sum256(encodedResponse)}
+		packet, err := newHelperResponsePacket(receive, header, owned, response)
+		if err != nil {
+			t.Fatalf("newHelperResponsePacket() error = %v", err)
+		}
+		arm, ok := packet.responseValue()
+		if !ok || arm.RequestType != credentialprotocol.PacketTypePrepareCommit || packet.packetTypeValue() != credentialprotocol.PacketTypeResponse || !owned.destroyed {
+			t.Fatal("response packet did not retain typed ownership or destroy the non-sensitive body")
+		}
+		if _, err := newHelperResponsePacket(receive, header, nil, response); !errors.Is(err, errInvalidHelperReceiveRequest) {
+			t.Fatalf("consume-once error = %v", err)
+		}
+		mismatch := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperResponsePacket(mismatch, testHelperHeader(credentialprotocol.PacketTypeResponse, 2, requestID, identity, nonce, uint32(len(encodedResponse))), nil, response); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("sequence mismatch error = %v", err)
+		}
+		if _, err := newHelperResponsePacket(mismatch, header, nil, response); !errors.Is(err, errInvalidHelperReceiveRequest) {
+			t.Fatalf("failed issue did not consume receive request: %v", err)
+		}
+		identityMismatch := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperResponsePacket(identityMismatch, testHelperHeader(credentialprotocol.PacketTypeResponse, 1, requestID, otherIdentity, nonce, uint32(len(encodedResponse))), nil, response); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("identity mismatch error = %v", err)
+		}
+		unset := mustHelperReceiveRequest(t, 1, [16]byte{}, false, identity, 0)
+		if _, err := newHelperResponsePacket(unset, testHelperHeader(credentialprotocol.PacketTypeResponse, 1, requestID, identity, nonce, uint32(len(encodedResponse))), nil, response); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("missing expected request ID error = %v", err)
+		}
+		invalid := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperResponsePacket(invalid, header, nil, credentialprotocol.HelperResponseBody{}); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("validator failure error = %v", err)
+		}
+	})
+
+	t.Run("event", func(t *testing.T) {
+		receive := mustHelperReceiveRequest(t, 1, [16]byte{}, false, identity, 0)
+		header := testHelperHeader(credentialprotocol.PacketTypeEvent, 1, requestID, identity, nonce, uint32(len(encodedEvent)))
+		packet, err := newHelperEventPacket(receive, header, nil, event)
+		if err != nil {
+			t.Fatalf("idle event error = %v", err)
+		}
+		arm, ok := packet.eventValue()
+		if !ok || arm.EventID != event.EventID {
+			t.Fatal("event packet did not retain typed ownership")
+		}
+		matched := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperEventPacket(matched, header, nil, event); err != nil {
+			t.Fatalf("correlated event error = %v", err)
+		}
+		invalid := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperEventPacket(invalid, header, nil, credentialprotocol.HelperEventBody{}); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("validator failure error = %v", err)
+		}
+	})
+
+	t.Run("exec-stream", func(t *testing.T) {
+		receive := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		header := testHelperHeader(credentialprotocol.PacketTypeExecStream, 1, requestID, identity, nonce, helperExecStreamCanonicalPrefixBytes+7)
+		body := &testHelperBody{length: helperExecStreamCanonicalPrefixBytes + 7, digest: payloadDigest}
+		packet, err := newHelperExecStreamPacket(receive, header, body, 3, credentialprotocol.HelperExecStreamStdout, credentialprotocol.HelperExecStreamFlagsNone, 0, 7, payloadDigest)
+		if err != nil {
+			t.Fatalf("exec stream error = %v", err)
+		}
+		arm, ok := packet.execStreamValue()
+		if !ok || arm.revision != 3 || arm.payloadLength != 7 || body.destroyed || packet.body == nil {
+			t.Fatal("exec stream did not retain live payload body")
+		}
+		eofReceive := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		eofHeader := testHelperHeader(credentialprotocol.PacketTypeExecStream, 1, requestID, identity, nonce, helperExecStreamCanonicalPrefixBytes)
+		eofPacket, err := newHelperExecStreamPacket(eofReceive, eofHeader, nil, 3, credentialprotocol.HelperExecStreamStderr, credentialprotocol.HelperExecStreamFlagEOF, 7, 0, emptyPayloadDigest)
+		if err != nil {
+			t.Fatalf("eof stream error = %v", err)
+		}
+		eofArm, ok := eofPacket.execStreamValue()
+		if !ok || eofArm.flags != credentialprotocol.HelperExecStreamFlagEOF {
+			t.Fatal("eof stream arm missing")
+		}
+		stdin := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperExecStreamPacket(stdin, header, nil, 3, credentialprotocol.HelperExecStreamStdin, credentialprotocol.HelperExecStreamFlagsNone, 0, 7, payloadDigest); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("stdin stream error = %v", err)
+		}
+	})
+
+	t.Run("exec-credit", func(t *testing.T) {
+		receive := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		header := testHelperHeader(credentialprotocol.PacketTypeExecCredit, 1, requestID, identity, nonce, uint32(len(encodedCredit)))
+		packet, err := newHelperExecCreditPacket(receive, header, nil, credit)
+		if err != nil {
+			t.Fatalf("exec credit error = %v", err)
+		}
+		arm, ok := packet.execCreditValue()
+		if !ok || arm.NextOffset != 8 {
+			t.Fatal("exec credit packet did not retain typed ownership")
+		}
+		stdout := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		stdoutCredit := credit
+		stdoutCredit.StreamKind = credentialprotocol.HelperExecStreamStdout
+		if _, err := newHelperExecCreditPacket(stdout, header, nil, stdoutCredit); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("stdout credit error = %v", err)
+		}
+	})
+
+	t.Run("ssh-accepted", func(t *testing.T) {
+		digest := [32]byte{0x41}
+		issuer := &sshTestIssuer{digest: digest}
+		receive := mustHelperReceiveRequest(t, 1, requestID, true, identity, 1)
+		header := testHelperHeader(credentialprotocol.PacketTypeSSHAcceptedFD, 1, requestID, identity, nonce, credentialprotocol.HelperSSHAcceptedFDBodyEncodedLength())
+		packet, err := newHelperSSHAcceptedPacket(receive, header, nil, 7, 2, 3, digest, issuer)
+		if err != nil {
+			t.Fatalf("ssh accepted error = %v", err)
+		}
+		arm, ok := packet.sshAcceptedValue()
+		if !ok || arm.Revision() != 7 || arm.BindingIndex() != 2 || arm.Ordinal() != 3 || arm.CapabilitySHA256() != digest {
+			t.Fatal("ssh accepted packet lost metadata")
+		}
+		if reflect.TypeOf(arm.Connection()) == reflect.TypeOf(issuer) || issuer.closes.Load() != 0 {
+			t.Fatal("ssh accepted packet exposed the issuer or closed it")
+		}
+		idle := mustHelperReceiveRequest(t, 1, [16]byte{}, false, identity, 1)
+		idleIssuer := &sshTestIssuer{digest: digest}
+		if _, err := newHelperSSHAcceptedPacket(idle, header, nil, 7, 2, 3, digest, idleIssuer); err != nil {
+			t.Fatalf("idle ssh accepted error = %v", err)
+		}
+		noRight := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		closedIssuer := &sshTestIssuer{digest: digest}
+		if _, err := newHelperSSHAcceptedPacket(noRight, header, nil, 7, 2, 3, digest, closedIssuer); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("zero-rights ssh error = %v", err)
+		}
+		if closedIssuer.closes.Load() != 1 {
+			t.Fatalf("failed ssh constructor Close calls = %d, want 1", closedIssuer.closes.Load())
+		}
+	})
+
+	t.Run("close-notify", func(t *testing.T) {
+		receive := mustHelperReceiveRequest(t, 1, [16]byte{}, false, identity, 0)
+		header := testHelperHeader(credentialprotocol.PacketTypeCloseNotify, 1, [16]byte{}, identity, nonce, uint32(len(encodedClose)))
+		packet, err := newHelperCloseNotifyPacket(receive, header, nil, closeBody)
+		if err != nil {
+			t.Fatalf("close notify error = %v", err)
+		}
+		arm, ok := packet.closeNotifyValue()
+		if !ok || arm.Reason != credentialprotocol.CloseReasonNormal {
+			t.Fatal("close notify packet did not retain typed ownership")
+		}
+		outstanding := mustHelperReceiveRequest(t, 1, requestID, true, identity, 0)
+		if _, err := newHelperCloseNotifyPacket(outstanding, header, nil, closeBody); !errors.Is(err, errInvalidHelperPacket) {
+			t.Fatalf("close with expected request ID error = %v", err)
+		}
+	})
+}
+
+func TestL8D6GuestPacketHelperSendWriteCanonicalBody(t *testing.T) {
+	identity := testHelperPacketIdentity()
+	nonce := testHelperPacketNonce()
+	closeBody := credentialprotocol.HelperCloseNotifyBody{Reason: credentialprotocol.CloseReasonShutdown}
+	encoded := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperCloseNotifyBody(closeBody) })
+	header := testHelperHeader(credentialprotocol.PacketTypeCloseNotify, 1, [16]byte{}, identity, nonce, uint32(len(encoded)))
+	packet, err := finishHelperSendPacket(header, helperSendArmClose, helperSendArm{kind: helperSendArmClose, close: closeBody})
+	if err != nil {
+		t.Fatalf("finishHelperSendPacket() error = %v", err)
+	}
+	if packet.packetTypeValue() != credentialprotocol.PacketTypeCloseNotify || packet.encodedBodyLengthValue() != uint32(len(encoded)) || packet.bodySHA256Value() != sha256.Sum256(encoded) {
+		t.Fatal("helper send packet did not pin canonical body length and digest")
+	}
+	sink := &testCanonicalBodySink{capacity: packet.encodedBodyLengthValue()}
+	if err := packet.writeCanonicalBody(sink); err != nil {
+		t.Fatalf("writeCanonicalBody() error = %v", err)
+	}
+	if string(sink.buf) != string(encoded) {
+		t.Fatalf("canonical body = %s, want %s", sink.buf, encoded)
+	}
+	if err := packet.writeCanonicalBody(sink); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Fatalf("second writeCanonicalBody() error = %v", err)
 	}
 	if err := (HelperSendPacket{}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("helper writeCanonicalBody error = %v", err)
+		t.Fatalf("zero helper send write error = %v", err)
+	}
+	if err := (HelperSendPacket{arm: helperSendArmPrepareFile}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("payload helper send write error = %v", err)
 	}
 }
 
@@ -856,6 +1109,84 @@ func mustEncode(t *testing.T, encode func() ([]byte, error)) []byte {
 		t.Fatal(err)
 	}
 	return body
+}
+
+func testHelperPacketIdentity() [32]byte {
+	var identity [32]byte
+	for index := range identity {
+		identity[index] = byte(index + 1)
+	}
+	return identity
+}
+
+func testHelperPacketNonce() [32]byte {
+	var nonce [32]byte
+	for index := range nonce {
+		nonce[index] = byte(index + 17)
+	}
+	return nonce
+}
+
+func testHelperPacketRequestID() [16]byte {
+	var requestID [16]byte
+	for index := range requestID {
+		requestID[index] = byte(index + 3)
+	}
+	return requestID
+}
+
+func mustHelperReceiveRequest(t *testing.T, sequence uint64, requestID [16]byte, requestIDSet bool, identity [32]byte, maximumRights uint32) HelperReceiveRequest {
+	t.Helper()
+	receive, err := newHelperControlReceiveRequest(sequence, credentialprotocol.MaxHelperPacketBodyBytes, maximumRights, requestID, requestIDSet, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receive
+}
+
+func testHelperHeader(packetType credentialprotocol.PacketType, sequence uint64, requestID [16]byte, identity, nonce [32]byte, bodyLength uint32) credentialprotocol.HelperPacketHeader {
+	return credentialprotocol.HelperPacketHeader{
+		Type:                          packetType,
+		Sequence:                      sequence,
+		RequestID:                     requestID,
+		BodyLength:                    bodyLength,
+		GuestCredentialIdentityDigest: identity,
+		BootNonce:                     nonce,
+	}
+}
+
+func testHelperPrepareResponseBody() credentialprotocol.HelperResponseBody {
+	return credentialprotocol.HelperResponseBody{
+		RequestType: credentialprotocol.PacketTypePrepareCommit,
+		Disposition: credentialprotocol.ResponseDispositionAccepted,
+		Revision:    1,
+		FailureCode: credentialprotocol.FailureCodeNone,
+		Prepare: &credentialprotocol.HelperPrepareResponseResult{
+			ExpiresAtUnixNano: 1700000001123456789,
+			ActiveProofID:     "active-proof",
+			ExecBindingID:     "exec-binding",
+			BindingProofs: []credentialprotocol.HelperBindingProof{
+				{BindingID: "binding-http", Mode: credentialprotocol.DeliveryModeHTTPProxy, ProofID: "proof-http"},
+				{BindingID: "binding-file", Mode: credentialprotocol.DeliveryModeFileTmpfs, ProofID: "proof-file"},
+			},
+		},
+	}
+}
+
+type testHelperBody struct {
+	length    uint32
+	digest    [32]byte
+	destroyed bool
+}
+
+func (body *testHelperBody) Len() uint32      { return body.length }
+func (body *testHelperBody) SHA256() [32]byte { return body.digest }
+func (body *testHelperBody) Borrow(context.Context, func(credentialmemory.BorrowedView) error) error {
+	return nil
+}
+func (body *testHelperBody) Destroy(context.Context) error {
+	body.destroyed = true
+	return nil
 }
 
 type testCanonicalBodySink struct {


### PR DESCRIPTION
## Summary
Metadata-only helper packet constructors: receive request plus response/event/exec-stream/credit/SSH-accepted/close-notify unions, and `HelperSendPacket.writeCanonicalBody` for non-payload send arms.

Consume-once, sequence, identity. No bind/listen/dial/SCM_RIGHTS. Live helper transport remains unaccepted.

Serve (from PR #53) now builds a valid helper receive after prepare/renew/revoke/exec and still fails closed on unimplemented helper **send** constructors.

Controller unknown/malformed/private/stream/credit/close remain unaccepted.

## Tests
- `go test ./internal/sandboxruntime/microvm/guestagent/server/credentialclient -run '^TestL8D6Guest(Control|Transport|Packet|CredentialClient)' -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.