### PR TITLE
feat: US-049 - L8 remaining guest v2 packet constructors

### DIFF
--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -15,11 +15,16 @@ controller packet as its sequence, session, request-ID, identity-digest, and
 lifecycle-correlation authority. Helper receive construction, helper packet
 unions, and helper `writeCanonicalBody` for non-payload send arms follow that
 same consume-once sequence and identity discipline as metadata constructors.
-Live helper transport, SCM_RIGHTS, bind/listen/dial, and helper send constructors
-remain unaccepted. Unknown and malformed controller arms and
-private/stream/credit/close-notify controller packets remain
-`dependency_unaccepted`. Serve fails closed when a later operation needs an
-unimplemented helper send issuer instead of synthesizing proofs.
+Controller unknown, malformed-known, private, stream, credit, and close-notify
+packet constructors are accepted metadata-only issuers. Helper send constructors
+for prepare-begin, prepare-commit, renew, revoke, exec, stdout/stderr exec-credit,
+and close-notify are accepted metadata-only issuers and write canonical bodies
+through `writeCanonicalBody`. Live helper transport, SCM_RIGHTS, bind/listen/dial,
+SSH-accepted send, and payload-bearing helper send (prepare-file, exec-private,
+and nonempty exec-stream) remain `dependency_unaccepted` because they require
+live rights or locked payload delivery. Serve fails closed when a later
+operation needs an unimplemented helper payload send issuer instead of
+synthesizing proofs.
 
 The frozen surface is limited to:
 

--- a/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
+++ b/docs/design/sandbox-runtime-v2-l8-d6-guest-control-contract-red.md
@@ -16,10 +16,15 @@ lifecycle-correlation authority. Helper receive construction, helper packet
 unions, and helper `writeCanonicalBody` for non-payload send arms follow that
 same consume-once sequence and identity discipline as metadata constructors.
 Controller unknown, malformed-known, private, stream, credit, and close-notify
-packet constructors are accepted metadata-only issuers. Helper send constructors
+packet constructors are accepted private issuers. Private and nonempty stdin
+packets retain one locked body capability; the current `Serve` path destroys and
+rejects every such body because live payload forwarding remains unaccepted.
+Helper send constructors
 for prepare-begin, prepare-commit, renew, revoke, exec, stdout/stderr exec-credit,
 and close-notify are accepted metadata-only issuers and write canonical bodies
-through `writeCanonicalBody`. Live helper transport, SCM_RIGHTS, bind/listen/dial,
+through `writeCanonicalBody`. Receive and helper-send sequences are bounded to
+the frozen `2^32` record cap, and helper close-notify uses an exact zero request
+ID. Live helper transport, SCM_RIGHTS, bind/listen/dial,
 SSH-accepted send, and payload-bearing helper send (prepare-file, exec-private,
 and nonempty exec-stream) remain `dependency_unaccepted` because they require
 live rights or locked payload delivery. Serve fails closed when a later

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
@@ -135,9 +135,9 @@ func requirePinnedCredentialIdentity(expectedIdentitySet bool, expected, observe
 }
 
 func helperPacketDependencyUnaccepted(identity v2control.IdentityDigest) error {
-	// Helper receive is implemented; first helper receive after a controller
-	// credential op has no expected request ID yet. Helper send constructors
-	// remain unaccepted.
+	// Helper receive and metadata-only helper send constructors exist. Serve
+	// still fails closed here because payload-bearing helper send, SSH rights,
+	// and live helper transport remain unaccepted; do not mint proofs.
 	_, err := newHelperControlReceiveRequest(1, credentialprotocol.MaxHelperPacketBodyBytes, 0, [16]byte{}, false, identity.Bytes())
 	if err != nil {
 		return err

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red.go
@@ -41,6 +41,13 @@ func (client *Client) serveCredentialLifecycle(ctx context.Context) (err error) 
 		if panicked {
 			return clientError(ClientContractPanic, ClientFieldPacketType)
 		}
+		bodyPresent, cleanupErr := rejectControllerPacketBody(&packet)
+		if cleanupErr != nil {
+			return clientError(ClientContractCleanup, ClientFieldBody)
+		}
+		if bodyPresent {
+			return clientError(ClientContractPacket, ClientFieldBody)
+		}
 		if dispatchErr != nil {
 			if client.drainStarted() || ctx.Err() != nil {
 				return nil
@@ -92,6 +99,21 @@ func (client *Client) serveCredentialLifecycle(ctx context.Context) (err error) 
 		}
 		return clientError(ClientContractPacket, ClientFieldPacketType)
 	}
+}
+
+// rejectControllerPacketBody closes the current default-off boundary: no
+// controller payload arm has a live consumer yet. Future payload forwarding
+// must explicitly transfer and clear this owner before dispatch continues.
+func rejectControllerPacketBody(packet *ControllerPacket) (present bool, cleanupErr error) {
+	if packet == nil || packet.body == nil {
+		return false, nil
+	}
+	body := packet.body
+	packet.body = nil
+	if !configuredDependency(body) {
+		return true, nil
+	}
+	return true, destroyControllerBody(body)
 }
 
 func acceptControllerPrepareIdentity(sessionID [32]byte, hardExpiryUnixNano int64, prepare v2control.CredentialPrepareRequest, expectedIdentity v2control.IdentityDigest, expectedIdentitySet bool) (v2control.IdentityDigest, error) {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/client_dispatch_red_test.go
@@ -2,6 +2,7 @@ package credentialclient
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"strings"
 	"sync"
@@ -152,6 +153,104 @@ func TestL8D6GuestCredentialClientDispatcherContainsDependencyErrorAndPanic(t *t
 				t.Fatalf("Serve() error = %v, want sanitized code %d", err, test.code)
 			}
 		})
+	}
+}
+
+func TestL8D6GuestCredentialClientServeDestroysRejectedControllerBodies(t *testing.T) {
+	identity := testDispatchTransportIdentity()
+	payload := []byte("controller-private-payload")
+	digest := sha256.Sum256(payload)
+
+	for _, test := range []struct {
+		name     string
+		packet   func(*testHelperBody) ControllerPacket
+		err      error
+		body     *testHelperBody
+		wantCode ClientContractErrorCode
+	}{
+		{
+			name: "transport-error",
+			packet: func(body *testHelperBody) ControllerPacket {
+				return ControllerPacket{body: body}
+			},
+			err:      errors.New("receive failed"),
+			wantCode: ClientContractPacket,
+		},
+		{
+			name: "cross-session",
+			packet: func(body *testHelperBody) ControllerPacket {
+				otherSession := identity.sessionID
+				otherSession[0] ^= 0xff
+				return ControllerPacket{sequence: 1, sessionID: otherSession, body: body}
+			},
+			wantCode: ClientContractPacket,
+		},
+		{
+			name: "unsupported-private",
+			packet: func(body *testHelperBody) ControllerPacket {
+				return ControllerPacket{
+					sequence:  1,
+					sessionID: identity.sessionID,
+					arm:       controllerPacketArm{kind: controllerPacketArmPrivate},
+					body:      body,
+				}
+			},
+			wantCode: ClientContractPacket,
+		},
+		{
+			name: "unsupported-stream",
+			packet: func(body *testHelperBody) ControllerPacket {
+				return ControllerPacket{
+					sequence:  1,
+					sessionID: identity.sessionID,
+					arm:       controllerPacketArm{kind: controllerPacketArmStream},
+					body:      body,
+				}
+			},
+			wantCode: ClientContractPacket,
+		},
+		{
+			name: "destroy-error",
+			packet: func(body *testHelperBody) ControllerPacket {
+				return ControllerPacket{sequence: 1, sessionID: identity.sessionID, body: body}
+			},
+			body:     &testHelperBody{length: uint32(len(payload)), digest: digest, destroyErr: errors.New("destroy failed")},
+			wantCode: ClientContractCleanup,
+		},
+		{
+			name: "destroy-panic",
+			packet: func(body *testHelperBody) ControllerPacket {
+				return ControllerPacket{sequence: 1, sessionID: identity.sessionID, body: body}
+			},
+			body:     &testHelperBody{length: uint32(len(payload)), digest: digest, destroyPanic: true},
+			wantCode: ClientContractCleanup,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := test.body
+			if body == nil {
+				body = &testHelperBody{length: uint32(len(payload)), digest: digest}
+			}
+			transport := &dispatchRedTransport{identity: identity}
+			transport.receiveController = func(context.Context, ControllerReceiveRequest) (ControllerPacket, error) {
+				return test.packet(body), test.err
+			}
+			if err := newDispatchRedClient(t, transport).Serve(context.Background()); clientContractCode(err) != test.wantCode {
+				t.Fatalf("Serve() error = %v, want code %d", err, test.wantCode)
+			}
+			if !body.destroyed {
+				t.Fatal("Serve did not destroy the rejected controller body")
+			}
+		})
+	}
+
+	var typedNilBody *testHelperBody
+	transport := &dispatchRedTransport{identity: identity}
+	transport.receiveController = func(context.Context, ControllerReceiveRequest) (ControllerPacket, error) {
+		return ControllerPacket{sequence: 1, sessionID: identity.sessionID, body: typedNilBody}, nil
+	}
+	if err := newDispatchRedClient(t, transport).Serve(context.Background()); clientContractCode(err) != ClientContractPacket {
+		t.Fatalf("Serve() typed-nil body error = %v, want code %d", err, ClientContractPacket)
 	}
 }
 

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
@@ -418,12 +418,41 @@ func (request HelperReceiveRequest) expectedIdentityDigestValue() [32]byte {
 	return request.expectedIdentity
 }
 
-func newControllerUnknownOperationPacket(ControllerReceiveRequest, uint64, [32]byte, v2control.InspectedRequest) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func newControllerUnknownOperationPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, inspected v2control.InspectedRequest) (ControllerPacket, error) {
+	return newControllerInspectedPacket(request, sequence, sessionID, inspected, false, controllerPacketArmUnknown)
 }
 
-func newControllerMalformedKnownPacket(ControllerReceiveRequest, uint64, [32]byte, v2control.InspectedRequest) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func newControllerMalformedKnownPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, inspected v2control.InspectedRequest) (ControllerPacket, error) {
+	return newControllerInspectedPacket(request, sequence, sessionID, inspected, true, controllerPacketArmMalformed)
+}
+
+func newControllerInspectedPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, inspected v2control.InspectedRequest, requireKnown bool, kind controllerPacketArmKind) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if _, err := v2control.EncodeOperationToken(inspected.OperationToken()); err != nil {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if _, err := v2control.EncodeRequestID(inspected.RequestID()); err != nil {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	_, known := inspected.KnownOperation()
+	if known != requireKnown {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != inspected.IdentityDigest() {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	packet := ControllerPacket{sequence: sequence, sessionID: sessionID}
+	if requireKnown {
+		packet.arm = controllerPacketArm{kind: kind, malformed: controllerMalformedKnown{inspected: inspected}}
+	} else {
+		packet.arm = controllerPacketArm{kind: kind, unknown: controllerUnknownOperation{inspected: inspected}}
+	}
+	return packet, nil
 }
 
 func newControllerReadinessPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, readiness v2control.ReadinessRequest) (ControllerPacket, error) {
@@ -640,20 +669,149 @@ func encodeControllerSendCanonicalBody(kind controllerSendArmKind, arm controlle
 	}
 }
 
-func newControllerPrivatePacket(ControllerReceiveRequest, uint64, [32]byte, credentialprotocol.PrivateRecordKind, v2control.RequestID, v2control.IdentityDigest, uint16, uint16, uint16, uint32, [32]byte, controllerBodyCapability) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func newControllerPrivatePacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, kind credentialprotocol.PrivateRecordKind, requestID v2control.RequestID, identityDigest v2control.IdentityDigest, bindingIndex, chunkIndex, chunkCount uint16, payloadLength uint32, payloadSHA256 [32]byte, body controllerBodyCapability) (packet ControllerPacket, err error) {
+	retainedBody := false
+	defer func() {
+		if err != nil && !retainedBody {
+			_ = destroyControllerBody(body)
+		}
+	}()
+	if consumeErr := consumeControllerReceiveRequest(request); consumeErr != nil {
+		return ControllerPacket{}, consumeErr
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		!validControllerPrivateMetadata(kind, requestID, identityDigest, bindingIndex, chunkIndex, chunkCount, payloadLength, payloadSHA256) ||
+		!configuredDependency(body) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	length, digest, ok := controllerBodyMetadata(body)
+	if !ok || length != payloadLength || digest != payloadSHA256 {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != identityDigest {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	retainedBody = true
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm: controllerPacketArm{
+			kind: controllerPacketArmPrivate,
+			private: controllerPrivateRecord{
+				kind:           kind,
+				requestID:      requestID,
+				identityDigest: identityDigest,
+				bindingIndex:   bindingIndex,
+				chunkIndex:     chunkIndex,
+				chunkCount:     chunkCount,
+				payloadLength:  payloadLength,
+				payloadSHA256:  payloadSHA256,
+			},
+		},
+		body: body,
+	}, nil
 }
 
-func newControllerStreamPacket(ControllerReceiveRequest, uint64, [32]byte, credentialprotocol.HelperExecStreamKind, credentialprotocol.HelperExecStreamFlags, v2control.RequestID, v2control.IdentityDigest, uint64, uint32, [32]byte, controllerBodyCapability) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func newControllerStreamPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, kind credentialprotocol.HelperExecStreamKind, flags credentialprotocol.HelperExecStreamFlags, requestID v2control.RequestID, identityDigest v2control.IdentityDigest, offset uint64, payloadLength uint32, payloadSHA256 [32]byte, body controllerBodyCapability) (packet ControllerPacket, err error) {
+	retainedBody := false
+	defer func() {
+		if err != nil && !retainedBody {
+			_ = destroyControllerBody(body)
+		}
+	}()
+	if consumeErr := consumeControllerReceiveRequest(request); consumeErr != nil {
+		return ControllerPacket{}, consumeErr
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		!validControllerReceiveExecStream(kind, flags, payloadLength, payloadSHA256) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if _, err := v2control.EncodeRequestID(requestID); err != nil {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if identityDigest == (v2control.IdentityDigest{}) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if payloadLength == 0 {
+		if configuredDependency(body) {
+			return ControllerPacket{}, errInvalidControllerPacket
+		}
+	} else if !configuredDependency(body) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	} else {
+		length, digest, ok := controllerBodyMetadata(body)
+		if !ok || length != payloadLength || digest != payloadSHA256 {
+			return ControllerPacket{}, errInvalidControllerPacket
+		}
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != identityDigest {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	retainedBody = configuredDependency(body)
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm: controllerPacketArm{
+			kind: controllerPacketArmStream,
+			stream: controllerStreamRecord{
+				kind:           kind,
+				flags:          flags,
+				requestID:      requestID,
+				identityDigest: identityDigest,
+				offset:         offset,
+				payloadLength:  payloadLength,
+				payloadSHA256:  payloadSHA256,
+			},
+		},
+		body: body,
+	}, nil
 }
 
-func newControllerCreditPacket(ControllerReceiveRequest, uint64, [32]byte, credentialprotocol.HelperExecStreamKind, v2control.RequestID, v2control.IdentityDigest, uint64) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func newControllerCreditPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, kind credentialprotocol.HelperExecStreamKind, requestID v2control.RequestID, identityDigest v2control.IdentityDigest, nextOffset uint64) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		!validControllerReceiveCredit(kind) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if _, err := v2control.EncodeRequestID(requestID); err != nil {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if identityDigest == (v2control.IdentityDigest{}) {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	if request.expectedIdentitySet && request.expectedIdentity != identityDigest {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm: controllerPacketArm{
+			kind: controllerPacketArmCredit,
+			credit: controllerCreditRecord{
+				kind:           kind,
+				requestID:      requestID,
+				identityDigest: identityDigest,
+				nextOffset:     nextOffset,
+			},
+		},
+	}, nil
 }
 
-func newControllerCloseNotifyPacket(ControllerReceiveRequest, uint64, [32]byte, credentialprotocol.CloseReason) (ControllerPacket, error) {
-	return ControllerPacket{}, ErrClientControlDependencyUnaccepted
+func newControllerCloseNotifyPacket(request ControllerReceiveRequest, sequence uint64, sessionID [32]byte, reason credentialprotocol.CloseReason) (ControllerPacket, error) {
+	if err := consumeControllerReceiveRequest(request); err != nil {
+		return ControllerPacket{}, err
+	}
+	if sequence == 0 || sequence != request.nextSequence || sessionID == ([32]byte{}) ||
+		credentialprotocol.ValidateCloseReason(reason) != nil {
+		return ControllerPacket{}, errInvalidControllerPacket
+	}
+	return ControllerPacket{
+		sequence:  sequence,
+		sessionID: sessionID,
+		arm:       controllerPacketArm{kind: controllerPacketArmClose, close: reason},
+	}, nil
 }
 
 func (packet ControllerPacket) sequenceValue() uint64    { return packet.sequence }
@@ -997,6 +1155,21 @@ func validHelperReceiveExecStream(kind credentialprotocol.HelperExecStreamKind, 
 	if kind != credentialprotocol.HelperExecStreamStdout && kind != credentialprotocol.HelperExecStreamStderr {
 		return false
 	}
+	return validHelperExecStreamShape(flags, payloadLength, payloadSHA256)
+}
+
+func validControllerReceiveExecStream(kind credentialprotocol.HelperExecStreamKind, flags credentialprotocol.HelperExecStreamFlags, payloadLength uint32, payloadSHA256 [32]byte) bool {
+	if kind != credentialprotocol.HelperExecStreamStdin {
+		return false
+	}
+	return validHelperExecStreamShape(flags, payloadLength, payloadSHA256)
+}
+
+func validControllerReceiveCredit(kind credentialprotocol.HelperExecStreamKind) bool {
+	return kind == credentialprotocol.HelperExecStreamStdout || kind == credentialprotocol.HelperExecStreamStderr
+}
+
+func validHelperExecStreamShape(flags credentialprotocol.HelperExecStreamFlags, payloadLength uint32, payloadSHA256 [32]byte) bool {
 	if flags != credentialprotocol.HelperExecStreamFlagsNone && flags != credentialprotocol.HelperExecStreamFlagEOF {
 		return false
 	}
@@ -1013,6 +1186,34 @@ func validHelperReceiveExecStream(kind credentialprotocol.HelperExecStreamKind, 
 		return payloadSHA256 == sha256.Sum256(nil)
 	}
 	return payloadSHA256 != ([32]byte{})
+}
+
+func validControllerPrivateMetadata(kind credentialprotocol.PrivateRecordKind, requestID v2control.RequestID, identityDigest v2control.IdentityDigest, bindingIndex, chunkIndex, chunkCount uint16, payloadLength uint32, payloadSHA256 [32]byte) bool {
+	if kind != credentialprotocol.PrivateRecordKindFileBytes && kind != credentialprotocol.PrivateRecordKindOpaqueExecBinding {
+		return false
+	}
+	if _, err := v2control.EncodeRequestID(requestID); err != nil {
+		return false
+	}
+	if identityDigest == (v2control.IdentityDigest{}) {
+		return false
+	}
+	if chunkIndex != 0 || chunkCount != 1 {
+		return false
+	}
+	if payloadLength < 1 || payloadLength > credentialprotocol.MaxPrivateRecordPayloadBytes {
+		return false
+	}
+	if payloadSHA256 == ([32]byte{}) {
+		return false
+	}
+	if kind == credentialprotocol.PrivateRecordKindFileBytes && bindingIndex >= credentialprotocol.MaxPreparePrivateRecordCount {
+		return false
+	}
+	if kind == credentialprotocol.PrivateRecordKindOpaqueExecBinding && bindingIndex != 0 {
+		return false
+	}
+	return true
 }
 
 func validateOptionalHelperBody(body helperBodyCapability, encoded []byte) error {
@@ -1044,6 +1245,17 @@ func validateOptionalHelperBodyLength(body helperBodyCapability, length uint32) 
 }
 
 func helperBodyMetadata(body helperBodyCapability) (length uint32, digest [32]byte, ok bool) {
+	return bodyCapabilityMetadata(body)
+}
+
+func controllerBodyMetadata(body controllerBodyCapability) (length uint32, digest [32]byte, ok bool) {
+	return bodyCapabilityMetadata(body)
+}
+
+func bodyCapabilityMetadata(body interface {
+	Len() uint32
+	SHA256() [32]byte
+}) (length uint32, digest [32]byte, ok bool) {
 	defer func() {
 		if recover() != nil {
 			length = 0
@@ -1054,19 +1266,29 @@ func helperBodyMetadata(body helperBodyCapability) (length uint32, digest [32]by
 	return body.Len(), body.SHA256(), true
 }
 
-func destroyHelperBody(body helperBodyCapability) (err error) {
+func destroyHelperBody(body helperBodyCapability) error {
+	return destroyOwnedBody(body, errInvalidHelperPacket)
+}
+
+func destroyControllerBody(body controllerBodyCapability) error {
+	return destroyOwnedBody(body, errInvalidControllerPacket)
+}
+
+func destroyOwnedBody(body interface {
+	Destroy(context.Context) error
+}, invalid error) (err error) {
 	if !configuredDependency(body) {
 		return nil
 	}
 	defer func() {
 		if recover() != nil {
-			err = errInvalidHelperPacket
+			err = invalid
 		}
 	}()
 	ctx, cancel := context.WithTimeout(context.Background(), sshConnectionCleanupTimeout)
 	defer cancel()
 	if destroyErr := body.Destroy(ctx); destroyErr != nil {
-		return errInvalidHelperPacket
+		return invalid
 	}
 	return nil
 }
@@ -1191,12 +1413,66 @@ func encodeHelperSendCanonicalBody(kind helperSendArmKind, arm helperSendArm) ([
 	case helperSendArmExec:
 		return credentialprotocol.EncodeHelperExecBody(arm.exec)
 	case helperSendArmExecCredit:
+		if arm.execCredit.StreamKind != credentialprotocol.HelperExecStreamStdout &&
+			arm.execCredit.StreamKind != credentialprotocol.HelperExecStreamStderr {
+			return nil, errInvalidHelperSendPacket
+		}
 		return credentialprotocol.EncodeHelperExecCreditBody(arm.execCredit)
 	case helperSendArmClose:
 		return credentialprotocol.EncodeHelperCloseNotifyBody(arm.close)
 	default:
 		return nil, ErrClientControlDependencyUnaccepted
 	}
+}
+
+func newHelperPrepareBeginSendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperPrepareBeginBody) (HelperSendPacket, error) {
+	cloned := body
+	cloned.Bindings = cloneValues(body.Bindings)
+	return newHelperMetadataSendPacket(header, helperSendArmPrepareBegin, helperSendArm{kind: helperSendArmPrepareBegin, prepareBegin: cloned})
+}
+
+func newHelperPrepareCommitSendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperPrepareCommitBody) (HelperSendPacket, error) {
+	return newHelperMetadataSendPacket(header, helperSendArmPrepareCommit, helperSendArm{kind: helperSendArmPrepareCommit, prepareCommit: body})
+}
+
+func newHelperRenewSendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperRenewBody) (HelperSendPacket, error) {
+	return newHelperMetadataSendPacket(header, helperSendArmRenew, helperSendArm{kind: helperSendArmRenew, renew: body})
+}
+
+func newHelperRevokeSendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperRevokeBody) (HelperSendPacket, error) {
+	return newHelperMetadataSendPacket(header, helperSendArmRevoke, helperSendArm{kind: helperSendArmRevoke, revoke: body})
+}
+
+func newHelperExecSendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperExecBody) (HelperSendPacket, error) {
+	cloned := body
+	cloned.Plan.Arguments = cloneValues(body.Plan.Arguments)
+	cloned.Plan.Environment = cloneValues(body.Plan.Environment)
+	return newHelperMetadataSendPacket(header, helperSendArmExec, helperSendArm{kind: helperSendArmExec, exec: cloned})
+}
+
+func newHelperExecCreditSendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperExecCreditBody) (HelperSendPacket, error) {
+	if body.StreamKind != credentialprotocol.HelperExecStreamStdout &&
+		body.StreamKind != credentialprotocol.HelperExecStreamStderr {
+		return HelperSendPacket{}, errInvalidHelperSendPacket
+	}
+	return newHelperMetadataSendPacket(header, helperSendArmExecCredit, helperSendArm{kind: helperSendArmExecCredit, execCredit: body})
+}
+
+func newHelperCloseNotifySendPacket(header credentialprotocol.HelperPacketHeader, body credentialprotocol.HelperCloseNotifyBody) (HelperSendPacket, error) {
+	return newHelperMetadataSendPacket(header, helperSendArmClose, helperSendArm{kind: helperSendArmClose, close: body})
+}
+
+func newHelperMetadataSendPacket(header credentialprotocol.HelperPacketHeader, kind helperSendArmKind, arm helperSendArm) (HelperSendPacket, error) {
+	if header.Sequence == 0 {
+		return HelperSendPacket{}, errInvalidHelperSendPacket
+	}
+	header.Type = helperSendArmPacketType(kind)
+	encoded, err := encodeHelperSendCanonicalBody(kind, arm)
+	if err != nil || len(encoded) == 0 {
+		return HelperSendPacket{}, errInvalidHelperSendPacket
+	}
+	header.BodyLength = uint32(len(encoded))
+	return finishHelperSendPacket(header, kind, arm)
 }
 
 func helperSendArmPacketType(kind helperSendArmKind) credentialprotocol.PacketType {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red.go
@@ -338,7 +338,7 @@ type helperSendPacketOwner struct {
 }
 
 func newControlReceiveRequest(sequence uint64, identity v2control.IdentityDigest, identitySet bool, maximumPlaintextBytes uint32) (ControllerReceiveRequest, error) {
-	if sequence == 0 || maximumPlaintextBytes < 1 || maximumPlaintextBytes > session.MaxControlPlaintextBytes {
+	if sequence == 0 || sequence > uint64(^uint32(0)) || maximumPlaintextBytes < 1 || maximumPlaintextBytes > session.MaxControlPlaintextBytes {
 		return ControllerReceiveRequest{}, errInvalidControlReceiveRequest
 	}
 	if identitySet && identity == (v2control.IdentityDigest{}) {
@@ -367,7 +367,7 @@ func consumeControllerReceiveRequest(request ControllerReceiveRequest) error {
 }
 
 func newHelperControlReceiveRequest(sequence uint64, maximumBodyBytes, maximumRights uint32, expectedRequestID [16]byte, expectedRequestIDSet bool, expectedIdentity [32]byte) (HelperReceiveRequest, error) {
-	if sequence == 0 || maximumBodyBytes > credentialprotocol.MaxHelperPacketBodyBytes || maximumRights > 1 {
+	if sequence == 0 || sequence > uint64(^uint32(0)) || maximumBodyBytes > credentialprotocol.MaxHelperPacketBodyBytes || maximumRights > 1 {
 		return HelperReceiveRequest{}, errInvalidHelperReceiveRequest
 	}
 	if expectedIdentity == ([32]byte{}) {
@@ -1385,7 +1385,8 @@ func (packet HelperSendPacket) writeCanonicalBody(sink bodySegmentSink) (err err
 
 func finishHelperSendPacket(header credentialprotocol.HelperPacketHeader, kind helperSendArmKind, arm helperSendArm) (HelperSendPacket, error) {
 	body, err := encodeHelperSendCanonicalBody(kind, arm)
-	if err != nil || len(body) == 0 || header.BodyLength != uint32(len(body)) ||
+	if err != nil || len(body) == 0 || header.Sequence == 0 || header.Sequence > uint64(^uint32(0)) ||
+		(kind == helperSendArmClose && header.RequestID != ([16]byte{})) || header.BodyLength != uint32(len(body)) ||
 		credentialprotocol.ValidateHelperPacketHeaderSemantics(header) != nil || header.Type != helperSendArmPacketType(kind) {
 		return HelperSendPacket{}, errInvalidHelperSendPacket
 	}

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
@@ -270,6 +270,12 @@ func TestL8D6GuestControllerUnionConsumesOneExactReceiveRequest(t *testing.T) {
 	if _, err := newControllerReadinessPacket(receive, 1, sessionID, readiness); err == nil {
 		t.Fatal("receive request was consumed twice")
 	}
+	if _, err := newControlReceiveRequest(uint64(^uint32(0))+1, v2control.NewIdentityDigest(sessionID), true, session.MaxControlPlaintextBytes); !errors.Is(err, errInvalidControlReceiveRequest) {
+		t.Fatalf("exhausted control receive sequence error = %v", err)
+	}
+	if _, err := newControlReceiveRequest(uint64(^uint32(0)), v2control.NewIdentityDigest(sessionID), true, session.MaxControlPlaintextBytes); err != nil {
+		t.Fatalf("last legal control receive sequence error = %v", err)
+	}
 }
 
 func TestL8D6GuestControllerCredentialPacketsMirrorReadinessDiscipline(t *testing.T) {
@@ -810,6 +816,9 @@ func TestL8D6GuestPacketHelperReceiveRequestMirrorsControlDiscipline(t *testing.
 	if _, set := unset.expectedRequestIDValue(); set {
 		t.Fatal("unset expected request ID was reported set")
 	}
+	if _, err := newHelperControlReceiveRequest(uint64(^uint32(0)), 1, 0, [16]byte{}, false, identity); err != nil {
+		t.Fatalf("last legal helper receive sequence error = %v", err)
+	}
 
 	for _, test := range []struct {
 		name string
@@ -817,6 +826,10 @@ func TestL8D6GuestPacketHelperReceiveRequestMirrorsControlDiscipline(t *testing.
 	}{
 		{name: "zero sequence", call: func() error {
 			_, err := newHelperControlReceiveRequest(0, 1, 0, [16]byte{}, false, identity)
+			return err
+		}},
+		{name: "exhausted sequence", call: func() error {
+			_, err := newHelperControlReceiveRequest(uint64(^uint32(0))+1, 1, 0, [16]byte{}, false, identity)
 			return err
 		}},
 		{name: "oversize body", call: func() error {
@@ -1162,8 +1175,22 @@ func TestL8D6GuestPacketHelperSendWriteCanonicalBody(t *testing.T) {
 	if _, err := newHelperPrepareBeginSendPacket(testHelperHeader(0, 1, [16]byte{}, identity, nonce, 0), begin); !errors.Is(err, errInvalidHelperSendPacket) {
 		t.Fatalf("zero request ID helper send error = %v", err)
 	}
+	if _, err := newHelperPrepareBeginSendPacket(testHelperHeader(0, uint64(^uint32(0))+1, requestID, identity, nonce, 0), begin); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Errorf("exhausted sequence helper send error = %v", err)
+	}
+	if _, err := newHelperPrepareBeginSendPacket(testHelperHeader(0, uint64(^uint32(0)), requestID, identity, nonce, 0), begin); err != nil {
+		t.Errorf("last legal helper send sequence error = %v", err)
+	}
 	if _, err := newHelperExecCreditSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), credentialprotocol.HelperExecCreditBody{Revision: 3, StreamKind: credentialprotocol.HelperExecStreamStdin, NextOffset: 8}); !errors.Is(err, errInvalidHelperSendPacket) {
 		t.Fatalf("stdin helper credit send error = %v", err)
+	}
+	if _, err := newHelperCloseNotifySendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), closeBody); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Errorf("nonzero request ID helper close send error = %v", err)
+	}
+	nonzeroCloseBody := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperCloseNotifyBody(closeBody) })
+	nonzeroCloseHeader := testHelperHeader(credentialprotocol.PacketTypeCloseNotify, 1, requestID, identity, nonce, uint32(len(nonzeroCloseBody)))
+	if _, err := finishHelperSendPacket(nonzeroCloseHeader, helperSendArmClose, helperSendArm{kind: helperSendArmClose, close: closeBody}); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Errorf("direct nonzero request ID helper close finish error = %v", err)
 	}
 	if _, err := newHelperCloseNotifySendPacket(testHelperHeader(0, 1, [16]byte{}, identity, nonce, 0), credentialprotocol.HelperCloseNotifyBody{}); !errors.Is(err, errInvalidHelperSendPacket) {
 		t.Fatalf("unknown helper close send error = %v", err)
@@ -1534,9 +1561,11 @@ func testHelperPrepareResponseBody() credentialprotocol.HelperResponseBody {
 }
 
 type testHelperBody struct {
-	length    uint32
-	digest    [32]byte
-	destroyed bool
+	length       uint32
+	digest       [32]byte
+	destroyed    bool
+	destroyErr   error
+	destroyPanic bool
 }
 
 func (body *testHelperBody) Len() uint32      { return body.length }
@@ -1546,7 +1575,10 @@ func (body *testHelperBody) Borrow(context.Context, func(credentialmemory.Borrow
 }
 func (body *testHelperBody) Destroy(context.Context) error {
 	body.destroyed = true
-	return nil
+	if body.destroyPanic {
+		panic("test controller body destroy panic")
+	}
+	return body.destroyErr
 }
 
 type testCanonicalBodySink struct {

--- a/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
+++ b/internal/sandboxruntime/microvm/guestagent/server/credentialclient/control_contract_red_test.go
@@ -572,28 +572,221 @@ func TestL8D6GuestControllerSendPacketsWriteCanonicalJSON(t *testing.T) {
 	}
 }
 
-func TestL8D6GuestControllerRemainingPacketsStayUnaccepted(t *testing.T) {
-	receive := mustControlReceiveRequest(t, 1, v2control.IdentityDigest{}, false)
-	var sessionID [32]byte
-	sessionID[0] = 1
-	if _, err := newControllerUnknownOperationPacket(receive, 1, sessionID, v2control.InspectedRequest{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("unknown packet error = %v", err)
-	}
-	if _, err := newControllerMalformedKnownPacket(receive, 1, sessionID, v2control.InspectedRequest{}); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("malformed packet error = %v", err)
-	}
-	if _, err := newControllerPrivatePacket(receive, 1, sessionID, 0, v2control.RequestID{}, v2control.IdentityDigest{}, 0, 0, 0, 0, [32]byte{}, nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("private packet error = %v", err)
-	}
-	if _, err := newControllerStreamPacket(receive, 1, sessionID, 0, 0, v2control.RequestID{}, v2control.IdentityDigest{}, 0, 0, [32]byte{}, nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("stream packet error = %v", err)
-	}
-	if _, err := newControllerCreditPacket(receive, 1, sessionID, 0, v2control.RequestID{}, v2control.IdentityDigest{}, 0); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("credit packet error = %v", err)
-	}
-	if _, err := newControllerCloseNotifyPacket(receive, 1, sessionID, 0); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("close notify packet error = %v", err)
-	}
+func TestL8D6GuestControllerRemainingPacketsMirrorReadinessDiscipline(t *testing.T) {
+	sessionID := testCredentialPacketSessionID()
+	identity := testCredentialPacketSessionIdentity(t, sessionID)
+	digest := identityDigestForSession(t, identity)
+	requestID := testPacketRequestID(t)
+	prepare := testCredentialPreparePacketRequest(t, requestID, identity)
+	unknown := testInspectedUnknownRequest(t, requestID, digest)
+	malformed := testInspectedKnownRequest(t, prepare)
+	payload := []byte("private-payload")
+	payloadDigest := sha256.Sum256(payload)
+	emptyDigest := sha256.Sum256(nil)
+	otherSessionID := sessionID
+	otherSessionID[31] ^= 0xff
+
+	t.Run("unknown", func(t *testing.T) {
+		receive := mustControlReceiveRequest(t, 1, digest, true)
+		packet, err := newControllerUnknownOperationPacket(receive, 1, sessionID, unknown)
+		if err != nil {
+			t.Fatalf("unknown packet error = %v", err)
+		}
+		arm, ok := packet.unknownOperationValue()
+		if !ok || arm.inspected.RequestID() != requestID || arm.inspected.IdentityDigest() != digest || packet.sequenceValue() != 1 {
+			t.Fatal("unknown packet did not retain inspected metadata")
+		}
+		if _, known := arm.inspected.KnownOperation(); known {
+			t.Fatal("unknown packet classified a safe unknown operation as known")
+		}
+		if _, err := newControllerUnknownOperationPacket(receive, 1, sessionID, unknown); !errors.Is(err, errInvalidControlReceiveRequest) {
+			t.Fatalf("consume-once error = %v", err)
+		}
+		unset := mustControlReceiveRequest(t, 1, v2control.IdentityDigest{}, false)
+		if _, err := newControllerUnknownOperationPacket(unset, 1, sessionID, unknown); err != nil {
+			t.Fatalf("unset expected identity unknown error = %v", err)
+		}
+		mismatch := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerUnknownOperationPacket(mismatch, 2, sessionID, unknown); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("sequence mismatch error = %v", err)
+		}
+		if _, err := newControllerUnknownOperationPacket(mismatch, 1, sessionID, unknown); !errors.Is(err, errInvalidControlReceiveRequest) {
+			t.Fatalf("failed issue did not consume receive request: %v", err)
+		}
+		identityMismatch := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerUnknownOperationPacket(identityMismatch, 1, sessionID, testInspectedUnknownRequest(t, requestID, v2control.NewIdentityDigest(sessionID))); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("expected identity mismatch error = %v", err)
+		}
+		zero := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerUnknownOperationPacket(zero, 1, sessionID, v2control.InspectedRequest{}); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("zero inspected unknown error = %v", err)
+		}
+		known := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerUnknownOperationPacket(known, 1, sessionID, malformed); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("known operation as unknown error = %v", err)
+		}
+	})
+
+	t.Run("malformed", func(t *testing.T) {
+		receive := mustControlReceiveRequest(t, 1, digest, true)
+		packet, err := newControllerMalformedKnownPacket(receive, 1, sessionID, malformed)
+		if err != nil {
+			t.Fatalf("malformed packet error = %v", err)
+		}
+		arm, ok := packet.malformedKnownValue()
+		if !ok || arm.inspected.RequestID() != requestID || arm.inspected.IdentityDigest() != digest {
+			t.Fatal("malformed packet did not retain inspected metadata")
+		}
+		operation, known := arm.inspected.KnownOperation()
+		if !known || operation != v2control.OperationCredentialPrepare {
+			t.Fatal("malformed packet lost known operation classification")
+		}
+		if _, err := newControllerMalformedKnownPacket(receive, 1, sessionID, malformed); !errors.Is(err, errInvalidControlReceiveRequest) {
+			t.Fatalf("consume-once error = %v", err)
+		}
+		unknownReceive := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerMalformedKnownPacket(unknownReceive, 1, sessionID, unknown); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("unknown operation as malformed error = %v", err)
+		}
+		zero := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerMalformedKnownPacket(zero, 1, sessionID, v2control.InspectedRequest{}); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("zero inspected malformed error = %v", err)
+		}
+	})
+
+	t.Run("private", func(t *testing.T) {
+		receive := mustControlReceiveRequest(t, 1, digest, true)
+		body := &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}
+		packet, err := newControllerPrivatePacket(receive, 1, sessionID, credentialprotocol.PrivateRecordKindFileBytes, requestID, digest, 2, 0, 1, uint32(len(payload)), payloadDigest, body)
+		if err != nil {
+			t.Fatalf("private packet error = %v", err)
+		}
+		arm, ok := packet.privateValue()
+		if !ok || arm.kind != credentialprotocol.PrivateRecordKindFileBytes || arm.requestID != requestID || arm.identityDigest != digest || arm.bindingIndex != 2 || arm.chunkIndex != 0 || arm.chunkCount != 1 || arm.payloadLength != uint32(len(payload)) || body.destroyed || packet.body == nil {
+			t.Fatal("private packet did not retain payload body")
+		}
+		if _, err := newControllerPrivatePacket(receive, 1, sessionID, credentialprotocol.PrivateRecordKindFileBytes, requestID, digest, 2, 0, 1, uint32(len(payload)), payloadDigest, &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}); !errors.Is(err, errInvalidControlReceiveRequest) {
+			t.Fatalf("consume-once error = %v", err)
+		}
+		execReceive := mustControlReceiveRequest(t, 1, digest, true)
+		execBody := &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}
+		execPacket, err := newControllerPrivatePacket(execReceive, 1, sessionID, credentialprotocol.PrivateRecordKindOpaqueExecBinding, requestID, digest, 0, 0, 1, uint32(len(payload)), payloadDigest, execBody)
+		if err != nil || execPacket.body == nil {
+			t.Fatalf("opaque exec private error = %v", err)
+		}
+		failedBody := &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}
+		invalid := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerPrivatePacket(invalid, 1, sessionID, 0, requestID, digest, 2, 0, 1, uint32(len(payload)), payloadDigest, failedBody); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("unknown kind error = %v", err)
+		}
+		if !failedBody.destroyed {
+			t.Fatal("failed private constructor did not destroy the supplied body")
+		}
+		missing := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerPrivatePacket(missing, 1, sessionID, credentialprotocol.PrivateRecordKindFileBytes, requestID, digest, 2, 0, 1, uint32(len(payload)), payloadDigest, nil); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("missing payload body error = %v", err)
+		}
+		execIndex := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerPrivatePacket(execIndex, 1, sessionID, credentialprotocol.PrivateRecordKindOpaqueExecBinding, requestID, digest, 1, 0, 1, uint32(len(payload)), payloadDigest, &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("opaque exec binding index error = %v", err)
+		}
+		identityMismatch := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerPrivatePacket(identityMismatch, 1, otherSessionID, credentialprotocol.PrivateRecordKindFileBytes, requestID, digest, 2, 0, 1, uint32(len(payload)), payloadDigest, &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}); err != nil {
+			t.Fatalf("private packet does not bind payload identity to raw session bytes: %v", err)
+		}
+		expectedMismatch := mustControlReceiveRequest(t, 1, v2control.NewIdentityDigest(sessionID), true)
+		if _, err := newControllerPrivatePacket(expectedMismatch, 1, sessionID, credentialprotocol.PrivateRecordKindFileBytes, requestID, digest, 2, 0, 1, uint32(len(payload)), payloadDigest, &testHelperBody{length: uint32(len(payload)), digest: payloadDigest}); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("expected identity mismatch error = %v", err)
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		receive := mustControlReceiveRequest(t, 1, digest, true)
+		body := &testHelperBody{length: 7, digest: payloadDigest}
+		packet, err := newControllerStreamPacket(receive, 1, sessionID, credentialprotocol.HelperExecStreamStdin, credentialprotocol.HelperExecStreamFlagsNone, requestID, digest, 4, 7, payloadDigest, body)
+		if err != nil {
+			t.Fatalf("stream packet error = %v", err)
+		}
+		arm, ok := packet.streamValue()
+		if !ok || arm.kind != credentialprotocol.HelperExecStreamStdin || arm.offset != 4 || arm.payloadLength != 7 || body.destroyed || packet.body == nil {
+			t.Fatal("stdin stream did not retain live payload body")
+		}
+		eofReceive := mustControlReceiveRequest(t, 1, digest, true)
+		eofPacket, err := newControllerStreamPacket(eofReceive, 1, sessionID, credentialprotocol.HelperExecStreamStdin, credentialprotocol.HelperExecStreamFlagEOF, requestID, digest, 7, 0, emptyDigest, nil)
+		if err != nil {
+			t.Fatalf("eof stream error = %v", err)
+		}
+		eofArm, ok := eofPacket.streamValue()
+		if !ok || eofArm.flags != credentialprotocol.HelperExecStreamFlagEOF || eofPacket.body != nil {
+			t.Fatal("eof stream arm missing")
+		}
+		stdout := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerStreamPacket(stdout, 1, sessionID, credentialprotocol.HelperExecStreamStdout, credentialprotocol.HelperExecStreamFlagsNone, requestID, digest, 0, 7, payloadDigest, &testHelperBody{length: 7, digest: payloadDigest}); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("stdout stream error = %v", err)
+		}
+		missingPayload := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerStreamPacket(missingPayload, 1, sessionID, credentialprotocol.HelperExecStreamStdin, credentialprotocol.HelperExecStreamFlagsNone, requestID, digest, 0, 7, payloadDigest, nil); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("nonempty stream without owned payload error = %v", err)
+		}
+		retryBody := &testHelperBody{length: 7, digest: payloadDigest}
+		if _, err := newControllerStreamPacket(missingPayload, 1, sessionID, credentialprotocol.HelperExecStreamStdin, credentialprotocol.HelperExecStreamFlagsNone, requestID, digest, 0, 7, payloadDigest, retryBody); !errors.Is(err, errInvalidControlReceiveRequest) {
+			t.Fatalf("failed missing-payload issue did not consume receive request: %v", err)
+		}
+		if !retryBody.destroyed {
+			t.Fatal("replayed receive request did not destroy the newly supplied body")
+		}
+	})
+
+	t.Run("credit", func(t *testing.T) {
+		receive := mustControlReceiveRequest(t, 1, digest, true)
+		packet, err := newControllerCreditPacket(receive, 1, sessionID, credentialprotocol.HelperExecStreamStdout, requestID, digest, 8)
+		if err != nil {
+			t.Fatalf("credit packet error = %v", err)
+		}
+		arm, ok := packet.creditValue()
+		if !ok || arm.kind != credentialprotocol.HelperExecStreamStdout || arm.nextOffset != 8 || arm.requestID != requestID {
+			t.Fatal("credit packet did not retain typed ownership")
+		}
+		stderr := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerCreditPacket(stderr, 1, sessionID, credentialprotocol.HelperExecStreamStderr, requestID, digest, 0); err != nil {
+			t.Fatalf("stderr credit error = %v", err)
+		}
+		stdin := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerCreditPacket(stdin, 1, sessionID, credentialprotocol.HelperExecStreamStdin, requestID, digest, 8); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("stdin credit error = %v", err)
+		}
+		zero := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerCreditPacket(zero, 1, sessionID, credentialprotocol.HelperExecStreamStdout, v2control.RequestID{}, digest, 8); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("zero request ID credit error = %v", err)
+		}
+	})
+
+	t.Run("close-notify", func(t *testing.T) {
+		receive := mustControlReceiveRequest(t, 1, digest, true)
+		packet, err := newControllerCloseNotifyPacket(receive, 1, sessionID, credentialprotocol.CloseReasonNormal)
+		if err != nil {
+			t.Fatalf("close notify error = %v", err)
+		}
+		arm, ok := packet.closeNotifyValue()
+		if !ok || arm != credentialprotocol.CloseReasonNormal {
+			t.Fatal("close notify packet did not retain typed ownership")
+		}
+		if _, err := newControllerCloseNotifyPacket(receive, 1, sessionID, credentialprotocol.CloseReasonNormal); !errors.Is(err, errInvalidControlReceiveRequest) {
+			t.Fatalf("consume-once error = %v", err)
+		}
+		unset := mustControlReceiveRequest(t, 1, v2control.IdentityDigest{}, false)
+		if _, err := newControllerCloseNotifyPacket(unset, 1, sessionID, credentialprotocol.CloseReasonShutdown); err != nil {
+			t.Fatalf("close without expected identity error = %v", err)
+		}
+		unknown := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerCloseNotifyPacket(unknown, 1, sessionID, 0); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("unknown close reason error = %v", err)
+		}
+		sequence := mustControlReceiveRequest(t, 1, digest, true)
+		if _, err := newControllerCloseNotifyPacket(sequence, 2, sessionID, credentialprotocol.CloseReasonNormal); !errors.Is(err, errInvalidControllerPacket) {
+			t.Fatalf("sequence mismatch error = %v", err)
+		}
+	})
 }
 
 func TestL8D6GuestPacketHelperReceiveRequestMirrorsControlDiscipline(t *testing.T) {
@@ -844,31 +1037,148 @@ func TestL8D6GuestPacketHelperUnionsMirrorReadinessDiscipline(t *testing.T) {
 func TestL8D6GuestPacketHelperSendWriteCanonicalBody(t *testing.T) {
 	identity := testHelperPacketIdentity()
 	nonce := testHelperPacketNonce()
+	requestID := testHelperPacketRequestID()
+	fileDigest := sha256.Sum256([]byte("private-file"))
+	manifestDigest := sha256.Sum256([]byte("manifest"))
+	begin := credentialprotocol.HelperPrepareBeginBody{
+		Revision:       1,
+		ExpiryUnixNano: 1700000001123456789,
+		Bindings: []credentialprotocol.HelperBindingManifestRecord{
+			{BindingID: "binding-http", Mode: credentialprotocol.DeliveryModeHTTPProxy},
+			{BindingID: "binding-file", Mode: credentialprotocol.DeliveryModeFileTmpfs, TargetPath: "credentials/config", DeclaredFileBytes: 12, FileSHA256: fileDigest},
+		},
+	}
+	commit := credentialprotocol.HelperPrepareCommitBody{Revision: 1, ManifestSHA256: manifestDigest}
+	renew := credentialprotocol.HelperRenewBody{Revision: 2, ExpiryUnixNano: 1700000600123456789, PriorProofID: "proof-1"}
+	revoke := credentialprotocol.HelperRevokeBody{Revision: 2, Reason: credentialprotocol.RevokeReasonRequested}
+	execBody := credentialprotocol.HelperExecBody{
+		Revision:      3,
+		ExecBindingID: "exec-1",
+		Plan: credentialprotocol.HelperExecPlan{
+			Arguments:      []string{"/usr/bin/tool", "run"},
+			WorkDirectory:  "/workspace",
+			StdinMode:      credentialprotocol.HelperExecStreamModePipe,
+			StdoutMode:     credentialprotocol.HelperExecStreamModePipe,
+			StderrMode:     credentialprotocol.HelperExecStreamModePipe,
+			StdinMaxBytes:  1024,
+			StdoutMaxBytes: 2048,
+			StderrMaxBytes: 4096,
+			Timing:         credentialprotocol.HelperExecTiming{Kind: credentialprotocol.HelperExecTimingTimeoutMillis, Value: 1000},
+		},
+	}
+	credit := credentialprotocol.HelperExecCreditBody{Revision: 3, StreamKind: credentialprotocol.HelperExecStreamStdout, NextOffset: 8}
 	closeBody := credentialprotocol.HelperCloseNotifyBody{Reason: credentialprotocol.CloseReasonShutdown}
-	encoded := mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperCloseNotifyBody(closeBody) })
-	header := testHelperHeader(credentialprotocol.PacketTypeCloseNotify, 1, [16]byte{}, identity, nonce, uint32(len(encoded)))
-	packet, err := finishHelperSendPacket(header, helperSendArmClose, helperSendArm{kind: helperSendArmClose, close: closeBody})
-	if err != nil {
-		t.Fatalf("finishHelperSendPacket() error = %v", err)
+
+	type sendCase struct {
+		name  string
+		issue func() (HelperSendPacket, error)
+		want  []byte
+		typ   credentialprotocol.PacketType
 	}
-	if packet.packetTypeValue() != credentialprotocol.PacketTypeCloseNotify || packet.encodedBodyLengthValue() != uint32(len(encoded)) || packet.bodySHA256Value() != sha256.Sum256(encoded) {
-		t.Fatal("helper send packet did not pin canonical body length and digest")
+	cases := []sendCase{
+		{
+			name: "prepare-begin",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperPrepareBeginSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), begin)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperPrepareBeginBody(begin) }),
+			typ:  credentialprotocol.PacketTypePrepareBegin,
+		},
+		{
+			name: "prepare-commit",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperPrepareCommitSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), commit)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperPrepareCommitBody(commit) }),
+			typ:  credentialprotocol.PacketTypePrepareCommit,
+		},
+		{
+			name: "renew",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperRenewSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), renew)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperRenewBody(renew) }),
+			typ:  credentialprotocol.PacketTypeRenew,
+		},
+		{
+			name: "revoke",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperRevokeSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), revoke)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperRevokeBody(revoke) }),
+			typ:  credentialprotocol.PacketTypeRevoke,
+		},
+		{
+			name: "exec",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperExecSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), execBody)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperExecBody(execBody) }),
+			typ:  credentialprotocol.PacketTypeExec,
+		},
+		{
+			name: "exec-credit",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperExecCreditSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), credit)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperExecCreditBody(credit) }),
+			typ:  credentialprotocol.PacketTypeExecCredit,
+		},
+		{
+			name: "close",
+			issue: func() (HelperSendPacket, error) {
+				return newHelperCloseNotifySendPacket(testHelperHeader(0, 1, [16]byte{}, identity, nonce, 0), closeBody)
+			},
+			want: mustEncode(t, func() ([]byte, error) { return credentialprotocol.EncodeHelperCloseNotifyBody(closeBody) }),
+			typ:  credentialprotocol.PacketTypeCloseNotify,
+		},
 	}
-	sink := &testCanonicalBodySink{capacity: packet.encodedBodyLengthValue()}
-	if err := packet.writeCanonicalBody(sink); err != nil {
-		t.Fatalf("writeCanonicalBody() error = %v", err)
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			packet, err := test.issue()
+			if err != nil {
+				t.Fatalf("send constructor error = %v", err)
+			}
+			if packet.packetTypeValue() != test.typ || packet.encodedBodyLengthValue() != uint32(len(test.want)) || packet.bodySHA256Value() != sha256.Sum256(test.want) {
+				t.Fatal("helper send packet did not pin canonical body length and digest")
+			}
+			sink := &testCanonicalBodySink{capacity: packet.encodedBodyLengthValue()}
+			if err := packet.writeCanonicalBody(sink); err != nil {
+				t.Fatalf("writeCanonicalBody() error = %v", err)
+			}
+			if string(sink.buf) != string(test.want) {
+				t.Fatalf("canonical body = %x, want %x", sink.buf, test.want)
+			}
+			if err := packet.writeCanonicalBody(sink); !errors.Is(err, errInvalidHelperSendPacket) {
+				t.Fatalf("second writeCanonicalBody() error = %v", err)
+			}
+		})
 	}
-	if string(sink.buf) != string(encoded) {
-		t.Fatalf("canonical body = %s, want %s", sink.buf, encoded)
+
+	if _, err := newHelperPrepareBeginSendPacket(testHelperHeader(0, 0, requestID, identity, nonce, 0), begin); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Fatalf("zero sequence helper send error = %v", err)
 	}
-	if err := packet.writeCanonicalBody(sink); !errors.Is(err, errInvalidHelperSendPacket) {
-		t.Fatalf("second writeCanonicalBody() error = %v", err)
+	if _, err := newHelperPrepareBeginSendPacket(testHelperHeader(0, 1, [16]byte{}, identity, nonce, 0), begin); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Fatalf("zero request ID helper send error = %v", err)
+	}
+	if _, err := newHelperExecCreditSendPacket(testHelperHeader(0, 1, requestID, identity, nonce, 0), credentialprotocol.HelperExecCreditBody{Revision: 3, StreamKind: credentialprotocol.HelperExecStreamStdin, NextOffset: 8}); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Fatalf("stdin helper credit send error = %v", err)
+	}
+	if _, err := newHelperCloseNotifySendPacket(testHelperHeader(0, 1, [16]byte{}, identity, nonce, 0), credentialprotocol.HelperCloseNotifyBody{}); !errors.Is(err, errInvalidHelperSendPacket) {
+		t.Fatalf("unknown helper close send error = %v", err)
 	}
 	if err := (HelperSendPacket{}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
 		t.Fatalf("zero helper send write error = %v", err)
 	}
 	if err := (HelperSendPacket{arm: helperSendArmPrepareFile}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
-		t.Fatalf("payload helper send write error = %v", err)
+		t.Fatalf("prepare-file helper send write error = %v", err)
+	}
+	if err := (HelperSendPacket{arm: helperSendArmExecPrivate}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("exec-private helper send write error = %v", err)
+	}
+	if err := (HelperSendPacket{arm: helperSendArmExecStream}).writeCanonicalBody(nil); !errors.Is(err, ErrClientControlDependencyUnaccepted) {
+		t.Fatalf("exec-stream helper send write error = %v", err)
 	}
 }
 
@@ -1169,6 +1479,40 @@ func testHelperHeader(packetType credentialprotocol.PacketType, sequence uint64,
 		GuestCredentialIdentityDigest: identity,
 		BootNonce:                     nonce,
 	}
+}
+
+func testInspectedUnknownRequest(t *testing.T, requestID v2control.RequestID, digest v2control.IdentityDigest) v2control.InspectedRequest {
+	t.Helper()
+	encodedID, err := v2control.EncodeRequestID(requestID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire := []byte(`{"protocolVersion":"guest-agent-v2","operation":"future_operation","requestId":"` + encodedID + `","identityDigest":"` + v2control.EncodeIdentityDigest(digest) + `","body":{"uninterpreted":true}}`)
+	inspected, err := v2control.InspectCredentialRequestRoot(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, known := inspected.KnownOperation(); known {
+		t.Fatal("future_operation was classified as known")
+	}
+	return inspected
+}
+
+func testInspectedKnownRequest(t *testing.T, prepare v2control.CredentialPrepareRequest) v2control.InspectedRequest {
+	t.Helper()
+	wire, err := v2control.EncodeCredentialPrepareRequest(prepare)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspected, err := v2control.InspectCredentialRequestRoot(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation, known := inspected.KnownOperation()
+	if !known || operation != v2control.OperationCredentialPrepare {
+		t.Fatal("prepare request was not classified as known")
+	}
+	return inspected
 }
 
 func testHelperPrepareResponseBody() credentialprotocol.HelperResponseBody {


### PR DESCRIPTION
## Summary
Metadata-only remaining controller receive constructors (unknown, malformed, private, stream, credit, close-notify) and helper send issuers for prepare-begin/commit, renew, revoke, exec, stdout/stderr credit, and close-notify.

No bind/listen/dial/SCM_RIGHTS. Serve still fails closed after credential ops instead of synthesizing proofs. Payload helper send (prepare-file, exec-private, nonempty exec-stream) and live helper transport remain unaccepted.

## Tests
- `go test ./internal/sandboxruntime/microvm/guestagent/server/credentialclient -count=1`

Please review this PR only. Do not merge. Do not force-push. Do not touch `develop`.